### PR TITLE
docs: add PR template and issue closure policy

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -83,10 +83,13 @@ All work follows this lifecycle:
    work
 3. **Implement and test** — Write code, run `npm run lint:all` and
    `npm run type-check`
-4. **Open a PR** — Reference the issue (`Closes #XX`), fill the PR template
+4. **Open a PR** — Reference the issue (`Refs #XX`), fill the PR template
 5. **Merge to master** — After review and CI passes
 6. **Auto-deploy** — Merge triggers Docker build → k8s-gitops dispatch →
    Argo CD sync
+7. **Validate on cluster** — Verify acceptance criteria against deployed
+   behavior
+8. **Close the issue** — Post validation evidence and close manually
 
 ### Upstream Types Dependency PRs (Required)
 
@@ -115,8 +118,17 @@ before considering work complete.
    screenshots as applicable).
 5. Only then mark the issue/project item as done.
 
-If an issue is auto-closed by merge keywords (`Closes #...`) before deployment
-validation is complete, reopen it until acceptance criteria are confirmed.
+### Issue Closure Policy
+
+⚠️ **Do NOT use `Closes #` or `Fixes #` in PR descriptions.** Issues must
+remain open until post-deploy acceptance criteria are validated on the cluster.
+
+1. After the PR merges, wait for Docker build and k8s-gitops deployment.
+2. Validate each acceptance criterion against the live cluster.
+3. Post a final validation comment on the issue with evidence.
+4. Close the issue manually only after all criteria pass.
+5. If any criterion cannot be validated, document the reason on the issue
+   instead of closing it.
 
 ### Release Hygiene Completion (Required)
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -121,10 +121,12 @@ before considering work complete.
 ### Issue Closure Policy
 
 ⚠️ **Do NOT use `Closes #` or `Fixes #` in PR descriptions.** Issues must
-remain open until post-deploy acceptance criteria are validated on the cluster.
+remain open until acceptance criteria are validated.
 
-1. After the PR merges, wait for Docker build and k8s-gitops deployment.
-2. Validate each acceptance criterion against the live cluster.
+1. After the PR merges, wait for Docker build and k8s-gitops deployment
+   (for changes that affect deployed UI).
+2. Validate each acceptance criterion against the live cluster (for deployed
+   changes) or in the appropriate environment (for docs/CI-only changes).
 3. Post a final validation comment on the issue with evidence.
 4. Close the issue manually only after all criteria pass.
 5. If any criterion cannot be validated, document the reason on the issue

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -40,14 +40,19 @@ npm run build
 ## Post-Merge Validation
 
 ⚠️ **Do NOT use `Closes #` or `Fixes #` in this PR.** Issues must remain open
-until post-deploy acceptance criteria are validated on the cluster.
+until acceptance criteria are validated.
 
 After this PR merges:
+
+### For changes that affect deployed UI (components, pages, GraphQL, config)
 
 - [ ] Docker image built and pushed (CI)
 - [ ] k8s-gitops deployment PR created and merged
 - [ ] Argo CD synced to cluster
 - [ ] Acceptance criteria validated against deployed behavior
+
+### For all PRs
+
 - [ ] Final validation comment posted on the linked issue
 - [ ] Issue closed manually after all criteria confirmed
 - [ ] If any criterion cannot be validated, reason documented on the issue

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,57 @@
+## Summary
+
+Refs #<!-- issue number — do NOT use "Closes" or "Fixes" (see below) -->
+
+Describe the change and why it's needed.
+
+## Type of Change
+
+- [ ] Bug fix (non-breaking change fixing an issue)
+- [ ] New page / component
+- [ ] UI enhancement (non-breaking)
+- [ ] GraphQL query / mutation change
+- [ ] CI/CD pipeline change
+- [ ] Documentation update
+
+## Checklist
+
+- [ ] Read `README.md` and relevant docs
+- [ ] No secrets or credentials committed
+- [ ] Environment variables use `VITE_` prefix
+- [ ] Ran `npm run lint:all` locally (hooks passing)
+- [ ] Ran `npm run test` (tests passing)
+- [ ] Ran `npm run type-check` (no type errors)
+
+## Deployment
+
+- [ ] Does this need [k8s-gitops](https://github.com/stuartshay/k8s-gitops)
+      manifest changes?
+
+## Testing
+
+```bash
+# Commands used to validate changes
+npm run test
+npm run lint:all
+npm run type-check
+npm run build
+```
+
+## Post-Merge Validation
+
+⚠️ **Do NOT use `Closes #` or `Fixes #` in this PR.** Issues must remain open
+until post-deploy acceptance criteria are validated on the cluster.
+
+After this PR merges:
+
+- [ ] Docker image built and pushed (CI)
+- [ ] k8s-gitops deployment PR created and merged
+- [ ] Argo CD synced to cluster
+- [ ] Acceptance criteria validated against deployed behavior
+- [ ] Final validation comment posted on the linked issue
+- [ ] Issue closed manually after all criteria confirmed
+- [ ] If any criterion cannot be validated, reason documented on the issue
+
+## Notes
+
+Any additional context, screenshots, or log output.


### PR DESCRIPTION
## Summary

Refs cross-repo workflow refinement

Adds a standardized PR template and updates copilot-instructions to enforce manual issue closure after post-deploy acceptance criteria validation.

## Changes

- **New**: `.github/pull_request_template.md` — PR template with `Refs #` (not `Closes #`), post-merge validation checklist
- **Updated**: `.github/copilot-instructions.md` — Replaced `Closes #XX` with `Refs #XX` in issue-first workflow, added Issue Closure Policy section, added validate + close steps to lifecycle

## Motivation

Issues should not be auto-closed on merge. They must remain open until:
1. PR merges and deploys to the cluster
2. Each acceptance criterion is validated against live behavior
3. Final validation comment is posted with evidence
4. Issue is closed manually

This aligns the workflow across all repos in the homelab ecosystem.