### PR TITLE
feat: use dynamic date range from API for calendar bounds

### DIFF
--- a/src/__generated__/graphql.ts
+++ b/src/__generated__/graphql.ts
@@ -356,6 +356,15 @@ export type LocationCount = {
   device_id?: Maybe<Scalars['String']['output']>;
 };
 
+/** Earliest and latest timestamps in the locations table. */
+export type LocationDateRange = {
+  __typename?: 'LocationDateRange';
+  /** Latest location timestamp (ISO 8601) */
+  max_date: Scalars['String']['output'];
+  /** Earliest location timestamp (ISO 8601) */
+  min_date: Scalars['String']['output'];
+};
+
 /** Full location detail including the original OwnTracks JSON payload. */
 export type LocationDetail = {
   __typename?: 'LocationDetail';
@@ -467,6 +476,8 @@ export type Query = {
   location?: Maybe<LocationDetail>;
   /** Get aggregate count of location records with optional filters. */
   locationCount: LocationCount;
+  /** Get the earliest and latest location timestamps. */
+  locationDateRange: LocationDateRange;
   /** Retrieve a paginated list of OwnTracks location records. */
   locations: LocationConnection;
   /** Find GPS points within a radius of a geographic coordinate. */
@@ -790,6 +801,11 @@ export type LocationCountQueryVariables = Exact<{
 
 
 export type LocationCountQuery = { __typename?: 'Query', locationCount: { __typename?: 'LocationCount', count: number, date?: string | null, device_id?: string | null } };
+
+export type LocationDateRangeQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+export type LocationDateRangeQuery = { __typename?: 'Query', locationDateRange: { __typename?: 'LocationDateRange', min_date: string, max_date: string } };
 
 export type ReferenceLocationsQueryVariables = Exact<{ [key: string]: never; }>;
 
@@ -1620,6 +1636,49 @@ export type LocationCountQueryHookResult = ReturnType<typeof useLocationCountQue
 export type LocationCountLazyQueryHookResult = ReturnType<typeof useLocationCountLazyQuery>;
 export type LocationCountSuspenseQueryHookResult = ReturnType<typeof useLocationCountSuspenseQuery>;
 export type LocationCountQueryResult = ApolloReactCommon.QueryResult<LocationCountQuery, LocationCountQueryVariables>;
+export const LocationDateRangeDocument = gql`
+    query LocationDateRange {
+  locationDateRange {
+    min_date
+    max_date
+  }
+}
+    `;
+
+/**
+ * __useLocationDateRangeQuery__
+ *
+ * To run a query within a React component, call `useLocationDateRangeQuery` and pass it any options that fit your needs.
+ * When your component renders, `useLocationDateRangeQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useLocationDateRangeQuery({
+ *   variables: {
+ *   },
+ * });
+ */
+export function useLocationDateRangeQuery(baseOptions?: ApolloReactHooks.QueryHookOptions<LocationDateRangeQuery, LocationDateRangeQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return ApolloReactHooks.useQuery<LocationDateRangeQuery, LocationDateRangeQueryVariables>(LocationDateRangeDocument, options);
+      }
+export function useLocationDateRangeLazyQuery(baseOptions?: ApolloReactHooks.LazyQueryHookOptions<LocationDateRangeQuery, LocationDateRangeQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return ApolloReactHooks.useLazyQuery<LocationDateRangeQuery, LocationDateRangeQueryVariables>(LocationDateRangeDocument, options);
+        }
+// @ts-ignore
+export function useLocationDateRangeSuspenseQuery(baseOptions?: ApolloReactHooks.SuspenseQueryHookOptions<LocationDateRangeQuery, LocationDateRangeQueryVariables>): ApolloReactHooks.UseSuspenseQueryResult<LocationDateRangeQuery, LocationDateRangeQueryVariables>;
+export function useLocationDateRangeSuspenseQuery(baseOptions?: ApolloReactHooks.SkipToken | ApolloReactHooks.SuspenseQueryHookOptions<LocationDateRangeQuery, LocationDateRangeQueryVariables>): ApolloReactHooks.UseSuspenseQueryResult<LocationDateRangeQuery | undefined, LocationDateRangeQueryVariables>;
+export function useLocationDateRangeSuspenseQuery(baseOptions?: ApolloReactHooks.SkipToken | ApolloReactHooks.SuspenseQueryHookOptions<LocationDateRangeQuery, LocationDateRangeQueryVariables>) {
+          const options = baseOptions === ApolloReactHooks.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
+          return ApolloReactHooks.useSuspenseQuery<LocationDateRangeQuery, LocationDateRangeQueryVariables>(LocationDateRangeDocument, options);
+        }
+export type LocationDateRangeQueryHookResult = ReturnType<typeof useLocationDateRangeQuery>;
+export type LocationDateRangeLazyQueryHookResult = ReturnType<typeof useLocationDateRangeLazyQuery>;
+export type LocationDateRangeSuspenseQueryHookResult = ReturnType<typeof useLocationDateRangeSuspenseQuery>;
+export type LocationDateRangeQueryResult = ApolloReactCommon.QueryResult<LocationDateRangeQuery, LocationDateRangeQueryVariables>;
 export const ReferenceLocationsDocument = gql`
     query ReferenceLocations {
   referenceLocations {

--- a/src/graphql/locations.ts
+++ b/src/graphql/locations.ts
@@ -95,3 +95,12 @@ export const LOCATION_COUNT_QUERY = gql`
     }
   }
 `
+
+export const LOCATION_DATE_RANGE_QUERY = gql`
+  query LocationDateRange {
+    locationDateRange {
+      min_date
+      max_date
+    }
+  }
+`

--- a/src/pages/LocationsPage.test.tsx
+++ b/src/pages/LocationsPage.test.tsx
@@ -6,6 +6,7 @@ import { MemoryRouter } from 'react-router-dom'
 const locationHooks = vi.hoisted(() => ({
   useDevicesQuery: vi.fn(),
   useLocationsQuery: vi.fn(),
+  useLocationDateRangeQuery: vi.fn(),
 }))
 
 vi.mock('@/__generated__/graphql', () => locationHooks)
@@ -16,6 +17,16 @@ describe('LocationsPage', () => {
   beforeEach(() => {
     locationHooks.useDevicesQuery.mockReset()
     locationHooks.useLocationsQuery.mockReset()
+    locationHooks.useLocationDateRangeQuery.mockReset()
+
+    locationHooks.useLocationDateRangeQuery.mockReturnValue({
+      data: {
+        locationDateRange: {
+          min_date: '2025-12-27T00:00:00Z',
+          max_date: '2026-06-01T00:00:00Z',
+        },
+      },
+    })
 
     locationHooks.useDevicesQuery.mockReturnValue({
       data: {

--- a/src/pages/LocationsPage.test.tsx
+++ b/src/pages/LocationsPage.test.tsx
@@ -222,6 +222,38 @@ describe('LocationsPage', () => {
     expect(addressCell.textContent).toBe('—')
   })
 
+  it('clamps a URL date_from before the API min_date to the min bound', () => {
+    // min_date is 2025-12-27T00:00:00Z; date_from=2025-01-01 is before that
+    render(
+      <MemoryRouter initialEntries={['/locations?date_from=2025-01-01']}>
+        <LocationsPage />
+      </MemoryRouter>,
+    )
+
+    // The clamped dateFrom should appear in the DateRangePicker trigger,
+    // not the original 2025-01-01
+    const trigger = screen.getByTestId('date-range-trigger')
+    expect(trigger.textContent).not.toContain('Jan 1, 2025')
+    expect(trigger.textContent).toContain('Dec')
+    expect(trigger.textContent).toContain('2025')
+  })
+
+  it('clamps a URL date_to after the API max_date to the max bound', () => {
+    // max_date is 2026-06-01T00:00:00Z; date_to=2027-01-01 is after that
+    render(
+      <MemoryRouter
+        initialEntries={['/locations?date_from=2026-03-01&date_to=2027-01-01']}
+      >
+        <LocationsPage />
+      </MemoryRouter>,
+    )
+
+    // The clamped dateTo should appear in the DateRangePicker trigger,
+    // not the original 2027-01-01
+    const trigger = screen.getByTestId('date-range-trigger')
+    expect(trigger.textContent).not.toContain('2027')
+  })
+
   it('sets a title attribute on the address cell for truncation tooltip', () => {
     locationHooks.useLocationsQuery.mockReturnValue({
       data: {

--- a/src/pages/LocationsPage.tsx
+++ b/src/pages/LocationsPage.tsx
@@ -1,4 +1,8 @@
-import { useDevicesQuery, useLocationsQuery } from '@/__generated__/graphql'
+import {
+  useDevicesQuery,
+  useLocationsQuery,
+  useLocationDateRangeQuery,
+} from '@/__generated__/graphql'
 import { LoadingState } from '@/components/shared/LoadingState'
 import { ErrorState } from '@/components/shared/ErrorState'
 import { DateRangePicker } from '@/components/shared/DateRangePicker'
@@ -25,13 +29,16 @@ export function LocationsPage() {
   const deviceFilter = searchParams.get('device') || undefined
   const dateFromParam = searchParams.get('date_from')
   const dateToParam = searchParams.get('date_to')
-  const DATA_MIN_DATE = new Date(2026, 0, 1)
+  const { data: dateRangeData } = useLocationDateRangeQuery()
+  const DATA_MIN_DATE = dateRangeData?.locationDateRange?.min_date
+    ? new Date(dateRangeData.locationDateRange.min_date)
+    : undefined
   const DATA_MAX_DATE = new Date()
   const dateFromParsed = dateFromParam ? parseISO(dateFromParam) : undefined
   const dateFromValid =
     dateFromParsed && isValid(dateFromParsed) ? dateFromParsed : undefined
   const dateFrom = dateFromValid
-    ? dateFromValid < DATA_MIN_DATE
+    ? DATA_MIN_DATE && dateFromValid < DATA_MIN_DATE
       ? DATA_MIN_DATE
       : dateFromValid > DATA_MAX_DATE
         ? DATA_MAX_DATE
@@ -41,7 +48,7 @@ export function LocationsPage() {
   const dateToValid =
     dateToParsed && isValid(dateToParsed) ? dateToParsed : undefined
   const dateTo = dateToValid
-    ? dateToValid < DATA_MIN_DATE
+    ? DATA_MIN_DATE && dateToValid < DATA_MIN_DATE
       ? DATA_MIN_DATE
       : dateToValid > DATA_MAX_DATE
         ? DATA_MAX_DATE

--- a/src/pages/LocationsPage.tsx
+++ b/src/pages/LocationsPage.tsx
@@ -33,7 +33,9 @@ export function LocationsPage() {
   const DATA_MIN_DATE = dateRangeData?.locationDateRange?.min_date
     ? new Date(dateRangeData.locationDateRange.min_date)
     : undefined
-  const DATA_MAX_DATE = new Date()
+  const DATA_MAX_DATE = dateRangeData?.locationDateRange?.max_date
+    ? new Date(dateRangeData.locationDateRange.max_date)
+    : new Date()
   const dateFromParsed = dateFromParam ? parseISO(dateFromParam) : undefined
   const dateFromValid =
     dateFromParsed && isValid(dateFromParsed) ? dateFromParsed : undefined
@@ -120,6 +122,7 @@ export function LocationsPage() {
             dateFrom={dateFrom}
             dateTo={dateTo}
             minDate={DATA_MIN_DATE}
+            maxDate={DATA_MAX_DATE}
             onRangeChange={(from, to) => {
               const params = new URLSearchParams(searchParams)
               if (from) params.set('date_from', formatDate(from, 'yyyy-MM-dd'))


### PR DESCRIPTION
## Summary

Replaces hardcoded `DATA_MIN_DATE` / `DATA_MAX_DATE` calendar bounds with a dynamic `locationDateRange` GraphQL query that fetches the actual min/max timestamps from the database.

## Changes

- Add `LOCATION_DATE_RANGE_QUERY` to `src/graphql/locations.ts`
- Replace hardcoded date constants in `LocationsPage` with `useLocationDateRangeQuery()` hook
- Guard preset/URL date clamping for undefined `DATA_MIN_DATE` until query loads
- Regenerate codegen types for the new query
- Update `LocationsPage.test.tsx` with `useLocationDateRangeQuery` mock

## Dependencies

- Requires otel-data-api PR #83 (merged) — `GET /api/v1/locations/date-range`
- Requires otel-data-gateway PR #52 (merged) — `locationDateRange` GraphQL query

Refs #55