### PR TITLE
feat: add date range filter to Locations page

### DIFF
--- a/src/components/shared/DateRangePicker.tsx
+++ b/src/components/shared/DateRangePicker.tsx
@@ -1,0 +1,123 @@
+import { format, subDays, startOfMonth, startOfDay, endOfDay } from 'date-fns'
+import { CalendarIcon, X } from 'lucide-react'
+import type { DateRange } from 'react-day-picker'
+
+import { Button } from '@/components/ui/button'
+import { Calendar } from '@/components/ui/calendar'
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '@/components/ui/popover'
+
+interface DateRangePickerProps {
+  dateFrom: Date | undefined
+  dateTo: Date | undefined
+  onRangeChange: (from: Date | undefined, to: Date | undefined) => void
+}
+
+const presets = [
+  {
+    label: 'Today',
+    getRange: () => ({
+      from: startOfDay(new Date()),
+      to: endOfDay(new Date()),
+    }),
+  },
+  {
+    label: 'Last 7 days',
+    getRange: () => ({
+      from: startOfDay(subDays(new Date(), 6)),
+      to: endOfDay(new Date()),
+    }),
+  },
+  {
+    label: 'Last 30 days',
+    getRange: () => ({
+      from: startOfDay(subDays(new Date(), 29)),
+      to: endOfDay(new Date()),
+    }),
+  },
+  {
+    label: 'This month',
+    getRange: () => ({
+      from: startOfMonth(new Date()),
+      to: endOfDay(new Date()),
+    }),
+  },
+]
+
+export function DateRangePicker({
+  dateFrom,
+  dateTo,
+  onRangeChange,
+}: DateRangePickerProps) {
+  const hasRange = dateFrom != null || dateTo != null
+
+  const selected: DateRange | undefined =
+    dateFrom || dateTo ? { from: dateFrom, to: dateTo } : undefined
+
+  const handleSelect = (range: DateRange | undefined) => {
+    onRangeChange(range?.from, range?.to)
+  }
+
+  const handleClear = (e: React.MouseEvent) => {
+    e.stopPropagation()
+    onRangeChange(undefined, undefined)
+  }
+
+  const formatLabel = () => {
+    if (!dateFrom && !dateTo) return 'Select dates'
+    if (dateFrom && dateTo)
+      return `${format(dateFrom, 'MMM d, yyyy')} – ${format(dateTo, 'MMM d, yyyy')}`
+    if (dateFrom) return `${format(dateFrom, 'MMM d, yyyy')} – …`
+    return 'Select dates'
+  }
+
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <Button
+          variant="outline"
+          size="sm"
+          data-testid="date-range-trigger"
+          className={hasRange ? 'border-primary' : undefined}
+        >
+          <CalendarIcon className="h-4 w-4" />
+          {formatLabel()}
+          {hasRange && (
+            <X
+              className="h-3 w-3 ml-1 opacity-60 hover:opacity-100"
+              onClick={handleClear}
+            />
+          )}
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-auto p-0" align="start">
+        <div className="flex gap-2 border-b p-2">
+          {presets.map((preset) => (
+            <Button
+              key={preset.label}
+              variant="ghost"
+              size="sm"
+              onClick={() => {
+                const { from, to } = preset.getRange()
+                onRangeChange(from, to)
+              }}
+            >
+              {preset.label}
+            </Button>
+          ))}
+        </div>
+        <Calendar
+          mode="range"
+          selected={selected}
+          onSelect={handleSelect}
+          numberOfMonths={2}
+          toDate={new Date()}
+          defaultMonth={dateFrom ?? subDays(new Date(), 30)}
+        />
+      </PopoverContent>
+    </Popover>
+  )
+}

--- a/src/components/shared/DateRangePicker.tsx
+++ b/src/components/shared/DateRangePicker.tsx
@@ -1,4 +1,11 @@
-import { format, subDays, startOfMonth, startOfDay, endOfDay } from 'date-fns'
+import {
+  format,
+  isValid,
+  subDays,
+  startOfMonth,
+  startOfDay,
+  endOfDay,
+} from 'date-fns'
 import { CalendarIcon, X } from 'lucide-react'
 import type { DateRange } from 'react-day-picker'
 
@@ -66,58 +73,70 @@ export function DateRangePicker({
     onRangeChange(undefined, undefined)
   }
 
+  const safeFormat = (date: Date) =>
+    isValid(date) ? format(date, 'MMM d, yyyy') : undefined
+
   const formatLabel = () => {
     if (!dateFrom && !dateTo) return 'Select dates'
-    if (dateFrom && dateTo)
-      return `${format(dateFrom, 'MMM d, yyyy')} – ${format(dateTo, 'MMM d, yyyy')}`
-    if (dateFrom) return `${format(dateFrom, 'MMM d, yyyy')} – …`
+    const fromStr = dateFrom ? safeFormat(dateFrom) : undefined
+    const toStr = dateTo ? safeFormat(dateTo) : undefined
+    if (fromStr && toStr) return `${fromStr} – ${toStr}`
+    if (fromStr) return `${fromStr} – …`
     return 'Select dates'
   }
 
   return (
-    <Popover>
-      <PopoverTrigger asChild>
+    <div className="flex items-center gap-1">
+      <Popover>
+        <PopoverTrigger asChild>
+          <Button
+            variant="outline"
+            size="sm"
+            data-testid="date-range-trigger"
+            className={hasRange ? 'border-primary' : undefined}
+          >
+            <CalendarIcon className="h-4 w-4" />
+            {formatLabel()}
+          </Button>
+        </PopoverTrigger>
+        <PopoverContent className="w-auto p-0" align="start">
+          <div className="flex gap-2 border-b p-2">
+            {presets.map((preset) => (
+              <Button
+                key={preset.label}
+                variant="ghost"
+                size="sm"
+                onClick={() => {
+                  const { from, to } = preset.getRange()
+                  onRangeChange(from, to)
+                }}
+              >
+                {preset.label}
+              </Button>
+            ))}
+          </div>
+          <Calendar
+            mode="range"
+            selected={selected}
+            onSelect={handleSelect}
+            numberOfMonths={2}
+            toDate={new Date()}
+            defaultMonth={dateFrom ?? subDays(new Date(), 30)}
+          />
+        </PopoverContent>
+      </Popover>
+      {hasRange && (
         <Button
-          variant="outline"
-          size="sm"
-          data-testid="date-range-trigger"
-          className={hasRange ? 'border-primary' : undefined}
+          type="button"
+          variant="ghost"
+          size="icon"
+          className="h-8 w-8"
+          aria-label="Clear date range"
+          onClick={handleClear}
         >
-          <CalendarIcon className="h-4 w-4" />
-          {formatLabel()}
-          {hasRange && (
-            <X
-              className="h-3 w-3 ml-1 opacity-60 hover:opacity-100"
-              onClick={handleClear}
-            />
-          )}
+          <X className="h-3 w-3" />
         </Button>
-      </PopoverTrigger>
-      <PopoverContent className="w-auto p-0" align="start">
-        <div className="flex gap-2 border-b p-2">
-          {presets.map((preset) => (
-            <Button
-              key={preset.label}
-              variant="ghost"
-              size="sm"
-              onClick={() => {
-                const { from, to } = preset.getRange()
-                onRangeChange(from, to)
-              }}
-            >
-              {preset.label}
-            </Button>
-          ))}
-        </div>
-        <Calendar
-          mode="range"
-          selected={selected}
-          onSelect={handleSelect}
-          numberOfMonths={2}
-          toDate={new Date()}
-          defaultMonth={dateFrom ?? subDays(new Date(), 30)}
-        />
-      </PopoverContent>
-    </Popover>
+      )}
+    </div>
   )
 }

--- a/src/pages/LocationsPage.test.tsx
+++ b/src/pages/LocationsPage.test.tsx
@@ -31,6 +31,8 @@ describe('LocationsPage', () => {
           limit: number
           offset: number
           device_id?: string
+          date_from?: string
+          date_to?: string
           order: string
           sort: string
         }
@@ -87,6 +89,8 @@ describe('LocationsPage', () => {
         limit: 25,
         offset: 25,
         device_id: undefined,
+        date_from: undefined,
+        date_to: undefined,
         order: 'desc',
         sort: 'timestamp',
       },
@@ -118,6 +122,30 @@ describe('LocationsPage', () => {
         limit: 25,
         offset: 0,
         device_id: 'phone',
+        date_from: undefined,
+        date_to: undefined,
+        order: 'desc',
+        sort: 'timestamp',
+      },
+    })
+  })
+
+  it('passes date_from and date_to from URL params to the query', () => {
+    render(
+      <MemoryRouter
+        initialEntries={['/locations?date_from=2026-03-01&date_to=2026-03-14']}
+      >
+        <LocationsPage />
+      </MemoryRouter>,
+    )
+
+    expect(locationHooks.useLocationsQuery).toHaveBeenLastCalledWith({
+      variables: {
+        limit: 25,
+        offset: 0,
+        device_id: undefined,
+        date_from: '2026-03-01',
+        date_to: '2026-03-14',
         order: 'desc',
         sort: 'timestamp',
       },

--- a/src/pages/LocationsPage.tsx
+++ b/src/pages/LocationsPage.tsx
@@ -1,6 +1,7 @@
 import { useDevicesQuery, useLocationsQuery } from '@/__generated__/graphql'
 import { LoadingState } from '@/components/shared/LoadingState'
 import { ErrorState } from '@/components/shared/ErrorState'
+import { DateRangePicker } from '@/components/shared/DateRangePicker'
 import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
 import {
@@ -13,6 +14,7 @@ import {
 } from '@/components/ui/table'
 import { ChevronLeft, ChevronRight } from 'lucide-react'
 import { Link, useSearchParams } from 'react-router-dom'
+import { parseISO, format as formatDate } from 'date-fns'
 
 const PAGE_SIZE = 25
 
@@ -21,6 +23,10 @@ export function LocationsPage() {
   const parsedPage = Number.parseInt(searchParams.get('page') ?? '', 10)
   const page = Math.max(1, Number.isNaN(parsedPage) ? 1 : parsedPage)
   const deviceFilter = searchParams.get('device') || undefined
+  const dateFromParam = searchParams.get('date_from')
+  const dateToParam = searchParams.get('date_to')
+  const dateFrom = dateFromParam ? parseISO(dateFromParam) : undefined
+  const dateTo = dateToParam ? parseISO(dateToParam) : undefined
   const offset = (page - 1) * PAGE_SIZE
 
   const { data: devicesData } = useDevicesQuery()
@@ -29,6 +35,8 @@ export function LocationsPage() {
       limit: PAGE_SIZE,
       offset,
       device_id: deviceFilter,
+      date_from: dateFromParam || undefined,
+      date_to: dateToParam || undefined,
       order: 'desc',
       sort: 'timestamp',
     },
@@ -51,11 +59,16 @@ export function LocationsPage() {
       </div>
 
       {/* Device filter */}
-      <div className="flex flex-wrap gap-2">
+      <div className="flex flex-wrap items-center gap-2">
         <Button
           variant={!deviceFilter ? 'default' : 'outline'}
           size="sm"
-          onClick={() => setSearchParams({})}
+          onClick={() => {
+            const params = new URLSearchParams(searchParams)
+            params.delete('device')
+            params.delete('page')
+            setSearchParams(params)
+          }}
         >
           All
         </Button>
@@ -64,11 +77,32 @@ export function LocationsPage() {
             key={d.device_id}
             variant={deviceFilter === d.device_id ? 'default' : 'outline'}
             size="sm"
-            onClick={() => setSearchParams({ device: d.device_id })}
+            onClick={() => {
+              const params = new URLSearchParams(searchParams)
+              params.set('device', d.device_id)
+              params.delete('page')
+              setSearchParams(params)
+            }}
           >
             {d.device_id}
           </Button>
         ))}
+
+        <div className="ml-auto">
+          <DateRangePicker
+            dateFrom={dateFrom}
+            dateTo={dateTo}
+            onRangeChange={(from, to) => {
+              const params = new URLSearchParams(searchParams)
+              if (from) params.set('date_from', formatDate(from, 'yyyy-MM-dd'))
+              else params.delete('date_from')
+              if (to) params.set('date_to', formatDate(to, 'yyyy-MM-dd'))
+              else params.delete('date_to')
+              params.delete('page')
+              setSearchParams(params)
+            }}
+          />
+        </div>
       </div>
 
       {/* Table */}

--- a/src/pages/LocationsPage.tsx
+++ b/src/pages/LocationsPage.tsx
@@ -14,7 +14,7 @@ import {
 } from '@/components/ui/table'
 import { ChevronLeft, ChevronRight } from 'lucide-react'
 import { Link, useSearchParams } from 'react-router-dom'
-import { parseISO, format as formatDate } from 'date-fns'
+import { parseISO, isValid, format as formatDate } from 'date-fns'
 
 const PAGE_SIZE = 25
 
@@ -25,8 +25,12 @@ export function LocationsPage() {
   const deviceFilter = searchParams.get('device') || undefined
   const dateFromParam = searchParams.get('date_from')
   const dateToParam = searchParams.get('date_to')
-  const dateFrom = dateFromParam ? parseISO(dateFromParam) : undefined
-  const dateTo = dateToParam ? parseISO(dateToParam) : undefined
+  const dateFromParsed = dateFromParam ? parseISO(dateFromParam) : undefined
+  const dateFrom =
+    dateFromParsed && isValid(dateFromParsed) ? dateFromParsed : undefined
+  const dateToParsed = dateToParam ? parseISO(dateToParam) : undefined
+  const dateTo =
+    dateToParsed && isValid(dateToParsed) ? dateToParsed : undefined
   const offset = (page - 1) * PAGE_SIZE
 
   const { data: devicesData } = useDevicesQuery()


### PR DESCRIPTION
## Summary

Add date range filtering to the Locations page using a calendar picker with quick presets for data discovery.

## Changes

### New: `DateRangePicker` component (`src/components/shared/DateRangePicker.tsx`)
- Reusable popover with dual-month calendar (`react-day-picker` range mode)
- Quick preset buttons: **Today**, **Last 7 days**, **Last 30 days**, **This month**
- Clear button to reset the date range
- `toDate={new Date()}` prevents future date selection
- Accepts `dateFrom`, `dateTo`, `onRangeChange` props

### Updated: `LocationsPage.tsx`
- Reads `date_from` and `date_to` from URL search params (ISO `YYYY-MM-DD` format)
- Passes date params to the existing `useLocationsQuery` GraphQL variables (already supported by schema)
- Renders `DateRangePicker` in the filter bar, right-aligned
- Device filter and "All" button now preserve date params (clone `searchParams` instead of resetting)
- Selecting a date range resets pagination to page 1

### Updated: `LocationsPage.test.tsx`
- Added test verifying `date_from`/`date_to` URL params are passed to query variables
- Updated existing test assertions to include the new `date_from`/`date_to` fields

## Key Design Decisions
- **URL-first state**: Date filters stored in URL params so they persist across navigation and are shareable
- **Reusable component**: `DateRangePicker` placed in `shared/` for future reuse on Garmin and Daily Summary pages
- **No schema changes needed**: GraphQL `locations` query already accepts `date_from`/`date_to` — this was unused UI wiring

## Verification
- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run src/pages/LocationsPage.test.tsx` — 6/6 pass
- [x] `npx eslint` — clean
- [x] `npm run build` — succeeds