### PR TITLE
fix: disable out-of-range dates in calendar day selection

### DIFF
--- a/e2e/calendar-date-selection-bounds.spec.ts
+++ b/e2e/calendar-date-selection-bounds.spec.ts
@@ -1,0 +1,386 @@
+import { test, expect } from '@playwright/test'
+import fs from 'fs'
+import path from 'path'
+
+const SCREENSHOT_DIR = path.join('e2e', 'screenshots', 'calendar-date-bounds')
+
+fs.mkdirSync(SCREENSHOT_DIR, { recursive: true })
+
+/**
+ * Verifies that dates outside the valid data range cannot be selected
+ * in the calendar, even when they fall within a boundary month.
+ *
+ * The data range is roughly Dec 27, 2025 → today (Apr 11, 2026).
+ * - Dec 2, 2025 is BEFORE the first data record → should be disabled
+ * - Apr 20, 2026 is AFTER the last data record → should be disabled
+ */
+test.describe('Calendar date selection bounds', () => {
+  test.setTimeout(60_000)
+
+  test('Map page: Apr 20 (future) should be disabled', async ({ page }) => {
+    const prefix = 'map-future'
+
+    await page.goto('/map', { waitUntil: 'domcontentloaded' })
+    const heading = page.getByRole('heading', { name: 'Unified Map' })
+    try {
+      await heading.waitFor({ timeout: 15_000 })
+    } catch {
+      await page.reload()
+      await heading.waitFor({ timeout: 15_000 })
+    }
+
+    // Query the API for data bounds
+    const graphqlUrl = await page.evaluate(
+      () =>
+        (window as { __ENV__?: { GRAPHQL_URL?: string } }).__ENV__
+          ?.GRAPHQL_URL ?? 'https://gateway.lab.informationcart.com',
+    )
+    const res = await page.request.post(graphqlUrl, {
+      headers: { 'Content-Type': 'application/json' },
+      data: {
+        query: `query { locationDateRange { min_date max_date } }`,
+      },
+    })
+    expect(res.ok()).toBeTruthy()
+    const body = await res.json()
+    const maxDate = new Date(body.data.locationDateRange.max_date)
+    console.log(`  API max_date: ${body.data.locationDateRange.max_date}`)
+
+    // Open the calendar
+    const main = page.getByRole('main')
+    const dateButton = main.getByRole('button', { name: /\w+ \d+, \d{4}/ })
+    await dateButton.click()
+
+    const calendar = page.locator('[data-slot="calendar"]')
+    await expect(calendar).toBeVisible({ timeout: 5_000 })
+
+    await page.screenshot({
+      path: path.join(SCREENSHOT_DIR, `${prefix}-01-calendar-opened.png`),
+      fullPage: false,
+    })
+
+    // Target: April 20 of the max_date's year
+    const apr20DataDay = `4/20/${maxDate.getFullYear()}`
+    const apr20Button = calendar.locator(`button[data-day="${apr20DataDay}"]`)
+
+    // Check if Apr 20 is present and whether it's disabled
+    if ((await apr20Button.count()) > 0) {
+      const isDisabled = await apr20Button.getAttribute('aria-disabled')
+      const hasDisabledAttr = await apr20Button.isDisabled().catch(() => false)
+      console.log(
+        `  Apr 20 button: aria-disabled=${isDisabled}, disabled=${hasDisabledAttr}`,
+      )
+
+      await page.screenshot({
+        path: path.join(SCREENSHOT_DIR, `${prefix}-02-apr20-state.png`),
+        fullPage: false,
+      })
+
+      // Try clicking it and check if the calendar accepts the selection
+      await apr20Button.click({ force: true })
+      await page.waitForTimeout(500)
+
+      await page.screenshot({
+        path: path.join(SCREENSHOT_DIR, `${prefix}-03-after-apr20-click.png`),
+        fullPage: false,
+      })
+
+      // The date button text should NOT change to "April 20"
+      const dateText = await main
+        .getByRole('button', { name: /\w+ \d+, \d{4}/ })
+        .textContent()
+      console.log(`  Date button text after click: ${dateText}`)
+
+      // If April 20 appears in the button text, the calendar allowed selection
+      const selectedApr20 = dateText?.includes('April 20')
+      expect(
+        selectedApr20,
+        `Calendar should NOT allow selecting April 20 (after max_date ${maxDate.toISOString()})`,
+      ).toBe(false)
+    } else {
+      console.log('  Apr 20 button not found on current calendar view')
+    }
+  })
+
+  test('Map page: Dec 2 (before data start) should be disabled', async ({
+    page,
+  }) => {
+    const prefix = 'map-past'
+
+    await page.goto('/map', { waitUntil: 'domcontentloaded' })
+    const heading = page.getByRole('heading', { name: 'Unified Map' })
+    try {
+      await heading.waitFor({ timeout: 15_000 })
+    } catch {
+      await page.reload()
+      await heading.waitFor({ timeout: 15_000 })
+    }
+
+    // Query the API for data bounds
+    const graphqlUrl = await page.evaluate(
+      () =>
+        (window as { __ENV__?: { GRAPHQL_URL?: string } }).__ENV__
+          ?.GRAPHQL_URL ?? 'https://gateway.lab.informationcart.com',
+    )
+    const res = await page.request.post(graphqlUrl, {
+      headers: { 'Content-Type': 'application/json' },
+      data: {
+        query: `query { locationDateRange { min_date max_date } }`,
+      },
+    })
+    expect(res.ok()).toBeTruthy()
+    const body = await res.json()
+    const minDate = new Date(body.data.locationDateRange.min_date)
+    console.log(`  API min_date: ${body.data.locationDateRange.min_date}`)
+
+    // Open the calendar
+    const main = page.getByRole('main')
+    const dateButton = main.getByRole('button', { name: /\w+ \d+, \d{4}/ })
+    await dateButton.click()
+
+    const calendar = page.locator('[data-slot="calendar"]')
+    await expect(calendar).toBeVisible({ timeout: 5_000 })
+
+    // Navigate backward to December 2025
+    const prevMonthBtn = calendar.getByRole('button', { name: /previous/i })
+    await expect(prevMonthBtn).toBeVisible()
+
+    // Click back to reach December (from April → Mar → Feb → Jan → Dec)
+    const today = new Date()
+    const monthsBack =
+      (today.getFullYear() - minDate.getFullYear()) * 12 +
+      (today.getMonth() - minDate.getMonth())
+    console.log(`  Clicking back ${monthsBack} months to reach December`)
+
+    for (let i = 0; i < monthsBack; i++) {
+      const isDisabled = await prevMonthBtn.isDisabled().catch(() => true)
+      if (isDisabled) {
+        console.log(`  Prev button disabled at click ${i}`)
+        break
+      }
+      await prevMonthBtn.click()
+    }
+
+    await page.screenshot({
+      path: path.join(SCREENSHOT_DIR, `${prefix}-01-december-view.png`),
+      fullPage: false,
+    })
+
+    // Target: December 2 of the min_date's year
+    const dec2DataDay = `12/2/${minDate.getFullYear()}`
+    const dec2Button = calendar.locator(`button[data-day="${dec2DataDay}"]`)
+
+    if ((await dec2Button.count()) > 0) {
+      const isDisabled = await dec2Button.getAttribute('aria-disabled')
+      const hasDisabledAttr = await dec2Button.isDisabled().catch(() => false)
+      console.log(
+        `  Dec 2 button: aria-disabled=${isDisabled}, disabled=${hasDisabledAttr}`,
+      )
+
+      await page.screenshot({
+        path: path.join(SCREENSHOT_DIR, `${prefix}-02-dec2-state.png`),
+        fullPage: false,
+      })
+
+      // Try clicking Dec 2 and check if the calendar accepts the selection
+      await dec2Button.click({ force: true })
+      await page.waitForTimeout(500)
+
+      await page.screenshot({
+        path: path.join(SCREENSHOT_DIR, `${prefix}-03-after-dec2-click.png`),
+        fullPage: false,
+      })
+
+      // The date button text should NOT change to "December 2"
+      const dateText = await main
+        .getByRole('button', { name: /\w+ \d+, \d{4}/ })
+        .textContent()
+      console.log(`  Date button text after click: ${dateText}`)
+
+      const selectedDec2 = dateText?.includes('December 2,')
+      expect(
+        selectedDec2,
+        `Calendar should NOT allow selecting Dec 2 (before min_date ${minDate.toISOString()})`,
+      ).toBe(false)
+    } else {
+      console.log(
+        '  Dec 2 button not found — may be properly hidden by fromDate',
+      )
+    }
+  })
+
+  test('Locations page: Apr 20 (future) should be disabled in range picker', async ({
+    page,
+  }) => {
+    const prefix = 'locations-future'
+
+    await page.goto('/locations', { waitUntil: 'domcontentloaded' })
+    await expect(page.getByTestId('date-range-trigger')).toBeVisible({
+      timeout: 30_000,
+    })
+
+    // Query the API for data bounds
+    const graphqlUrl = await page.evaluate(
+      () =>
+        (window as { __ENV__?: { GRAPHQL_URL?: string } }).__ENV__
+          ?.GRAPHQL_URL ?? 'https://gateway.lab.informationcart.com',
+    )
+    const res = await page.request.post(graphqlUrl, {
+      headers: { 'Content-Type': 'application/json' },
+      data: {
+        query: `query { locationDateRange { min_date max_date } }`,
+      },
+    })
+    expect(res.ok()).toBeTruthy()
+    const body = await res.json()
+    const maxDate = new Date(body.data.locationDateRange.max_date)
+    console.log(`  API max_date: ${body.data.locationDateRange.max_date}`)
+
+    // Open the date range picker
+    const trigger = page.getByTestId('date-range-trigger')
+    await trigger.click()
+
+    const calendar = page.locator('[data-slot="calendar"]')
+    await expect(calendar).toBeVisible({ timeout: 5_000 })
+
+    await page.screenshot({
+      path: path.join(SCREENSHOT_DIR, `${prefix}-01-calendar-opened.png`),
+      fullPage: false,
+    })
+
+    // The range picker shows 2 months. Navigate forward if needed to see April.
+    const nextMonthBtn = calendar.getByRole('button', { name: /next/i })
+
+    // Click forward until we can see April in the calendar
+    for (let i = 0; i < 5; i++) {
+      const apr20Button = calendar.locator(
+        `button[data-day="4/20/${maxDate.getFullYear()}"]`,
+      )
+      if ((await apr20Button.count()) > 0) break
+      const isDisabled = await nextMonthBtn.isDisabled().catch(() => true)
+      if (isDisabled) break
+      await nextMonthBtn.click()
+    }
+
+    const apr20DataDay = `4/20/${maxDate.getFullYear()}`
+    const apr20Button = calendar.locator(`button[data-day="${apr20DataDay}"]`)
+
+    if ((await apr20Button.count()) > 0) {
+      const isDisabled = await apr20Button.getAttribute('aria-disabled')
+      const hasDisabledAttr = await apr20Button.isDisabled().catch(() => false)
+      console.log(
+        `  Apr 20 button: aria-disabled=${isDisabled}, disabled=${hasDisabledAttr}`,
+      )
+
+      await page.screenshot({
+        path: path.join(SCREENSHOT_DIR, `${prefix}-02-apr20-state.png`),
+        fullPage: false,
+      })
+
+      // If Apr 20 is NOT disabled, that's the bug
+      if (isDisabled !== 'true' && !hasDisabledAttr) {
+        console.log('  BUG: Apr 20 is selectable but should be disabled')
+      }
+
+      // Try clicking and capture the result
+      await apr20Button.click({ force: true })
+      await page.waitForTimeout(500)
+
+      await page.screenshot({
+        path: path.join(SCREENSHOT_DIR, `${prefix}-03-after-apr20-click.png`),
+        fullPage: false,
+      })
+    } else {
+      console.log('  Apr 20 button not found in calendar view')
+    }
+  })
+
+  test('Locations page: Dec 2 (before data start) should be disabled in range picker', async ({
+    page,
+  }) => {
+    const prefix = 'locations-past'
+
+    await page.goto('/locations', { waitUntil: 'domcontentloaded' })
+    await expect(page.getByTestId('date-range-trigger')).toBeVisible({
+      timeout: 30_000,
+    })
+
+    // Query the API for data bounds
+    const graphqlUrl = await page.evaluate(
+      () =>
+        (window as { __ENV__?: { GRAPHQL_URL?: string } }).__ENV__
+          ?.GRAPHQL_URL ?? 'https://gateway.lab.informationcart.com',
+    )
+    const res = await page.request.post(graphqlUrl, {
+      headers: { 'Content-Type': 'application/json' },
+      data: {
+        query: `query { locationDateRange { min_date max_date } }`,
+      },
+    })
+    expect(res.ok()).toBeTruthy()
+    const body = await res.json()
+    const minDate = new Date(body.data.locationDateRange.min_date)
+    console.log(`  API min_date: ${body.data.locationDateRange.min_date}`)
+
+    // Open the date range picker
+    const trigger = page.getByTestId('date-range-trigger')
+    await trigger.click()
+
+    const calendar = page.locator('[data-slot="calendar"]')
+    await expect(calendar).toBeVisible({ timeout: 5_000 })
+
+    // Navigate backward to December
+    const prevMonthBtn = calendar.getByRole('button', { name: /previous/i })
+    await expect(prevMonthBtn).toBeVisible()
+
+    const today = new Date()
+    const monthsBack =
+      (today.getFullYear() - minDate.getFullYear()) * 12 +
+      (today.getMonth() - minDate.getMonth())
+
+    for (let i = 0; i < monthsBack; i++) {
+      const isDisabled = await prevMonthBtn.isDisabled().catch(() => true)
+      if (isDisabled) break
+      await prevMonthBtn.click()
+    }
+
+    await page.screenshot({
+      path: path.join(SCREENSHOT_DIR, `${prefix}-01-december-view.png`),
+      fullPage: false,
+    })
+
+    const dec2DataDay = `12/2/${minDate.getFullYear()}`
+    const dec2Button = calendar.locator(`button[data-day="${dec2DataDay}"]`)
+
+    if ((await dec2Button.count()) > 0) {
+      const isDisabled = await dec2Button.getAttribute('aria-disabled')
+      const hasDisabledAttr = await dec2Button.isDisabled().catch(() => false)
+      console.log(
+        `  Dec 2 button: aria-disabled=${isDisabled}, disabled=${hasDisabledAttr}`,
+      )
+
+      await page.screenshot({
+        path: path.join(SCREENSHOT_DIR, `${prefix}-02-dec2-state.png`),
+        fullPage: false,
+      })
+
+      // If Dec 2 is NOT disabled, that's the bug
+      if (isDisabled !== 'true' && !hasDisabledAttr) {
+        console.log('  BUG: Dec 2 is selectable but should be disabled')
+      }
+
+      // Try clicking and capture the result
+      await dec2Button.click({ force: true })
+      await page.waitForTimeout(500)
+
+      await page.screenshot({
+        path: path.join(SCREENSHOT_DIR, `${prefix}-03-after-dec2-click.png`),
+        fullPage: false,
+      })
+    } else {
+      console.log(
+        '  Dec 2 button not found — may be properly hidden by fromDate',
+      )
+    }
+  })
+})

--- a/e2e/calendar-date-selection-bounds.spec.ts
+++ b/e2e/calendar-date-selection-bounds.spec.ts
@@ -6,18 +6,121 @@ const SCREENSHOT_DIR = path.join('e2e', 'screenshots', 'calendar-date-bounds')
 
 fs.mkdirSync(SCREENSHOT_DIR, { recursive: true })
 
+/** Format a Date as the data-day attribute value: M/D/YYYY */
+const formatDataDay = (date: Date) =>
+  `${date.getMonth() + 1}/${date.getDate()}/${date.getFullYear()}`
+
+/** Format a Date as a readable label for logs/assertions */
+const formatReadable = (date: Date) =>
+  date.toLocaleString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  })
+
+/** Add days to a date (returns new Date) */
+const addDays = (date: Date, days: number) => {
+  const d = new Date(date)
+  d.setDate(d.getDate() + days)
+  return d
+}
+
+/** Fetch min_date and max_date from the GraphQL API */
+async function fetchDateBounds(page: import('@playwright/test').Page) {
+  const graphqlUrl = await page.evaluate(
+    () =>
+      (window as { __ENV__?: { GRAPHQL_URL?: string } }).__ENV__?.GRAPHQL_URL ??
+      'https://gateway.lab.informationcart.com',
+  )
+  const res = await page.request.post(graphqlUrl, {
+    headers: { 'Content-Type': 'application/json' },
+    data: {
+      query: `query { locationDateRange { min_date max_date } }`,
+    },
+  })
+  expect(res.ok()).toBeTruthy()
+  const body = await res.json()
+  return {
+    minDate: new Date(body.data.locationDateRange.min_date),
+    maxDate: new Date(body.data.locationDateRange.max_date),
+  }
+}
+
+/** Read the displayed month caption from the calendar (e.g., "April 2026") */
+async function getCalendarMonth(calendar: import('@playwright/test').Locator) {
+  const caption = calendar
+    .locator(
+      '[class*="caption"], [data-slot="month-caption"], .rdp-caption_label, caption',
+    )
+    .first()
+  if ((await caption.count()) > 0) {
+    return caption.textContent()
+  }
+  return null
+}
+
+/**
+ * Navigate the calendar to the month containing targetDate.
+ * Reads the displayed month caption to determine clicks needed.
+ */
+async function navigateToMonth(
+  calendar: import('@playwright/test').Locator,
+  targetDate: Date,
+  direction: 'previous' | 'next',
+) {
+  const btn = calendar.getByRole('button', { name: new RegExp(direction, 'i') })
+  await expect(btn).toBeVisible()
+
+  const targetMonth = targetDate.getMonth()
+  const targetYear = targetDate.getFullYear()
+
+  for (let i = 0; i < 24; i++) {
+    // Check if the target day button is already visible
+    const dayBtn = calendar.locator(
+      `button[data-day="${formatDataDay(targetDate)}"]`,
+    )
+    if ((await dayBtn.count()) > 0) return
+
+    const isDisabled = await btn.isDisabled().catch(() => true)
+    if (isDisabled) break
+
+    // Also check by caption text
+    const caption = await getCalendarMonth(calendar)
+    if (caption) {
+      const monthNames = [
+        'January',
+        'February',
+        'March',
+        'April',
+        'May',
+        'June',
+        'July',
+        'August',
+        'September',
+        'October',
+        'November',
+        'December',
+      ]
+      const targetCaption = `${monthNames[targetMonth]} ${targetYear}`
+      if (caption.includes(targetCaption)) return
+    }
+
+    await btn.click()
+  }
+}
+
 /**
  * Verifies that dates outside the valid data range cannot be selected
  * in the calendar, even when they fall within a boundary month.
  *
- * The data range is roughly Dec 27, 2025 → today (Apr 11, 2026).
- * - Dec 2, 2025 is BEFORE the first data record → should be disabled
- * - Apr 20, 2026 is AFTER the last data record → should be disabled
+ * Target dates are derived dynamically from the API:
+ * - Future out-of-range: max_date + 1 day
+ * - Past out-of-range: min_date - 1 day
  */
 test.describe('Calendar date selection bounds', () => {
   test.setTimeout(60_000)
 
-  test('Map page: Apr 20 (future) should be disabled', async ({ page }) => {
+  test('Map page: day after max_date should be disabled', async ({ page }) => {
     const prefix = 'map-future'
 
     await page.goto('/map', { waitUntil: 'domcontentloaded' })
@@ -29,26 +132,15 @@ test.describe('Calendar date selection bounds', () => {
       await heading.waitFor({ timeout: 15_000 })
     }
 
-    // Query the API for data bounds
-    const graphqlUrl = await page.evaluate(
-      () =>
-        (window as { __ENV__?: { GRAPHQL_URL?: string } }).__ENV__
-          ?.GRAPHQL_URL ?? 'https://gateway.lab.informationcart.com',
-    )
-    const res = await page.request.post(graphqlUrl, {
-      headers: { 'Content-Type': 'application/json' },
-      data: {
-        query: `query { locationDateRange { min_date max_date } }`,
-      },
-    })
-    expect(res.ok()).toBeTruthy()
-    const body = await res.json()
-    const maxDate = new Date(body.data.locationDateRange.max_date)
-    console.log(`  API max_date: ${body.data.locationDateRange.max_date}`)
+    const { maxDate } = await fetchDateBounds(page)
+    const futureDate = addDays(maxDate, 1)
+    console.log(`  API max_date: ${maxDate.toISOString()}`)
+    console.log(`  Target out-of-range date: ${formatReadable(futureDate)}`)
 
     // Open the calendar
     const main = page.getByRole('main')
     const dateButton = main.getByRole('button', { name: /\w+ \d+, \d{4}/ })
+    const triggerTextBefore = await dateButton.textContent()
     await dateButton.click()
 
     const calendar = page.locator('[data-slot="calendar"]')
@@ -59,52 +151,54 @@ test.describe('Calendar date selection bounds', () => {
       fullPage: false,
     })
 
-    // Target: April 20 of the max_date's year
-    const apr20DataDay = `4/20/${maxDate.getFullYear()}`
-    const apr20Button = calendar.locator(`button[data-day="${apr20DataDay}"]`)
+    // Navigate forward if the target month isn't visible
+    await navigateToMonth(calendar, futureDate, 'next')
 
-    // Check if Apr 20 is present and whether it's disabled
-    if ((await apr20Button.count()) > 0) {
-      const isDisabled = await apr20Button.getAttribute('aria-disabled')
-      const hasDisabledAttr = await apr20Button.isDisabled().catch(() => false)
-      console.log(
-        `  Apr 20 button: aria-disabled=${isDisabled}, disabled=${hasDisabledAttr}`,
-      )
+    const futureDayBtn = calendar.locator(
+      `button[data-day="${formatDataDay(futureDate)}"]`,
+    )
+    await expect(futureDayBtn).toHaveCount(1)
 
-      await page.screenshot({
-        path: path.join(SCREENSHOT_DIR, `${prefix}-02-apr20-state.png`),
-        fullPage: false,
-      })
+    const ariaDisabled = await futureDayBtn.getAttribute('aria-disabled')
+    const isDisabledProp = await futureDayBtn.isDisabled().catch(() => false)
+    console.log(
+      `  ${formatReadable(futureDate)} button: aria-disabled=${ariaDisabled}, disabled=${isDisabledProp}`,
+    )
 
-      // Try clicking it and check if the calendar accepts the selection
-      await apr20Button.click({ force: true })
-      await page.waitForTimeout(500)
+    await page.screenshot({
+      path: path.join(SCREENSHOT_DIR, `${prefix}-02-target-state.png`),
+      fullPage: false,
+    })
 
-      await page.screenshot({
-        path: path.join(SCREENSHOT_DIR, `${prefix}-03-after-apr20-click.png`),
-        fullPage: false,
-      })
+    // Assert the button is disabled
+    expect(
+      ariaDisabled === 'true' || isDisabledProp,
+      `${formatReadable(futureDate)} should be disabled (after max_date)`,
+    ).toBeTruthy()
 
-      // The date button text should NOT change to "April 20"
-      const dateText = await main
-        .getByRole('button', { name: /\w+ \d+, \d{4}/ })
-        .textContent()
-      console.log(`  Date button text after click: ${dateText}`)
+    // Verify clicking doesn't change the selected date
+    await futureDayBtn.click({ force: true })
+    await page.waitForTimeout(500)
 
-      // If April 20 appears in the button text, the calendar allowed selection
-      const selectedApr20 = dateText?.includes('April 20')
-      expect(
-        selectedApr20,
-        `Calendar should NOT allow selecting April 20 (after max_date ${maxDate.toISOString()})`,
-      ).toBe(false)
-    } else {
-      console.log('  Apr 20 button not found on current calendar view')
-    }
+    const triggerTextAfter = await main
+      .getByRole('button', { name: /\w+ \d+, \d{4}/ })
+      .textContent()
+    console.log(
+      `  Trigger before: ${triggerTextBefore}, after: ${triggerTextAfter}`,
+    )
+
+    expect(
+      triggerTextAfter,
+      'Clicking disabled date should not change the selected date',
+    ).toBe(triggerTextBefore)
+
+    await page.screenshot({
+      path: path.join(SCREENSHOT_DIR, `${prefix}-03-after-click.png`),
+      fullPage: false,
+    })
   })
 
-  test('Map page: Dec 2 (before data start) should be disabled', async ({
-    page,
-  }) => {
+  test('Map page: day before min_date should be disabled', async ({ page }) => {
     const prefix = 'map-past'
 
     await page.goto('/map', { waitUntil: 'domcontentloaded' })
@@ -116,100 +210,73 @@ test.describe('Calendar date selection bounds', () => {
       await heading.waitFor({ timeout: 15_000 })
     }
 
-    // Query the API for data bounds
-    const graphqlUrl = await page.evaluate(
-      () =>
-        (window as { __ENV__?: { GRAPHQL_URL?: string } }).__ENV__
-          ?.GRAPHQL_URL ?? 'https://gateway.lab.informationcart.com',
-    )
-    const res = await page.request.post(graphqlUrl, {
-      headers: { 'Content-Type': 'application/json' },
-      data: {
-        query: `query { locationDateRange { min_date max_date } }`,
-      },
-    })
-    expect(res.ok()).toBeTruthy()
-    const body = await res.json()
-    const minDate = new Date(body.data.locationDateRange.min_date)
-    console.log(`  API min_date: ${body.data.locationDateRange.min_date}`)
+    const { minDate } = await fetchDateBounds(page)
+    const pastDate = addDays(minDate, -1)
+    console.log(`  API min_date: ${minDate.toISOString()}`)
+    console.log(`  Target out-of-range date: ${formatReadable(pastDate)}`)
 
     // Open the calendar
     const main = page.getByRole('main')
     const dateButton = main.getByRole('button', { name: /\w+ \d+, \d{4}/ })
+    const triggerTextBefore = await dateButton.textContent()
     await dateButton.click()
 
     const calendar = page.locator('[data-slot="calendar"]')
     await expect(calendar).toBeVisible({ timeout: 5_000 })
 
-    // Navigate backward to December 2025
-    const prevMonthBtn = calendar.getByRole('button', { name: /previous/i })
-    await expect(prevMonthBtn).toBeVisible()
-
-    // Click back to reach December (from April → Mar → Feb → Jan → Dec)
-    const today = new Date()
-    const monthsBack =
-      (today.getFullYear() - minDate.getFullYear()) * 12 +
-      (today.getMonth() - minDate.getMonth())
-    console.log(`  Clicking back ${monthsBack} months to reach December`)
-
-    for (let i = 0; i < monthsBack; i++) {
-      const isDisabled = await prevMonthBtn.isDisabled().catch(() => true)
-      if (isDisabled) {
-        console.log(`  Prev button disabled at click ${i}`)
-        break
-      }
-      await prevMonthBtn.click()
-    }
+    // Navigate backward to the target month
+    await navigateToMonth(calendar, pastDate, 'previous')
 
     await page.screenshot({
-      path: path.join(SCREENSHOT_DIR, `${prefix}-01-december-view.png`),
+      path: path.join(SCREENSHOT_DIR, `${prefix}-01-target-month.png`),
       fullPage: false,
     })
 
-    // Target: December 2 of the min_date's year
-    const dec2DataDay = `12/2/${minDate.getFullYear()}`
-    const dec2Button = calendar.locator(`button[data-day="${dec2DataDay}"]`)
+    const pastDayBtn = calendar.locator(
+      `button[data-day="${formatDataDay(pastDate)}"]`,
+    )
+    await expect(pastDayBtn).toHaveCount(1)
 
-    if ((await dec2Button.count()) > 0) {
-      const isDisabled = await dec2Button.getAttribute('aria-disabled')
-      const hasDisabledAttr = await dec2Button.isDisabled().catch(() => false)
-      console.log(
-        `  Dec 2 button: aria-disabled=${isDisabled}, disabled=${hasDisabledAttr}`,
-      )
+    const ariaDisabled = await pastDayBtn.getAttribute('aria-disabled')
+    const isDisabledProp = await pastDayBtn.isDisabled().catch(() => false)
+    console.log(
+      `  ${formatReadable(pastDate)} button: aria-disabled=${ariaDisabled}, disabled=${isDisabledProp}`,
+    )
 
-      await page.screenshot({
-        path: path.join(SCREENSHOT_DIR, `${prefix}-02-dec2-state.png`),
-        fullPage: false,
-      })
+    await page.screenshot({
+      path: path.join(SCREENSHOT_DIR, `${prefix}-02-target-state.png`),
+      fullPage: false,
+    })
 
-      // Try clicking Dec 2 and check if the calendar accepts the selection
-      await dec2Button.click({ force: true })
-      await page.waitForTimeout(500)
+    // Assert the button is disabled
+    expect(
+      ariaDisabled === 'true' || isDisabledProp,
+      `${formatReadable(pastDate)} should be disabled (before min_date)`,
+    ).toBeTruthy()
 
-      await page.screenshot({
-        path: path.join(SCREENSHOT_DIR, `${prefix}-03-after-dec2-click.png`),
-        fullPage: false,
-      })
+    // Verify clicking doesn't change the selected date
+    await pastDayBtn.click({ force: true })
+    await page.waitForTimeout(500)
 
-      // The date button text should NOT change to "December 2"
-      const dateText = await main
-        .getByRole('button', { name: /\w+ \d+, \d{4}/ })
-        .textContent()
-      console.log(`  Date button text after click: ${dateText}`)
+    const triggerTextAfter = await main
+      .getByRole('button', { name: /\w+ \d+, \d{4}/ })
+      .textContent()
+    console.log(
+      `  Trigger before: ${triggerTextBefore}, after: ${triggerTextAfter}`,
+    )
 
-      const selectedDec2 = dateText?.includes('December 2,')
-      expect(
-        selectedDec2,
-        `Calendar should NOT allow selecting Dec 2 (before min_date ${minDate.toISOString()})`,
-      ).toBe(false)
-    } else {
-      console.log(
-        '  Dec 2 button not found — may be properly hidden by fromDate',
-      )
-    }
+    expect(
+      triggerTextAfter,
+      'Clicking disabled date should not change the selected date',
+    ).toBe(triggerTextBefore)
+
+    await page.screenshot({
+      path: path.join(SCREENSHOT_DIR, `${prefix}-03-after-click.png`),
+      fullPage: false,
+    })
   })
 
-  test('Locations page: Apr 20 (future) should be disabled in range picker', async ({
+  test('Locations page: day after max_date should be disabled in range picker', async ({
     page,
   }) => {
     const prefix = 'locations-future'
@@ -219,25 +286,14 @@ test.describe('Calendar date selection bounds', () => {
       timeout: 30_000,
     })
 
-    // Query the API for data bounds
-    const graphqlUrl = await page.evaluate(
-      () =>
-        (window as { __ENV__?: { GRAPHQL_URL?: string } }).__ENV__
-          ?.GRAPHQL_URL ?? 'https://gateway.lab.informationcart.com',
-    )
-    const res = await page.request.post(graphqlUrl, {
-      headers: { 'Content-Type': 'application/json' },
-      data: {
-        query: `query { locationDateRange { min_date max_date } }`,
-      },
-    })
-    expect(res.ok()).toBeTruthy()
-    const body = await res.json()
-    const maxDate = new Date(body.data.locationDateRange.max_date)
-    console.log(`  API max_date: ${body.data.locationDateRange.max_date}`)
+    const { maxDate } = await fetchDateBounds(page)
+    const futureDate = addDays(maxDate, 1)
+    console.log(`  API max_date: ${maxDate.toISOString()}`)
+    console.log(`  Target out-of-range date: ${formatReadable(futureDate)}`)
 
     // Open the date range picker
     const trigger = page.getByTestId('date-range-trigger')
+    const triggerTextBefore = await trigger.textContent()
     await trigger.click()
 
     const calendar = page.locator('[data-slot="calendar"]')
@@ -248,54 +304,52 @@ test.describe('Calendar date selection bounds', () => {
       fullPage: false,
     })
 
-    // The range picker shows 2 months. Navigate forward if needed to see April.
-    const nextMonthBtn = calendar.getByRole('button', { name: /next/i })
+    // Navigate forward to the target month
+    await navigateToMonth(calendar, futureDate, 'next')
 
-    // Click forward until we can see April in the calendar
-    for (let i = 0; i < 5; i++) {
-      const apr20Button = calendar.locator(
-        `button[data-day="4/20/${maxDate.getFullYear()}"]`,
-      )
-      if ((await apr20Button.count()) > 0) break
-      const isDisabled = await nextMonthBtn.isDisabled().catch(() => true)
-      if (isDisabled) break
-      await nextMonthBtn.click()
-    }
+    const futureDayBtn = calendar.locator(
+      `button[data-day="${formatDataDay(futureDate)}"]`,
+    )
+    await expect(futureDayBtn).toHaveCount(1)
 
-    const apr20DataDay = `4/20/${maxDate.getFullYear()}`
-    const apr20Button = calendar.locator(`button[data-day="${apr20DataDay}"]`)
+    const ariaDisabled = await futureDayBtn.getAttribute('aria-disabled')
+    const isDisabledProp = await futureDayBtn.isDisabled().catch(() => false)
+    console.log(
+      `  ${formatReadable(futureDate)} button: aria-disabled=${ariaDisabled}, disabled=${isDisabledProp}`,
+    )
 
-    if ((await apr20Button.count()) > 0) {
-      const isDisabled = await apr20Button.getAttribute('aria-disabled')
-      const hasDisabledAttr = await apr20Button.isDisabled().catch(() => false)
-      console.log(
-        `  Apr 20 button: aria-disabled=${isDisabled}, disabled=${hasDisabledAttr}`,
-      )
+    await page.screenshot({
+      path: path.join(SCREENSHOT_DIR, `${prefix}-02-target-state.png`),
+      fullPage: false,
+    })
 
-      await page.screenshot({
-        path: path.join(SCREENSHOT_DIR, `${prefix}-02-apr20-state.png`),
-        fullPage: false,
-      })
+    // Assert the button is disabled
+    expect(
+      ariaDisabled === 'true' || isDisabledProp,
+      `${formatReadable(futureDate)} should be disabled in range picker (after max_date)`,
+    ).toBeTruthy()
 
-      // If Apr 20 is NOT disabled, that's the bug
-      if (isDisabled !== 'true' && !hasDisabledAttr) {
-        console.log('  BUG: Apr 20 is selectable but should be disabled')
-      }
+    // Verify clicking doesn't change the trigger text
+    await futureDayBtn.click({ force: true })
+    await page.waitForTimeout(500)
 
-      // Try clicking and capture the result
-      await apr20Button.click({ force: true })
-      await page.waitForTimeout(500)
+    const triggerTextAfter = await trigger.textContent()
+    console.log(
+      `  Trigger before: ${triggerTextBefore}, after: ${triggerTextAfter}`,
+    )
 
-      await page.screenshot({
-        path: path.join(SCREENSHOT_DIR, `${prefix}-03-after-apr20-click.png`),
-        fullPage: false,
-      })
-    } else {
-      console.log('  Apr 20 button not found in calendar view')
-    }
+    expect(
+      triggerTextAfter,
+      'Clicking disabled date should not change the date range',
+    ).toBe(triggerTextBefore)
+
+    await page.screenshot({
+      path: path.join(SCREENSHOT_DIR, `${prefix}-03-after-click.png`),
+      fullPage: false,
+    })
   })
 
-  test('Locations page: Dec 2 (before data start) should be disabled in range picker', async ({
+  test('Locations page: day before min_date should be disabled in range picker', async ({
     page,
   }) => {
     const prefix = 'locations-past'
@@ -305,82 +359,66 @@ test.describe('Calendar date selection bounds', () => {
       timeout: 30_000,
     })
 
-    // Query the API for data bounds
-    const graphqlUrl = await page.evaluate(
-      () =>
-        (window as { __ENV__?: { GRAPHQL_URL?: string } }).__ENV__
-          ?.GRAPHQL_URL ?? 'https://gateway.lab.informationcart.com',
-    )
-    const res = await page.request.post(graphqlUrl, {
-      headers: { 'Content-Type': 'application/json' },
-      data: {
-        query: `query { locationDateRange { min_date max_date } }`,
-      },
-    })
-    expect(res.ok()).toBeTruthy()
-    const body = await res.json()
-    const minDate = new Date(body.data.locationDateRange.min_date)
-    console.log(`  API min_date: ${body.data.locationDateRange.min_date}`)
+    const { minDate } = await fetchDateBounds(page)
+    const pastDate = addDays(minDate, -1)
+    console.log(`  API min_date: ${minDate.toISOString()}`)
+    console.log(`  Target out-of-range date: ${formatReadable(pastDate)}`)
 
     // Open the date range picker
     const trigger = page.getByTestId('date-range-trigger')
+    const triggerTextBefore = await trigger.textContent()
     await trigger.click()
 
     const calendar = page.locator('[data-slot="calendar"]')
     await expect(calendar).toBeVisible({ timeout: 5_000 })
 
-    // Navigate backward to December
-    const prevMonthBtn = calendar.getByRole('button', { name: /previous/i })
-    await expect(prevMonthBtn).toBeVisible()
-
-    const today = new Date()
-    const monthsBack =
-      (today.getFullYear() - minDate.getFullYear()) * 12 +
-      (today.getMonth() - minDate.getMonth())
-
-    for (let i = 0; i < monthsBack; i++) {
-      const isDisabled = await prevMonthBtn.isDisabled().catch(() => true)
-      if (isDisabled) break
-      await prevMonthBtn.click()
-    }
+    // Navigate backward to the target month
+    await navigateToMonth(calendar, pastDate, 'previous')
 
     await page.screenshot({
-      path: path.join(SCREENSHOT_DIR, `${prefix}-01-december-view.png`),
+      path: path.join(SCREENSHOT_DIR, `${prefix}-01-target-month.png`),
       fullPage: false,
     })
 
-    const dec2DataDay = `12/2/${minDate.getFullYear()}`
-    const dec2Button = calendar.locator(`button[data-day="${dec2DataDay}"]`)
+    const pastDayBtn = calendar.locator(
+      `button[data-day="${formatDataDay(pastDate)}"]`,
+    )
+    await expect(pastDayBtn).toHaveCount(1)
 
-    if ((await dec2Button.count()) > 0) {
-      const isDisabled = await dec2Button.getAttribute('aria-disabled')
-      const hasDisabledAttr = await dec2Button.isDisabled().catch(() => false)
-      console.log(
-        `  Dec 2 button: aria-disabled=${isDisabled}, disabled=${hasDisabledAttr}`,
-      )
+    const ariaDisabled = await pastDayBtn.getAttribute('aria-disabled')
+    const isDisabledProp = await pastDayBtn.isDisabled().catch(() => false)
+    console.log(
+      `  ${formatReadable(pastDate)} button: aria-disabled=${ariaDisabled}, disabled=${isDisabledProp}`,
+    )
 
-      await page.screenshot({
-        path: path.join(SCREENSHOT_DIR, `${prefix}-02-dec2-state.png`),
-        fullPage: false,
-      })
+    await page.screenshot({
+      path: path.join(SCREENSHOT_DIR, `${prefix}-02-target-state.png`),
+      fullPage: false,
+    })
 
-      // If Dec 2 is NOT disabled, that's the bug
-      if (isDisabled !== 'true' && !hasDisabledAttr) {
-        console.log('  BUG: Dec 2 is selectable but should be disabled')
-      }
+    // Assert the button is disabled
+    expect(
+      ariaDisabled === 'true' || isDisabledProp,
+      `${formatReadable(pastDate)} should be disabled in range picker (before min_date)`,
+    ).toBeTruthy()
 
-      // Try clicking and capture the result
-      await dec2Button.click({ force: true })
-      await page.waitForTimeout(500)
+    // Verify clicking doesn't change the trigger text
+    await pastDayBtn.click({ force: true })
+    await page.waitForTimeout(500)
 
-      await page.screenshot({
-        path: path.join(SCREENSHOT_DIR, `${prefix}-03-after-dec2-click.png`),
-        fullPage: false,
-      })
-    } else {
-      console.log(
-        '  Dec 2 button not found — may be properly hidden by fromDate',
-      )
-    }
+    const triggerTextAfter = await trigger.textContent()
+    console.log(
+      `  Trigger before: ${triggerTextBefore}, after: ${triggerTextAfter}`,
+    )
+
+    expect(
+      triggerTextAfter,
+      'Clicking disabled date should not change the date range',
+    ).toBe(triggerTextBefore)
+
+    await page.screenshot({
+      path: path.join(SCREENSHOT_DIR, `${prefix}-03-after-click.png`),
+      fullPage: false,
+    })
   })
 })

--- a/src/components/shared/DateRangePicker.tsx
+++ b/src/components/shared/DateRangePicker.tsx
@@ -136,6 +136,10 @@ export function DateRangePicker({
             selected={selected}
             onSelect={handleSelect}
             numberOfMonths={2}
+            disabled={[
+              { after: maxDate },
+              ...(minDate ? [{ before: minDate }] : []),
+            ]}
             fromDate={minDate}
             toDate={maxDate}
             startMonth={minDate}

--- a/src/pages/MapPage.tsx
+++ b/src/pages/MapPage.tsx
@@ -166,7 +166,10 @@ export function MapPage() {
                     setCalendarOpen(false)
                   }
                 }}
-                disabled={{ after: dataMaxDate }}
+                disabled={[
+                  { after: dataMaxDate },
+                  ...(dataMinDate ? [{ before: dataMinDate }] : []),
+                ]}
                 fromDate={dataMinDate}
                 toDate={dataMaxDate}
                 startMonth={dataMinDate}


### PR DESCRIPTION
## Summary

Fixes calendar date selection bugs where out-of-range dates within boundary months were clickable instead of disabled.

### Changes

**MapPage.tsx** — Added `{ before: dataMinDate }` to the `disabled` prop alongside the existing `{ after: dataMaxDate }` rule. Previously, dates before the data start (e.g. Dec 2) were clickable (though JS-clamped), now they render as visually disabled.

**DateRangePicker.tsx** — Added `disabled` prop with both `{ before: minDate }` and `{ after: maxDate }` matchers. Previously there was no `disabled` prop at all, so any day within boundary months (e.g. Apr 20, Dec 2) was fully selectable on the Locations page.

### Testing

- Added Playwright e2e test `e2e/calendar-date-selection-bounds.spec.ts` covering both Map and Locations pages for future and past out-of-range dates
- TypeScript type-check passes
- Production build succeeds