### PR TITLE
test: update default Playwright chart test activity to 9965963574

### DIFF
--- a/e2e/garmin-charts.spec.ts
+++ b/e2e/garmin-charts.spec.ts
@@ -4,13 +4,13 @@ import { test, expect } from '@playwright/test'
  * Validates that the Garmin activity detail page renders
  * Elevation and Speed charts using Recharts.
  *
- * By default uses activity 21100373038 which has ~14 906 track points
+ * By default uses activity 9965963574 which has ~2 425 track points
  * with altitude / speed data from a Garmin FIT file.
  *
  * The activity ID can be overridden per-environment via the
  * PLAYWRIGHT_GARMIN_ACTIVITY_ID environment variable.
  */
-const ACTIVITY_ID = process.env.PLAYWRIGHT_GARMIN_ACTIVITY_ID ?? '21100373038'
+const ACTIVITY_ID = process.env.PLAYWRIGHT_GARMIN_ACTIVITY_ID ?? '9965963574'
 
 test.describe('Garmin Activity Charts', () => {
   test('page loads and activity header is visible', async ({ page }) => {


### PR DESCRIPTION
## Summary

Updates the default Garmin activity used in Playwright chart tests to one with complete altitude/speed data, fixing flaky test failures.

## Changes

### `e2e/garmin-charts.spec.ts`
- Changed default test activity from `21100373038` to `9965963574`
- Activity `21100373038` previously had NULL altitude/speed data (now backfilled in production, but `9965963574` is a more stable test fixture with guaranteed complete data)

## Context

The Playwright chart tests (elevation chart, speed chart, toggle buttons, time axis) were failing because the default activity `21100373038` had NULL altitude/speed values due to the Garmin FIT enhanced field extraction issue. While the production data has been backfilled, activity `9965963574` provides a more reliable test fixture with consistently complete track point data.

## Test Results

All 5 Playwright chart tests pass:
- ✅ chart section renders for valid activity
- ✅ elevation chart is visible
- ✅ speed chart is visible  
- ✅ toggle buttons switch x-axis
- ✅ time axis mode renders