### PR TITLE
refactor: Simplify activity charts to Speed and Elevation only

### DIFF
--- a/src/components/garmin/ActivityCharts.tsx
+++ b/src/components/garmin/ActivityCharts.tsx
@@ -56,9 +56,9 @@ export function ActivityCharts({ trackPoints }: ActivityChartsProps) {
   const sampled = downsample(trackPoints, 800)
   const startTime = new Date(sampled[0].timestamp).getTime()
 
-  // Compute cumulative distance from lat/lon when distance_from_start_km is sparse
+  // Determine whether distance_from_start_km is sufficiently populated to use as the X-axis
   const hasReliableDistance =
-    sampled.filter((pt) => pt.distance_from_start_km != null).length >
+    sampled.filter((pt) => pt.distance_from_start_km != null).length >=
     sampled.length * 0.5
 
   const chartData = sampled.map((pt) => ({
@@ -106,19 +106,22 @@ export function ActivityCharts({ trackPoints }: ActivityChartsProps) {
     <div className="space-y-4">
       {/* Toggle buttons */}
       <div className="flex gap-2">
-        <Button
-          size="sm"
-          variant={effectiveXMode === 'distance' ? 'default' : 'outline'}
-          onClick={() => setXMode('distance')}
-          disabled={!hasReliableDistance}
+        <span
           title={
             !hasReliableDistance
               ? 'Distance data unavailable for this activity'
               : undefined
           }
         >
-          Distance
-        </Button>
+          <Button
+            size="sm"
+            variant={effectiveXMode === 'distance' ? 'default' : 'outline'}
+            onClick={() => setXMode('distance')}
+            disabled={!hasReliableDistance}
+          >
+            Distance
+          </Button>
+        </span>
         <Button
           size="sm"
           variant={effectiveXMode === 'time' ? 'default' : 'outline'}


### PR DESCRIPTION
## Summary

Simplifies the Garmin activity detail charts to show only **Speed** and **Elevation** graphs below the route map. Removes Heart Rate and Temperature charts. Also fixes the broken X-axis distance labels.

## Changes

- **Remove Heart Rate and Temperature charts** — only Speed (mph, blue) and Elevation (ft, gray) remain
- **Fix X-axis distance labels** — previously showed repeating "0.0" values when `distance_from_start_km` was null for many track points (defaulted to `0`)
- **Auto-fallback to Time axis** — when <50% of track points have distance data, automatically switches X-axis to Time (min)
- **Disable Distance toggle** — grayed out with tooltip when distance data is unavailable
- **Null handling** — missing distance values set to `null` instead of `0` so Recharts skips them via `connectNulls`

## Files Changed

- `src/components/garmin/ActivityCharts.tsx`

## Testing

- TypeScript compiles cleanly (`tsc --noEmit`)
- Pre-commit hooks pass