### PR TITLE
feat: Redesign Garmin activity detail page

### DIFF
--- a/docs/garmin-detail-plan.md
+++ b/docs/garmin-detail-plan.md
@@ -1,0 +1,145 @@
+## Plan: Garmin Activity Detail Page Redesign
+
+Redesign the Garmin activity detail page (`/garmin/:activityId`) to match the
+Garmin Connect professional interface: route map with speed-colored polyline,
+elevation/speed/HR/temperature charts (Recharts), stat summary bar, and detailed
+stats panel — all using data already flowing through the stack.
+
+The work spans 3 repos (otel-data-api, otel-data-gateway, otel-data-ui) with
+the vast majority of effort in the frontend. All charting (recharts ^3.7.0) and
+mapping (leaflet ^1.9.4) packages are already installed. Track points already
+return altitude, speed_kmh, heart_rate, cadence, temperature_c, and
+distance_from_start_km — the detail page simply doesn't use them yet (fetches
+only 5 points for a count display).
+
+Imperial units (mi, mph, ft, °F) match the Garmin Connect screenshots. Backend
+exposes 5 additional DB columns (avg/min/max_temperature_c,
+total_elapsed_time, total_timer_time) for the stats panel.
+
+**Steps**
+
+### Phase 1 — Backend (otel-data-api) `develop` branch
+
+1. Add 5 fields to `GarminActivity` Pydantic model in
+   `app/models/garmin.py`: `avg_temperature_c` (int|None),
+   `min_temperature_c` (int|None), `max_temperature_c` (int|None),
+   `total_elapsed_time` (float|None), `total_timer_time` (float|None).
+
+2. Update SQL SELECT in `get_activity()` and `list_activities()` in
+   `app/routers/garmin.py` to include the 5 new columns from the
+   `garmin_activities` table.
+
+3. Bump track points max limit from `le=5000` to `le=10000` in
+   `list_track_points()` to support larger activities.
+
+### Phase 2 — Gateway (otel-data-gateway) `develop` branch
+
+4. Add 5 new fields to `GarminActivity` GraphQL type in
+   `src/schema/typeDefs.ts`: `avg_temperature_c: Int`,
+   `min_temperature_c: Int`, `max_temperature_c: Int`,
+   `total_elapsed_time: Float`, `total_timer_time: Float`. No resolver
+   changes needed (passthrough).
+
+### Phase 3 — Frontend (otel-data-ui) `develop` branch
+
+5. Create `src/lib/units.ts` — Unit conversion helpers:
+   `kmToMi()`, `kmhToMph()`, `metersToFeet()`, `celsiusToFahrenheit()`,
+   `formatDuration()` (moved from page), `formatPace()`. These are pure
+   functions, all stateless.
+
+6. Update `src/graphql/garmin.ts` — Add the 5 new fields to
+   `GARMIN_ACTIVITY_QUERY`. No changes to `GARMIN_TRACK_POINTS_QUERY`
+   (already returns all needed fields).
+
+7. Create `src/components/garmin/ActivityHeader.tsx` — Sport icon
+   (lucide-react: Bike, Footprints, Dumbbell, etc.), activity date/time,
+   device manufacturer badge, sub_sport badge, back button to `/garmin`.
+
+8. Create `src/components/garmin/ActivityStatsBar.tsx` — 4 large
+   highlighted stat cards in a horizontal row: Distance (mi), Time
+   (h:mm:ss), Avg Speed (mph), Elevation Gain (ft). Uses existing
+   `Card` component with larger typography.
+
+9. Create `src/components/garmin/ActivityRouteMap.tsx` — Leaflet map
+   using the raw `L.map()` + `useRef` pattern from `MapPage.tsx`.
+   Renders track points as a `L.polyline` with speed-based color
+   segments (blue→green→yellow→red gradient). Includes a speed color
+   legend. Start/end markers. Auto-fits bounds. Height: ~400px.
+
+10. Create `src/components/garmin/ActivityCharts.tsx` — Recharts
+    `AreaChart` components for Elevation, Speed, Heart Rate, and
+    Temperature. X-axis is `distance_from_start_km` (converted to mi).
+    Includes a Time/Distance toggle button group. Downsamples to ~800
+    points for performance using nth-point sampling. Each chart is a
+    separate card with consistent styling.
+
+11. Create `src/components/garmin/ActivityStatsPanel.tsx` — Detailed
+    stats grid inspired by Garmin Connect's tabbed panels. Sections:
+    Distance (total distance mi, total distance km), Timing (elapsed
+    time, timer time, moving time), Elevation (ascent ft, descent ft),
+    Speed (avg mph, max mph, avg km/h, max km/h), Heart Rate (avg bpm,
+    max bpm), Cadence (avg rpm, max rpm), Temperature (avg/min/max °F),
+    Calories. Placeholder sections with "—" for unavailable metrics
+    (Training Effect, VO2 Max, etc.).
+
+12. Rewrite `src/pages/GarminDetailPage.tsx` — Compose all 5 components.
+    Fetch activity detail + track points (limit: 5000). Pass data down
+    as props. Loading/error states. Layout: Header → StatsBar → Map →
+    Charts → StatsPanel (vertical stack).
+
+### Phase 4 — Quality & Deploy
+
+13. Run `npm run lint:all` and `npm run type-check` in otel-data-ui.
+    Run `pre-commit run -a` in otel-data-api and otel-data-gateway.
+
+14. Build Docker images and push to registries. Verify locally with
+    `npm run build` (otel-data-ui), `make dev` (otel-data-api),
+    `npm run build` (otel-data-gateway).
+
+15. Commit to `develop` branches, create PRs, merge to production
+    branches (master/main). Argo CD auto-syncs the k8s deployments.
+
+16. Verify live at `https://data-ui.lab.informationcart.com/garmin/{id}`.
+
+**Verification**
+
+- `npm run build` passes with no errors (otel-data-ui)
+- `npm run lint:all` and `npm run type-check` clean (otel-data-ui)
+- `pre-commit run -a` clean (otel-data-api, otel-data-gateway)
+- Navigate to `/garmin/{id}` — map renders with colored polyline
+- Charts show elevation/speed/HR/temperature profiles
+- Stats panel shows all available metrics in imperial units
+- Responsive layout works on mobile widths
+- Loading and error states display correctly
+
+**Decisions**
+
+- Imperial units (mi/mph/ft/°F) to match Garmin Connect screenshots
+- Raw Leaflet (`L.map`) pattern, NOT react-leaflet components (matches MapPage.tsx)
+- Recharts AreaChart (not LineChart) for filled chart appearance
+- Speed-colored polyline: blue (slow) → green → yellow → red (fast)
+- Track points downsampled to ~800 for charts, full set for map polyline
+- Placeholder "—" for unavailable metrics rather than hiding sections
+- 5 backend fields added for stats panel completeness (temperature summary, elapsed/timer time)
+- No new npm packages needed — all dependencies already installed
+
+**Files Modified (existing)**
+
+| File | Repo | Change |
+|------|------|--------|
+| `app/models/garmin.py` | otel-data-api | +5 fields |
+| `app/routers/garmin.py` | otel-data-api | SQL SELECT + limit bump |
+| `src/schema/typeDefs.ts` | otel-data-gateway | +5 GarminActivity fields |
+| `src/graphql/garmin.ts` | otel-data-ui | +5 fields in query |
+| `src/pages/GarminDetailPage.tsx` | otel-data-ui | Full rewrite |
+
+**Files Created (new)**
+
+| File | Repo | Purpose |
+|------|------|---------|
+| `src/lib/units.ts` | otel-data-ui | Unit conversion helpers |
+| `src/components/garmin/ActivityHeader.tsx` | otel-data-ui | Sport + date header |
+| `src/components/garmin/ActivityStatsBar.tsx` | otel-data-ui | 4 key stat cards |
+| `src/components/garmin/ActivityRouteMap.tsx` | otel-data-ui | Leaflet route map |
+| `src/components/garmin/ActivityCharts.tsx` | otel-data-ui | Recharts elevation/speed/HR/temp |
+| `src/components/garmin/ActivityStatsPanel.tsx` | otel-data-ui | Detailed stats grid |

--- a/src/components/garmin/ActivityCharts.tsx
+++ b/src/components/garmin/ActivityCharts.tsx
@@ -1,0 +1,197 @@
+import { useState } from 'react'
+import {
+  AreaChart,
+  Area,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+} from 'recharts'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import {
+  kmToMi,
+  metersToFeet,
+  kmhToMph,
+  celsiusToFahrenheit,
+} from '@/lib/units'
+
+interface TrackPoint {
+  distance_from_start_km?: number | null
+  timestamp: string
+  altitude?: number | null
+  speed_kmh?: number | null
+  heart_rate?: number | null
+  temperature_c?: number | null
+}
+
+interface ActivityChartsProps {
+  trackPoints: TrackPoint[]
+}
+
+type XAxisMode = 'distance' | 'time'
+
+function downsample<T>(data: T[], target: number): T[] {
+  if (data.length <= target) return data
+  const step = data.length / target
+  const result: T[] = []
+  for (let i = 0; i < target; i++) {
+    result.push(data[Math.floor(i * step)])
+  }
+  // Always include last point
+  if (result[result.length - 1] !== data[data.length - 1]) {
+    result.push(data[data.length - 1])
+  }
+  return result
+}
+
+interface ChartConfig {
+  title: string
+  dataKey: string
+  color: string
+  unit: string
+  hasData: boolean
+}
+
+export function ActivityCharts({ trackPoints }: ActivityChartsProps) {
+  const [xMode, setXMode] = useState<XAxisMode>('distance')
+
+  if (trackPoints.length === 0) return null
+
+  // Build chart data with unit conversions
+  const sampled = downsample(trackPoints, 800)
+  const startTime = new Date(sampled[0].timestamp).getTime()
+
+  const chartData = sampled.map((pt) => ({
+    distance:
+      pt.distance_from_start_km != null ? kmToMi(pt.distance_from_start_km) : 0,
+    time: (new Date(pt.timestamp).getTime() - startTime) / 60000, // minutes
+    elevation: pt.altitude != null ? metersToFeet(pt.altitude) : null,
+    speed: pt.speed_kmh != null ? kmhToMph(pt.speed_kmh) : null,
+    heartRate: pt.heart_rate ?? null,
+    temperature:
+      pt.temperature_c != null ? celsiusToFahrenheit(pt.temperature_c) : null,
+  }))
+
+  const xKey = xMode === 'distance' ? 'distance' : 'time'
+  const xLabel = xMode === 'distance' ? 'Distance (mi)' : 'Time (min)'
+
+  const hasElevation = chartData.some((d) => d.elevation != null)
+  const hasSpeed = chartData.some((d) => d.speed != null)
+  const hasHR = chartData.some((d) => d.heartRate != null)
+  const hasTemp = chartData.some((d) => d.temperature != null)
+
+  const charts: ChartConfig[] = [
+    {
+      title: 'Elevation',
+      dataKey: 'elevation',
+      color: '#6b7280',
+      unit: 'ft',
+      hasData: hasElevation,
+    },
+    {
+      title: 'Speed',
+      dataKey: 'speed',
+      color: '#3b82f6',
+      unit: 'mph',
+      hasData: hasSpeed,
+    },
+    {
+      title: 'Heart Rate',
+      dataKey: 'heartRate',
+      color: '#ef4444',
+      unit: 'bpm',
+      hasData: hasHR,
+    },
+    {
+      title: 'Temperature',
+      dataKey: 'temperature',
+      color: '#f97316',
+      unit: '°F',
+      hasData: hasTemp,
+    },
+  ]
+
+  const activeCharts = charts.filter((c) => c.hasData)
+
+  if (activeCharts.length === 0) return null
+
+  return (
+    <div className="space-y-4">
+      {/* Toggle buttons */}
+      <div className="flex gap-2">
+        <Button
+          size="sm"
+          variant={xMode === 'distance' ? 'default' : 'outline'}
+          onClick={() => setXMode('distance')}
+        >
+          Distance
+        </Button>
+        <Button
+          size="sm"
+          variant={xMode === 'time' ? 'default' : 'outline'}
+          onClick={() => setXMode('time')}
+        >
+          Time
+        </Button>
+      </div>
+
+      {activeCharts.map((chart) => (
+        <Card key={chart.dataKey}>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-base">{chart.title}</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <ResponsiveContainer width="100%" height={200}>
+              <AreaChart
+                data={chartData}
+                margin={{ top: 5, right: 20, left: 0, bottom: 5 }}
+              >
+                <CartesianGrid strokeDasharray="3 3" className="stroke-muted" />
+                <XAxis
+                  dataKey={xKey}
+                  tickFormatter={(v: number) =>
+                    v.toFixed(xMode === 'distance' ? 1 : 0)
+                  }
+                  label={{
+                    value: xLabel,
+                    position: 'insideBottomRight',
+                    offset: -5,
+                  }}
+                  className="text-xs"
+                />
+                <YAxis
+                  tickFormatter={(v: number) => v.toFixed(0)}
+                  className="text-xs"
+                  width={50}
+                />
+                <Tooltip
+                  formatter={(value) => [
+                    `${Number(value).toFixed(1)} ${chart.unit}`,
+                    chart.title,
+                  ]}
+                  labelFormatter={(label) =>
+                    xMode === 'distance'
+                      ? `${Number(label).toFixed(2)} mi`
+                      : `${Number(label).toFixed(0)} min`
+                  }
+                />
+                <Area
+                  type="monotone"
+                  dataKey={chart.dataKey}
+                  stroke={chart.color}
+                  fill={chart.color}
+                  fillOpacity={0.15}
+                  strokeWidth={1.5}
+                  dot={false}
+                  connectNulls
+                />
+              </AreaChart>
+            </ResponsiveContainer>
+          </CardContent>
+        </Card>
+      ))}
+    </div>
+  )
+}

--- a/src/components/garmin/ActivityHeader.tsx
+++ b/src/components/garmin/ActivityHeader.tsx
@@ -1,0 +1,74 @@
+import { Link } from 'react-router-dom'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import {
+  ArrowLeft,
+  Bike,
+  Footprints,
+  Dumbbell,
+  Waves,
+  Activity,
+} from 'lucide-react'
+
+const sportIcons: Record<string, React.ReactNode> = {
+  cycling: <Bike className="h-6 w-6" />,
+  running: <Footprints className="h-6 w-6" />,
+  swimming: <Waves className="h-6 w-6" />,
+  strength_training: <Dumbbell className="h-6 w-6" />,
+}
+
+interface ActivityHeaderProps {
+  sport: string
+  subSport?: string | null
+  startTime?: string | null
+  deviceManufacturer?: string | null
+}
+
+export function ActivityHeader({
+  sport,
+  subSport,
+  startTime,
+  deviceManufacturer,
+}: ActivityHeaderProps) {
+  const icon = sportIcons[sport] ?? <Activity className="h-6 w-6" />
+
+  return (
+    <div className="flex items-center gap-4">
+      <Button variant="ghost" size="icon" asChild>
+        <Link to="/garmin">
+          <ArrowLeft className="h-5 w-5" />
+        </Link>
+      </Button>
+      <div className="text-muted-foreground">{icon}</div>
+      <div className="flex-1">
+        <h1 className="text-2xl font-bold capitalize tracking-tight">
+          {sport.replace(/_/g, ' ')}
+        </h1>
+        <p className="text-sm text-muted-foreground">
+          {startTime
+            ? new Date(startTime).toLocaleDateString('en-US', {
+                weekday: 'long',
+                year: 'numeric',
+                month: 'long',
+                day: 'numeric',
+                hour: 'numeric',
+                minute: '2-digit',
+              })
+            : 'Unknown date'}
+        </p>
+      </div>
+      <div className="flex gap-2">
+        {subSport && (
+          <Badge variant="secondary" className="capitalize">
+            {subSport.replace(/_/g, ' ')}
+          </Badge>
+        )}
+        {deviceManufacturer && (
+          <Badge variant="outline" className="capitalize">
+            {deviceManufacturer}
+          </Badge>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/components/garmin/ActivityRouteMap.tsx
+++ b/src/components/garmin/ActivityRouteMap.tsx
@@ -1,0 +1,149 @@
+import { useEffect, useRef } from 'react'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import L from 'leaflet'
+import 'leaflet/dist/leaflet.css'
+
+interface TrackPoint {
+  latitude: number
+  longitude: number
+  speed_kmh?: number | null
+}
+
+interface ActivityRouteMapProps {
+  trackPoints: TrackPoint[]
+}
+
+function speedToColor(
+  speed: number,
+  minSpeed: number,
+  maxSpeed: number,
+): string {
+  if (maxSpeed <= minSpeed) return '#3b82f6'
+  const ratio = Math.min(
+    1,
+    Math.max(0, (speed - minSpeed) / (maxSpeed - minSpeed)),
+  )
+  if (ratio < 0.25) return '#3b82f6' // blue - slow
+  if (ratio < 0.5) return '#22c55e' // green
+  if (ratio < 0.75) return '#eab308' // yellow
+  return '#ef4444' // red - fast
+}
+
+export function ActivityRouteMap({ trackPoints }: ActivityRouteMapProps) {
+  const mapRef = useRef<HTMLDivElement>(null)
+  const mapInstanceRef = useRef<L.Map | null>(null)
+
+  useEffect(() => {
+    if (!mapRef.current || trackPoints.length === 0) return
+
+    // Clean up previous instance
+    if (mapInstanceRef.current) {
+      mapInstanceRef.current.remove()
+      mapInstanceRef.current = null
+    }
+
+    const map = L.map(mapRef.current).setView(
+      [trackPoints[0].latitude, trackPoints[0].longitude],
+      13,
+    )
+    mapInstanceRef.current = map
+
+    L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+      attribution: '&copy; OpenStreetMap contributors',
+    }).addTo(map)
+
+    // Compute speed range for color mapping
+    const speeds = trackPoints.map((p) => p.speed_kmh ?? 0).filter((s) => s > 0)
+    const minSpeed = speeds.length > 0 ? Math.min(...speeds) : 0
+    const maxSpeed = speeds.length > 0 ? Math.max(...speeds) : 1
+
+    // Draw speed-colored polyline segments
+    const bounds = L.latLngBounds([])
+    for (let i = 0; i < trackPoints.length - 1; i++) {
+      const p1 = trackPoints[i]
+      const p2 = trackPoints[i + 1]
+      const speed = p1.speed_kmh ?? 0
+      const color = speedToColor(speed, minSpeed, maxSpeed)
+
+      L.polyline(
+        [
+          [p1.latitude, p1.longitude],
+          [p2.latitude, p2.longitude],
+        ],
+        { color, weight: 4, opacity: 0.85 },
+      ).addTo(map)
+
+      bounds.extend([p1.latitude, p1.longitude])
+    }
+
+    // Extend bounds with last point
+    const last = trackPoints[trackPoints.length - 1]
+    bounds.extend([last.latitude, last.longitude])
+
+    // Start marker (green circle)
+    L.circleMarker([trackPoints[0].latitude, trackPoints[0].longitude], {
+      radius: 7,
+      fillColor: '#22c55e',
+      color: '#fff',
+      weight: 2,
+      fillOpacity: 1,
+    })
+      .bindPopup('Start')
+      .addTo(map)
+
+    // End marker (red circle)
+    L.circleMarker([last.latitude, last.longitude], {
+      radius: 7,
+      fillColor: '#ef4444',
+      color: '#fff',
+      weight: 2,
+      fillOpacity: 1,
+    })
+      .bindPopup('Finish')
+      .addTo(map)
+
+    if (bounds.isValid()) {
+      map.fitBounds(bounds, { padding: [30, 30] })
+    }
+
+    return () => {
+      map.remove()
+      mapInstanceRef.current = null
+    }
+  }, [trackPoints])
+
+  if (trackPoints.length === 0) return null
+
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <CardTitle className="text-base">Route</CardTitle>
+      </CardHeader>
+      <CardContent className="p-0 pb-4 px-4">
+        <div
+          ref={mapRef}
+          className="h-[400px] w-full rounded-lg overflow-hidden"
+        />
+        {/* Speed legend */}
+        <div className="flex items-center justify-center gap-4 mt-3 text-xs text-muted-foreground">
+          <div className="flex items-center gap-1">
+            <span className="inline-block h-3 w-3 rounded-full bg-blue-500" />
+            Slow
+          </div>
+          <div className="flex items-center gap-1">
+            <span className="inline-block h-3 w-3 rounded-full bg-green-500" />
+            Moderate
+          </div>
+          <div className="flex items-center gap-1">
+            <span className="inline-block h-3 w-3 rounded-full bg-yellow-500" />
+            Fast
+          </div>
+          <div className="flex items-center gap-1">
+            <span className="inline-block h-3 w-3 rounded-full bg-red-500" />
+            Sprint
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}

--- a/src/components/garmin/ActivityStatsBar.tsx
+++ b/src/components/garmin/ActivityStatsBar.tsx
@@ -1,0 +1,65 @@
+import { Card, CardContent } from '@/components/ui/card'
+import { kmToMi, kmhToMph, metersToFeet, formatDuration } from '@/lib/units'
+
+interface ActivityStatsBarProps {
+  distanceKm?: number | null
+  durationSeconds?: number | null
+  avgSpeedKmh?: number | null
+  totalAscentM?: number | null
+}
+
+function StatItem({
+  label,
+  value,
+  unit,
+}: {
+  label: string
+  value: string
+  unit: string
+}) {
+  return (
+    <Card className="flex-1">
+      <CardContent className="p-4 text-center">
+        <div className="text-3xl font-bold tracking-tight">{value}</div>
+        <div className="text-xs font-medium text-muted-foreground uppercase tracking-wider mt-1">
+          {unit}
+        </div>
+        <div className="text-xs text-muted-foreground mt-0.5">{label}</div>
+      </CardContent>
+    </Card>
+  )
+}
+
+export function ActivityStatsBar({
+  distanceKm,
+  durationSeconds,
+  avgSpeedKmh,
+  totalAscentM,
+}: ActivityStatsBarProps) {
+  return (
+    <div className="grid grid-cols-2 gap-3 md:grid-cols-4">
+      <StatItem
+        label="Distance"
+        value={distanceKm != null ? kmToMi(distanceKm).toFixed(2) : '—'}
+        unit="mi"
+      />
+      <StatItem
+        label="Time"
+        value={formatDuration(durationSeconds ?? null)}
+        unit=""
+      />
+      <StatItem
+        label="Avg Speed"
+        value={avgSpeedKmh != null ? kmhToMph(avgSpeedKmh).toFixed(1) : '—'}
+        unit="mph"
+      />
+      <StatItem
+        label="Elevation Gain"
+        value={
+          totalAscentM != null ? metersToFeet(totalAscentM).toFixed(0) : '—'
+        }
+        unit="ft"
+      />
+    </div>
+  )
+}

--- a/src/components/garmin/ActivityStatsPanel.tsx
+++ b/src/components/garmin/ActivityStatsPanel.tsx
@@ -1,0 +1,230 @@
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import {
+  kmToMi,
+  kmhToMph,
+  metersToFeet,
+  celsiusToFahrenheit,
+  formatDuration,
+  formatPace,
+} from '@/lib/units'
+
+interface ActivityStatsPanelProps {
+  activity: {
+    distance_km?: number | null
+    total_distance?: number | null
+    duration_seconds?: number | null
+    total_elapsed_time?: number | null
+    total_timer_time?: number | null
+    avg_speed_kmh?: number | null
+    max_speed_kmh?: number | null
+    avg_heart_rate?: number | null
+    max_heart_rate?: number | null
+    avg_cadence?: number | null
+    max_cadence?: number | null
+    total_ascent_m?: number | null
+    total_descent_m?: number | null
+    calories?: number | null
+    avg_temperature_c?: number | null
+    min_temperature_c?: number | null
+    max_temperature_c?: number | null
+    avg_pace?: number | null
+  }
+}
+
+interface StatRow {
+  label: string
+  value: string
+}
+
+interface StatSection {
+  title: string
+  rows: StatRow[]
+}
+
+function fmt(
+  val: number | null | undefined,
+  decimals: number,
+  unit: string,
+): string {
+  if (val == null) return '—'
+  return `${val.toFixed(decimals)} ${unit}`
+}
+
+export function ActivityStatsPanel({ activity: a }: ActivityStatsPanelProps) {
+  const sections: StatSection[] = [
+    {
+      title: 'Distance',
+      rows: [
+        {
+          label: 'Total Distance',
+          value:
+            a.distance_km != null ? fmt(kmToMi(a.distance_km), 2, 'mi') : '—',
+        },
+        { label: 'Total Distance', value: fmt(a.distance_km, 2, 'km') },
+      ],
+    },
+    {
+      title: 'Timing',
+      rows: [
+        {
+          label: 'Duration',
+          value: formatDuration(a.duration_seconds ?? null),
+        },
+        {
+          label: 'Elapsed Time',
+          value: formatDuration(a.total_elapsed_time ?? null),
+        },
+        {
+          label: 'Timer Time',
+          value: formatDuration(a.total_timer_time ?? null),
+        },
+      ],
+    },
+    {
+      title: 'Elevation',
+      rows: [
+        {
+          label: 'Ascent',
+          value:
+            a.total_ascent_m != null
+              ? fmt(metersToFeet(a.total_ascent_m), 0, 'ft')
+              : '—',
+        },
+        {
+          label: 'Descent',
+          value:
+            a.total_descent_m != null
+              ? fmt(metersToFeet(a.total_descent_m), 0, 'ft')
+              : '—',
+        },
+        { label: 'Ascent', value: fmt(a.total_ascent_m, 0, 'm') },
+        { label: 'Descent', value: fmt(a.total_descent_m, 0, 'm') },
+      ],
+    },
+    {
+      title: 'Speed',
+      rows: [
+        {
+          label: 'Avg Speed',
+          value:
+            a.avg_speed_kmh != null
+              ? fmt(kmhToMph(a.avg_speed_kmh), 1, 'mph')
+              : '—',
+        },
+        {
+          label: 'Max Speed',
+          value:
+            a.max_speed_kmh != null
+              ? fmt(kmhToMph(a.max_speed_kmh), 1, 'mph')
+              : '—',
+        },
+        { label: 'Avg Pace', value: formatPace(a.avg_speed_kmh ?? null) },
+        { label: 'Avg Speed', value: fmt(a.avg_speed_kmh, 1, 'km/h') },
+        { label: 'Max Speed', value: fmt(a.max_speed_kmh, 1, 'km/h') },
+      ],
+    },
+    {
+      title: 'Heart Rate',
+      rows: [
+        {
+          label: 'Avg Heart Rate',
+          value: a.avg_heart_rate != null ? `${a.avg_heart_rate} bpm` : '—',
+        },
+        {
+          label: 'Max Heart Rate',
+          value: a.max_heart_rate != null ? `${a.max_heart_rate} bpm` : '—',
+        },
+      ],
+    },
+    {
+      title: 'Cadence',
+      rows: [
+        {
+          label: 'Avg Cadence',
+          value: a.avg_cadence != null ? `${a.avg_cadence} rpm` : '—',
+        },
+        {
+          label: 'Max Cadence',
+          value: a.max_cadence != null ? `${a.max_cadence} rpm` : '—',
+        },
+      ],
+    },
+    {
+      title: 'Temperature',
+      rows: [
+        {
+          label: 'Avg Temperature',
+          value:
+            a.avg_temperature_c != null
+              ? fmt(celsiusToFahrenheit(a.avg_temperature_c), 0, '°F')
+              : '—',
+        },
+        {
+          label: 'Min Temperature',
+          value:
+            a.min_temperature_c != null
+              ? fmt(celsiusToFahrenheit(a.min_temperature_c), 0, '°F')
+              : '—',
+        },
+        {
+          label: 'Max Temperature',
+          value:
+            a.max_temperature_c != null
+              ? fmt(celsiusToFahrenheit(a.max_temperature_c), 0, '°F')
+              : '—',
+        },
+        {
+          label: 'Avg Temperature',
+          value:
+            a.avg_temperature_c != null ? `${a.avg_temperature_c} °C` : '—',
+        },
+      ],
+    },
+    {
+      title: 'Calories',
+      rows: [
+        {
+          label: 'Total Calories',
+          value: a.calories != null ? `${a.calories} kcal` : '—',
+        },
+      ],
+    },
+    {
+      title: 'Training Effect',
+      rows: [
+        { label: 'Aerobic TE', value: '—' },
+        { label: 'Anaerobic TE', value: '—' },
+      ],
+    },
+    {
+      title: 'Additional',
+      rows: [
+        { label: 'VO2 Max', value: '—' },
+        { label: 'Exercise Load', value: '—' },
+        { label: 'Sweat Loss', value: '—' },
+      ],
+    },
+  ]
+
+  return (
+    <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+      {sections.map((section) => (
+        <Card key={section.title}>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-sm font-semibold">
+              {section.title}
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-2">
+            {section.rows.map((row, i) => (
+              <div key={i} className="flex justify-between text-sm">
+                <span className="text-muted-foreground">{row.label}</span>
+                <span className="font-medium">{row.value}</span>
+              </div>
+            ))}
+          </CardContent>
+        </Card>
+      ))}
+    </div>
+  )
+}

--- a/src/graphql/garmin.ts
+++ b/src/graphql/garmin.ts
@@ -72,6 +72,11 @@ export const GARMIN_ACTIVITY_QUERY = gql`
       total_distance
       avg_pace
       device_manufacturer
+      avg_temperature_c
+      min_temperature_c
+      max_temperature_c
+      total_elapsed_time
+      total_timer_time
       created_at
       uploaded_at
       track_point_count

--- a/src/lib/units.ts
+++ b/src/lib/units.ts
@@ -1,0 +1,36 @@
+const KM_TO_MI = 0.621371
+const M_TO_FT = 3.28084
+
+export function kmToMi(km: number): number {
+  return km * KM_TO_MI
+}
+
+export function kmhToMph(kmh: number): number {
+  return kmh * KM_TO_MI
+}
+
+export function metersToFeet(m: number): number {
+  return m * M_TO_FT
+}
+
+export function celsiusToFahrenheit(c: number): number {
+  return c * 1.8 + 32
+}
+
+export function formatDuration(seconds: number | null): string {
+  if (seconds == null) return '—'
+  const h = Math.floor(seconds / 3600)
+  const m = Math.floor((seconds % 3600) / 60)
+  const s = Math.floor(seconds % 60)
+  if (h > 0)
+    return `${h}:${m.toString().padStart(2, '0')}:${s.toString().padStart(2, '0')}`
+  return `${m}:${s.toString().padStart(2, '0')}`
+}
+
+export function formatPace(avgSpeedKmh: number | null): string {
+  if (avgSpeedKmh == null || avgSpeedKmh === 0) return '—'
+  const minsPerMi = 60 / kmhToMph(avgSpeedKmh)
+  const mins = Math.floor(minsPerMi)
+  const secs = Math.round((minsPerMi - mins) * 60)
+  return `${mins}:${secs.toString().padStart(2, '0')} /mi`
+}

--- a/src/pages/GarminDetailPage.tsx
+++ b/src/pages/GarminDetailPage.tsx
@@ -1,4 +1,4 @@
-import { useParams, Link } from 'react-router-dom'
+import { useParams } from 'react-router-dom'
 import { useQuery } from '@apollo/client/react'
 import {
   GARMIN_ACTIVITY_QUERY,
@@ -6,20 +6,11 @@ import {
 } from '@/graphql/garmin'
 import { LoadingState } from '@/components/shared/LoadingState'
 import { ErrorState } from '@/components/shared/ErrorState'
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
-import { Badge } from '@/components/ui/badge'
-import { Button } from '@/components/ui/button'
-import { StatsCard } from '@/components/shared/StatsCard'
-import { ArrowLeft, Activity, Heart, Flame, Mountain } from 'lucide-react'
-
-function formatDuration(seconds: number | null): string {
-  if (seconds == null) return '—'
-  const h = Math.floor(seconds / 3600)
-  const m = Math.floor((seconds % 3600) / 60)
-  const s = Math.floor(seconds % 60)
-  if (h > 0) return `${h}h ${m}m ${s}s`
-  return `${m}m ${s}s`
-}
+import { ActivityHeader } from '@/components/garmin/ActivityHeader'
+import { ActivityStatsBar } from '@/components/garmin/ActivityStatsBar'
+import { ActivityRouteMap } from '@/components/garmin/ActivityRouteMap'
+import { ActivityCharts } from '@/components/garmin/ActivityCharts'
+import { ActivityStatsPanel } from '@/components/garmin/ActivityStatsPanel'
 
 export function GarminDetailPage() {
   const { activityId } = useParams<{ activityId: string }>()
@@ -30,13 +21,12 @@ export function GarminDetailPage() {
       skip: !activityId,
     },
   )
-  const { data: trackData } = useQuery<Record<string, any>>(
-    GARMIN_TRACK_POINTS_QUERY,
-    {
-      variables: { activity_id: activityId, limit: 5 },
-      skip: !activityId,
-    },
-  )
+  const { data: trackData, loading: trackLoading } = useQuery<
+    Record<string, any>
+  >(GARMIN_TRACK_POINTS_QUERY, {
+    variables: { activity_id: activityId, limit: 5000 },
+    skip: !activityId,
+  })
 
   if (loading) return <LoadingState message="Loading activity..." />
   if (error)
@@ -45,126 +35,34 @@ export function GarminDetailPage() {
   const a = data?.garminActivity
   if (!a) return <ErrorState message="Activity not found" />
 
+  const trackPoints = trackData?.garminTrackPoints?.items ?? []
+
   return (
     <div className="space-y-6">
-      <div className="flex items-center gap-4">
-        <Button variant="ghost" size="icon" asChild>
-          <Link to="/garmin">
-            <ArrowLeft className="h-4 w-4" />
-          </Link>
-        </Button>
-        <div>
-          <h1 className="text-3xl font-bold capitalize tracking-tight">
-            {a.sport}
-          </h1>
-          <p className="text-muted-foreground">
-            {a.start_time
-              ? new Date(a.start_time).toLocaleString()
-              : 'Unknown date'}
-          </p>
-        </div>
-        {a.sub_sport && <Badge variant="secondary">{a.sub_sport}</Badge>}
-      </div>
+      <ActivityHeader
+        sport={a.sport}
+        subSport={a.sub_sport}
+        startTime={a.start_time}
+        deviceManufacturer={a.device_manufacturer}
+      />
 
-      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
-        <StatsCard
-          title="Distance"
-          value={a.distance_km != null ? `${a.distance_km.toFixed(2)} km` : '—'}
-          icon={<Activity className="h-4 w-4" />}
-        />
-        <StatsCard
-          title="Duration"
-          value={formatDuration(a.duration_seconds)}
-        />
-        <StatsCard
-          title="Avg Heart Rate"
-          value={a.avg_heart_rate != null ? `${a.avg_heart_rate} bpm` : '—'}
-          icon={<Heart className="h-4 w-4" />}
-          description={
-            a.max_heart_rate != null
-              ? `Max: ${a.max_heart_rate} bpm`
-              : undefined
-          }
-        />
-        <StatsCard
-          title="Calories"
-          value={a.calories != null ? a.calories : '—'}
-          icon={<Flame className="h-4 w-4" />}
-        />
-      </div>
+      <ActivityStatsBar
+        distanceKm={a.distance_km}
+        durationSeconds={a.duration_seconds}
+        avgSpeedKmh={a.avg_speed_kmh}
+        totalAscentM={a.total_ascent_m}
+      />
 
-      <div className="grid gap-4 md:grid-cols-2">
-        <Card>
-          <CardHeader>
-            <CardTitle className="flex items-center gap-2">
-              <Mountain className="h-4 w-4" /> Elevation
-            </CardTitle>
-          </CardHeader>
-          <CardContent>
-            <dl className="grid grid-cols-2 gap-4">
-              <div>
-                <dt className="text-sm text-muted-foreground">Ascent</dt>
-                <dd>
-                  {a.total_ascent_m != null
-                    ? `${a.total_ascent_m.toFixed(0)}m`
-                    : '—'}
-                </dd>
-              </div>
-              <div>
-                <dt className="text-sm text-muted-foreground">Descent</dt>
-                <dd>
-                  {a.total_descent_m != null
-                    ? `${a.total_descent_m.toFixed(0)}m`
-                    : '—'}
-                </dd>
-              </div>
-            </dl>
-          </CardContent>
-        </Card>
+      {trackLoading && <LoadingState message="Loading track data..." />}
 
-        <Card>
-          <CardHeader>
-            <CardTitle>Speed</CardTitle>
-          </CardHeader>
-          <CardContent>
-            <dl className="grid grid-cols-2 gap-4">
-              <div>
-                <dt className="text-sm text-muted-foreground">Avg Speed</dt>
-                <dd>
-                  {a.avg_speed_kmh != null
-                    ? `${a.avg_speed_kmh.toFixed(1)} km/h`
-                    : '—'}
-                </dd>
-              </div>
-              <div>
-                <dt className="text-sm text-muted-foreground">Max Speed</dt>
-                <dd>
-                  {a.max_speed_kmh != null
-                    ? `${a.max_speed_kmh.toFixed(1)} km/h`
-                    : '—'}
-                </dd>
-              </div>
-            </dl>
-          </CardContent>
-        </Card>
-      </div>
-
-      {trackData?.garminTrackPoints?.total != null && (
-        <Card>
-          <CardHeader>
-            <CardTitle>
-              Track Points ({trackData.garminTrackPoints.total.toLocaleString()}
-              )
-            </CardTitle>
-          </CardHeader>
-          <CardContent>
-            <p className="text-sm text-muted-foreground">
-              {trackData.garminTrackPoints.total.toLocaleString()} GPS track
-              points recorded for this activity.
-            </p>
-          </CardContent>
-        </Card>
+      {trackPoints.length > 0 && (
+        <>
+          <ActivityRouteMap trackPoints={trackPoints} />
+          <ActivityCharts trackPoints={trackPoints} />
+        </>
       )}
+
+      <ActivityStatsPanel activity={a} />
     </div>
   )
 }


### PR DESCRIPTION
## Changes

### New Files
- `src/lib/units.ts` — Unit conversion helpers (imperial/metric)
- `src/components/garmin/ActivityHeader.tsx` — Sport icon, date, device/sub_sport badges
- `src/components/garmin/ActivityStatsBar.tsx` — Distance, time, speed, elevation stat cards
- `src/components/garmin/ActivityRouteMap.tsx` — Leaflet map with speed-colored polyline
- `src/components/garmin/ActivityCharts.tsx` — Recharts elevation, speed, HR, temperature charts
- `src/components/garmin/ActivityStatsPanel.tsx` — 10-section detailed stats grid

### Modified Files
- `src/graphql/garmin.ts` — Add temperature and timing fields to GraphQL query
- `src/pages/GarminDetailPage.tsx` — Full rewrite composing new components

## Screenshots
Matches Garmin Connect activity detail page layout with route map, performance charts, and comprehensive stats panel.