### PR TITLE
docs: add README badges for CI, Docker Hub, and tech stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,12 @@
 # otel-data-ui
 
+[![Lint](https://github.com/stuartshay/otel-data-ui/actions/workflows/lint.yml/badge.svg)](https://github.com/stuartshay/otel-data-ui/actions/workflows/lint.yml)
+[![Docker](https://github.com/stuartshay/otel-data-ui/actions/workflows/docker.yml/badge.svg)](https://github.com/stuartshay/otel-data-ui/actions/workflows/docker.yml)
+[![Docker Hub](https://img.shields.io/badge/Docker%20Hub-stuartshay%2Fotel--data--ui-blue?logo=docker)](https://hub.docker.com/repository/docker/stuartshay/otel-data-ui)
+[![TypeScript](https://img.shields.io/badge/TypeScript-5.9-3178C6?logo=typescript&logoColor=white)](https://www.typescriptlang.org/)
+[![React](https://img.shields.io/badge/React-19-61DAFB?logo=react&logoColor=black)](https://react.dev/)
+[![Renovate](https://img.shields.io/badge/renovate-enabled-brightgreen.svg?logo=renovatebot)](https://renovatebot.com)
+
 React frontend consuming the [otel-data-gateway](https://github.com/stuartshay/otel-data-gateway)
 GraphQL BFF for location and activity data visualization.
 


### PR DESCRIPTION
Add status badges to README matching the otel-worker pattern:

- **Lint** — GitHub Actions CI badge
- **Docker** — Docker build workflow badge
- **Docker Hub** — stuartshay/otel-data-ui image link
- **TypeScript** — v5.9 version badge
- **React** — v19 version badge
- **Renovate** — dependency management badge