### PR TITLE
fix: preserve Locations page pagination state in URL params

### DIFF
--- a/e2e/location-list-pagination.spec.ts
+++ b/e2e/location-list-pagination.spec.ts
@@ -1,0 +1,72 @@
+import { test, expect } from '@playwright/test'
+
+/**
+ * Validates that the Locations list persists pagination state
+ * in URL search params so navigating back from a detail page returns
+ * to the same page.
+ */
+test.describe('Locations List Pagination', () => {
+  test('page number is reflected in the URL', async ({ page }) => {
+    await page.goto('/locations')
+    await expect(page.getByText('Showing 1–')).toBeVisible({ timeout: 15_000 })
+
+    // Navigate to page 2
+    const nextBtn = page.getByRole('button', { name: 'Next' })
+    await nextBtn.click()
+    await expect(page).toHaveURL(/[?&]page=2/)
+    await expect(page.getByText('Showing 26–')).toBeVisible()
+  })
+
+  test('navigating back from detail page preserves page number', async ({
+    page,
+  }) => {
+    // Go directly to page 4
+    await page.goto('/locations?page=4')
+    await expect(page.getByText('Showing 76–')).toBeVisible({
+      timeout: 15_000,
+    })
+
+    // Click the first location link in the table
+    const firstLocationLink = page.locator('table tbody tr td a').first()
+    await firstLocationLink.click()
+
+    // Wait for the detail page to load
+    await expect(page.getByText('Location #')).toBeVisible({
+      timeout: 15_000,
+    })
+
+    // Click the back arrow to return to the list
+    const backButton = page.getByTestId('back-to-list')
+    await backButton.click()
+
+    // Should be back on page 4, not page 1
+    await expect(page).toHaveURL(/[?&]page=4/)
+    await expect(page.getByText('Showing 76–')).toBeVisible({
+      timeout: 15_000,
+    })
+  })
+
+  test('device filter is reflected in the URL', async ({ page }) => {
+    await page.goto('/locations')
+    await expect(page.getByText('Showing 1–')).toBeVisible({ timeout: 15_000 })
+
+    // Click a device filter button (skip "All")
+    const filterButtons = page.locator(
+      'div.flex.flex-wrap.gap-2 button:not(:first-child)',
+    )
+    const count = await filterButtons.count()
+    if (count > 0) {
+      await filterButtons.first().click()
+      await expect(page).toHaveURL(/[?&]device=/)
+    }
+  })
+
+  test('direct URL with page param loads correct page', async ({ page }) => {
+    await page.goto('/locations?page=2')
+    await expect(page.getByText('Showing 26–')).toBeVisible({ timeout: 15_000 })
+
+    // Prev button should be enabled
+    const prevBtn = page.getByRole('button', { name: 'Prev' })
+    await expect(prevBtn).toBeEnabled()
+  })
+})

--- a/src/pages/LocationDetailPage.tsx
+++ b/src/pages/LocationDetailPage.tsx
@@ -1,4 +1,4 @@
-import { useParams, Link } from 'react-router-dom'
+import { useParams, Link, useLocation } from 'react-router-dom'
 import { useLocationDetailQuery } from '@/__generated__/graphql'
 import { LoadingState } from '@/components/shared/LoadingState'
 import { ErrorState } from '@/components/shared/ErrorState'
@@ -9,6 +9,13 @@ import { ArrowLeft } from 'lucide-react'
 
 export function LocationDetailPage() {
   const { id } = useParams<{ id: string }>()
+  const location = useLocation()
+  const locationsListSearch = (
+    location.state as { locationsListSearch?: string } | null
+  )?.locationsListSearch
+  const backTo = locationsListSearch
+    ? `/locations?${locationsListSearch}`
+    : '/locations'
   const { data, loading, error, refetch } = useLocationDetailQuery({
     variables: { id: Number(id) },
     skip: !id,
@@ -52,7 +59,7 @@ export function LocationDetailPage() {
     <div className="space-y-6">
       <div className="flex items-center gap-4">
         <Button variant="ghost" size="icon" asChild>
-          <Link to="/locations">
+          <Link to={backTo} data-testid="back-to-list">
             <ArrowLeft className="h-4 w-4" />
           </Link>
         </Button>

--- a/src/pages/LocationsPage.tsx
+++ b/src/pages/LocationsPage.tsx
@@ -1,4 +1,3 @@
-import { useState } from 'react'
 import { useDevicesQuery, useLocationsQuery } from '@/__generated__/graphql'
 import { LoadingState } from '@/components/shared/LoadingState'
 import { ErrorState } from '@/components/shared/ErrorState'
@@ -13,13 +12,15 @@ import {
   TableRow,
 } from '@/components/ui/table'
 import { ChevronLeft, ChevronRight } from 'lucide-react'
-import { Link } from 'react-router-dom'
+import { Link, useSearchParams } from 'react-router-dom'
 
 const PAGE_SIZE = 25
 
 export function LocationsPage() {
-  const [offset, setOffset] = useState(0)
-  const [deviceFilter, setDeviceFilter] = useState<string | undefined>()
+  const [searchParams, setSearchParams] = useSearchParams()
+  const page = Math.max(1, Number(searchParams.get('page')) || 1)
+  const deviceFilter = searchParams.get('device') || undefined
+  const offset = (page - 1) * PAGE_SIZE
 
   const { data: devicesData } = useDevicesQuery()
   const { data, loading, error, refetch } = useLocationsQuery({
@@ -53,10 +54,7 @@ export function LocationsPage() {
         <Button
           variant={!deviceFilter ? 'default' : 'outline'}
           size="sm"
-          onClick={() => {
-            setDeviceFilter(undefined)
-            setOffset(0)
-          }}
+          onClick={() => setSearchParams({})}
         >
           All
         </Button>
@@ -65,10 +63,7 @@ export function LocationsPage() {
             key={d.device_id}
             variant={deviceFilter === d.device_id ? 'default' : 'outline'}
             size="sm"
-            onClick={() => {
-              setDeviceFilter(d.device_id)
-              setOffset(0)
-            }}
+            onClick={() => setSearchParams({ device: d.device_id })}
           >
             {d.device_id}
           </Button>
@@ -95,6 +90,7 @@ export function LocationsPage() {
                 <TableCell>
                   <Link
                     to={`/locations/${loc.id}`}
+                    state={{ locationsListSearch: searchParams.toString() }}
                     className="font-medium text-primary hover:underline"
                   >
                     {loc.id}
@@ -138,7 +134,11 @@ export function LocationsPage() {
             variant="outline"
             size="sm"
             disabled={offset === 0}
-            onClick={() => setOffset(Math.max(0, offset - PAGE_SIZE))}
+            onClick={() => {
+              const params: Record<string, string> = { page: String(page - 1) }
+              if (deviceFilter) params.device = deviceFilter
+              setSearchParams(params)
+            }}
           >
             <ChevronLeft className="h-4 w-4" /> Prev
           </Button>
@@ -146,7 +146,11 @@ export function LocationsPage() {
             variant="outline"
             size="sm"
             disabled={offset + PAGE_SIZE >= total}
-            onClick={() => setOffset(offset + PAGE_SIZE)}
+            onClick={() => {
+              const params: Record<string, string> = { page: String(page + 1) }
+              if (deviceFilter) params.device = deviceFilter
+              setSearchParams(params)
+            }}
           >
             Next <ChevronRight className="h-4 w-4" />
           </Button>

--- a/src/pages/LocationsPage.tsx
+++ b/src/pages/LocationsPage.tsx
@@ -18,7 +18,8 @@ const PAGE_SIZE = 25
 
 export function LocationsPage() {
   const [searchParams, setSearchParams] = useSearchParams()
-  const page = Math.max(1, Number(searchParams.get('page')) || 1)
+  const parsedPage = Number.parseInt(searchParams.get('page') ?? '', 10)
+  const page = Math.max(1, Number.isNaN(parsedPage) ? 1 : parsedPage)
   const deviceFilter = searchParams.get('device') || undefined
   const offset = (page - 1) * PAGE_SIZE
 
@@ -133,10 +134,11 @@ export function LocationsPage() {
           <Button
             variant="outline"
             size="sm"
-            disabled={offset === 0}
+            disabled={page <= 1}
             onClick={() => {
-              const params: Record<string, string> = { page: String(page - 1) }
-              if (deviceFilter) params.device = deviceFilter
+              const params = new URLSearchParams(searchParams)
+              if (page - 1 <= 1) params.delete('page')
+              else params.set('page', String(page - 1))
               setSearchParams(params)
             }}
           >
@@ -147,8 +149,8 @@ export function LocationsPage() {
             size="sm"
             disabled={offset + PAGE_SIZE >= total}
             onClick={() => {
-              const params: Record<string, string> = { page: String(page + 1) }
-              if (deviceFilter) params.device = deviceFilter
+              const params = new URLSearchParams(searchParams)
+              params.set('page', String(page + 1))
               setSearchParams(params)
             }}
           >


### PR DESCRIPTION
## Summary

Fixes a bug where navigating from a paginated Locations list to a Location detail page and then clicking the back breadcrumb would reset pagination to page 1.

## Root Cause

Two issues caused the pagination state to be lost:

1. **`LocationsPage.tsx`** stored pagination in local React state (`useState(0)`) — state is lost when the component unmounts on navigation
2. **`LocationDetailPage.tsx`** had the back link hardcoded to `/locations` with no query parameters

## Changes

### `src/pages/LocationsPage.tsx`
- Replace `useState(offset)` / `useState(deviceFilter)` with `useSearchParams()` for URL-based pagination
- Page number (`?page=4`) and device filter (`?device=watch`) are now encoded in the URL
- Detail page links pass `state={{ locationsListSearch: searchParams.toString() }}` via React Router state
- Follows the existing `GarminPage` pattern

### `src/pages/LocationDetailPage.tsx`
- Read `location.state.locationsListSearch` from router state
- Build dynamic `backTo` URL that preserves page and device filter
- Add `data-testid="back-to-list"` for E2E test targeting

### `e2e/location-list-pagination.spec.ts` (new)
- 4 Playwright E2E tests:
  - Page number reflected in URL on navigation
  - Back navigation from detail page preserves page number
  - Device filter reflected in URL
  - Direct URL with page param loads correct page

## Testing

- All existing unit tests pass (LocationsPage 5/5, LocationDetailPage 5/5)
- TypeScript compiles clean (`tsc --noEmit`)
- Pre-commit hooks pass