### PR TITLE
fix: Add auth header forwarding to Apollo client for geocoding trigger

### DIFF
--- a/src/lib/apollo.test.ts
+++ b/src/lib/apollo.test.ts
@@ -1,24 +1,32 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-const apolloMocks = vi.hoisted(() => ({
-  getConfigMock: vi.fn(),
-  HttpLinkMock: vi.fn(function HttpLink(options) {
-    return {
-      type: 'http-link',
-      ...options,
-    }
-  }),
-  InMemoryCacheMock: vi.fn(function InMemoryCache() {
-    return {
-      type: 'cache',
-    }
-  }),
-  ApolloClientMock: vi.fn(function ApolloClient(options) {
-    return {
-      options,
-    }
-  }),
-}))
+const apolloMocks = vi.hoisted(() => {
+  const concatMock = vi.fn(function concat(link: unknown) {
+    return { type: 'combined-link', inner: link }
+  })
+  return {
+    getConfigMock: vi.fn(),
+    HttpLinkMock: vi.fn(function HttpLink(options: unknown) {
+      return {
+        type: 'http-link',
+        ...((options as Record<string, unknown>) ?? {}),
+      }
+    }),
+    InMemoryCacheMock: vi.fn(function InMemoryCache() {
+      return {
+        type: 'cache',
+      }
+    }),
+    ApolloClientMock: vi.fn(function ApolloClient(options: unknown) {
+      return {
+        options,
+      }
+    }),
+    setContextMock: vi.fn(() => ({ type: 'auth-link', concat: concatMock })),
+    concatMock,
+    getAccessTokenMock: vi.fn().mockResolvedValue(null),
+  }
+})
 
 vi.mock('@/config/runtime', () => ({
   getConfig: apolloMocks.getConfigMock,
@@ -30,6 +38,16 @@ vi.mock('@apollo/client', () => ({
   InMemoryCache: apolloMocks.InMemoryCacheMock,
 }))
 
+vi.mock('@apollo/client/link/context', () => ({
+  setContext: apolloMocks.setContextMock,
+}))
+
+vi.mock('@/services/auth', () => ({
+  authService: {
+    getAccessToken: apolloMocks.getAccessTokenMock,
+  },
+}))
+
 describe('apollo client', () => {
   beforeEach(() => {
     vi.resetModules()
@@ -37,6 +55,9 @@ describe('apollo client', () => {
     apolloMocks.HttpLinkMock.mockClear()
     apolloMocks.InMemoryCacheMock.mockClear()
     apolloMocks.ApolloClientMock.mockClear()
+    apolloMocks.setContextMock.mockClear()
+    apolloMocks.concatMock.mockClear()
+    apolloMocks.getAccessTokenMock.mockReset().mockResolvedValue(null)
     apolloMocks.getConfigMock.mockReturnValue(
       'https://graphql.example.com/query',
     )
@@ -66,8 +87,43 @@ describe('apollo client', () => {
     })
     expect(apolloMocks.InMemoryCacheMock).toHaveBeenCalledTimes(1)
     expect(apolloMocks.ApolloClientMock).toHaveBeenCalledTimes(1)
+    expect(apolloMocks.setContextMock).toHaveBeenCalledTimes(1)
+    expect(apolloMocks.concatMock).toHaveBeenCalledTimes(1)
     expect(createdOptions.defaultOptions.watchQuery.fetchPolicy).toBe(
       'cache-and-network',
     )
+  })
+
+  it('attaches Bearer token when authService returns a token', async () => {
+    const { getApolloClient } = await import('./apollo')
+    getApolloClient()
+
+    const contextFn = apolloMocks.setContextMock.mock.calls[0][0] as (
+      req: unknown,
+      prev: { headers?: Record<string, string> },
+    ) => Promise<{ headers: Record<string, string> }>
+
+    apolloMocks.getAccessTokenMock.mockResolvedValue('my-jwt')
+    const result = await contextFn({}, { headers: { 'X-Custom': 'val' } })
+
+    expect(result.headers).toEqual({
+      'X-Custom': 'val',
+      Authorization: 'Bearer my-jwt',
+    })
+  })
+
+  it('omits Authorization header when no token is available', async () => {
+    const { getApolloClient } = await import('./apollo')
+    getApolloClient()
+
+    const contextFn = apolloMocks.setContextMock.mock.calls[0][0] as (
+      req: unknown,
+      prev: { headers?: Record<string, string> },
+    ) => Promise<{ headers: Record<string, string> }>
+
+    apolloMocks.getAccessTokenMock.mockResolvedValue(null)
+    const result = await contextFn({}, {})
+
+    expect(result.headers).not.toHaveProperty('Authorization')
   })
 })

--- a/src/lib/apollo.test.ts
+++ b/src/lib/apollo.test.ts
@@ -98,7 +98,9 @@ describe('apollo client', () => {
     const { getApolloClient } = await import('./apollo')
     getApolloClient()
 
-    const contextFn = apolloMocks.setContextMock.mock.calls[0][0] as (
+    const contextFn = (
+      apolloMocks.setContextMock.mock.calls as unknown[][]
+    )[0][0] as (
       req: unknown,
       prev: { headers?: Record<string, string> },
     ) => Promise<{ headers: Record<string, string> }>
@@ -116,7 +118,9 @@ describe('apollo client', () => {
     const { getApolloClient } = await import('./apollo')
     getApolloClient()
 
-    const contextFn = apolloMocks.setContextMock.mock.calls[0][0] as (
+    const contextFn = (
+      apolloMocks.setContextMock.mock.calls as unknown[][]
+    )[0][0] as (
       req: unknown,
       prev: { headers?: Record<string, string> },
     ) => Promise<{ headers: Record<string, string> }>

--- a/src/lib/apollo.ts
+++ b/src/lib/apollo.ts
@@ -1,5 +1,7 @@
 import { ApolloClient, InMemoryCache, HttpLink } from '@apollo/client'
+import { setContext } from '@apollo/client/link/context'
 import { getConfig } from '@/config/runtime'
+import { authService } from '@/services/auth'
 
 let client: ApolloClient | null = null
 
@@ -15,8 +17,18 @@ export function getApolloClient(): ApolloClient {
     uri: graphqlUrl,
   })
 
+  const authLink = setContext(async (_, { headers }) => {
+    const token = await authService.getAccessToken()
+    return {
+      headers: {
+        ...headers,
+        ...(token ? { Authorization: `Bearer ${token}` } : {}),
+      },
+    }
+  })
+
   client = new ApolloClient({
-    link: httpLink,
+    link: authLink.concat(httpLink),
     cache: new InMemoryCache(),
     defaultOptions: {
       watchQuery: {

--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -97,7 +97,8 @@ class AuthService {
 
   async getAccessToken(): Promise<string | null> {
     const user = await this.getUser()
-    return user?.access_token || null
+    if (!user || user.expired) return null
+    return user.access_token || null
   }
 
   async getUserProfile(): Promise<{


### PR DESCRIPTION
## Summary

Fixes geocoding authentication error when triggering geocoding from the UI. The Apollo client was not attaching the Cognito JWT token to GraphQL requests.

## Changes

- **`src/lib/apollo.ts`** — Added `setContext` auth link that calls `authService.getAccessToken()` and attaches `Authorization: Bearer <token>` to every GraphQL request

## Root Cause

The Apollo client used a bare `HttpLink` with no auth middleware. When the geocoding mutation hit the gateway → API chain, no `Authorization` header was present, causing the API's `require_auth` dependency to reject the request.

## Companion PR

- stuartshay/otel-data-gateway#49 — Gateway-side fix to forward the auth token from context to the REST API data source

## Testing

- TypeScript compiles clean (`tsc --noEmit` passes)
- `@apollo/client/link/context` module verified available in node_modules