### PR TITLE
feat: Add date range filtering to Garmin Activities page

### DIFF
--- a/e2e/garmin-date-range-bounds.spec.ts
+++ b/e2e/garmin-date-range-bounds.spec.ts
@@ -1,0 +1,129 @@
+import { test, expect } from '@playwright/test'
+
+/** Resolve GraphQL endpoint: env var → runtime config → default. */
+async function resolveGraphqlUrl(page: import('@playwright/test').Page) {
+  if (process.env.GRAPHQL_URL) return process.env.GRAPHQL_URL
+  return page.evaluate(
+    () =>
+      (window as { __ENV__?: { GRAPHQL_URL?: string } }).__ENV__?.GRAPHQL_URL ??
+      'https://gateway.lab.informationcart.com',
+  )
+}
+
+/**
+ * Validates that the Garmin Activities page dynamically fetches date-range
+ * bounds from the API (via garminDateRange GraphQL query) and applies them
+ * to the DateRangePicker calendar component.
+ */
+test.describe('Garmin Date Range Bounds', () => {
+  test.setTimeout(60_000)
+
+  test('garminDateRange GraphQL query returns valid min/max dates', async ({
+    page,
+  }) => {
+    await page.goto('/garmin', { waitUntil: 'domcontentloaded' })
+    await expect(page.getByTestId('date-range-trigger')).toBeVisible({
+      timeout: 30_000,
+    })
+
+    const graphqlUrl = await resolveGraphqlUrl(page)
+
+    const dateRangeApiResponse = await page.request.post(graphqlUrl, {
+      headers: { 'Content-Type': 'application/json' },
+      data: {
+        query: `query { garminDateRange { min_date max_date } }`,
+      },
+    })
+    expect(dateRangeApiResponse.ok()).toBeTruthy()
+
+    const dateRangeResponse = await dateRangeApiResponse.json()
+
+    // Verify the response contains valid date fields
+    expect(dateRangeResponse.data).toBeDefined()
+    expect(dateRangeResponse.data.garminDateRange).toBeDefined()
+    expect(dateRangeResponse.data.garminDateRange.min_date).toBeTruthy()
+    expect(dateRangeResponse.data.garminDateRange.max_date).toBeTruthy()
+
+    // Verify dates are parseable
+    const minDate = new Date(dateRangeResponse.data.garminDateRange.min_date)
+    const maxDate = new Date(dateRangeResponse.data.garminDateRange.max_date)
+    expect(minDate.getTime()).not.toBeNaN()
+    expect(maxDate.getTime()).not.toBeNaN()
+    expect(minDate.getTime()).toBeLessThan(maxDate.getTime())
+  })
+
+  test('date picker shows "Select dates" by default and preset range updates URL', async ({
+    page,
+  }) => {
+    await page.goto('/garmin', { waitUntil: 'domcontentloaded' })
+    await expect(page.getByTestId('date-range-trigger')).toBeVisible({
+      timeout: 30_000,
+    })
+
+    const trigger = page.getByTestId('date-range-trigger')
+
+    // Without any date params, should show "Select dates"
+    await expect(trigger).toHaveText(/Select dates/)
+
+    // Open the date picker popover
+    await trigger.click()
+
+    // Click "Last 7 days" preset — use force to bypass popover animation
+    const preset = page.getByRole('button', { name: 'Last 7 days' })
+    await expect(preset).toBeVisible({ timeout: 5_000 })
+    await preset.click({ force: true })
+
+    // URL should now contain date_from and date_to params
+    await expect(page).toHaveURL(/[?&]date_from=/, { timeout: 10_000 })
+    await expect(page).toHaveURL(/[?&]date_to=/)
+
+    // Trigger text should show a date range (not "Select dates")
+    await expect(trigger).not.toHaveText(/Select dates/)
+
+    // Now clear the date filter
+    const clearBtn = page.getByRole('button', { name: 'Clear date range' })
+    await clearBtn.click()
+
+    // URL should no longer contain date params
+    await expect(page).not.toHaveURL(/[?&]date_from=/, { timeout: 5_000 })
+    await expect(page).not.toHaveURL(/[?&]date_to=/)
+
+    // Trigger should revert to "Select dates"
+    await expect(trigger).toHaveText(/Select dates/)
+  })
+
+  test('out-of-range date_from URL param is clamped to API min_date', async ({
+    page,
+  }) => {
+    await page.goto('/garmin', { waitUntil: 'domcontentloaded' })
+    await expect(page.getByTestId('date-range-trigger')).toBeVisible({
+      timeout: 30_000,
+    })
+
+    const graphqlUrl = await resolveGraphqlUrl(page)
+
+    const res = await page.request.post(graphqlUrl, {
+      data: {
+        query: `query { garminDateRange { min_date max_date } }`,
+      },
+    })
+    const dateRangeResponse = await res.json()
+    const minDate = new Date(dateRangeResponse.data.garminDateRange.min_date)
+
+    // Navigate with a date_from before the actual min_date
+    const earlyDate = new Date(minDate)
+    earlyDate.setFullYear(earlyDate.getFullYear() - 1)
+    const earlyStr = earlyDate.toISOString().slice(0, 10)
+
+    await page.goto(`/garmin?date_from=${earlyStr}`)
+    await expect(page.getByTestId('date-range-trigger')).toBeVisible({
+      timeout: 30_000,
+    })
+
+    // The date picker trigger should NOT show the early date year
+    const trigger = page.getByTestId('date-range-trigger')
+    await expect(trigger).not.toHaveText(
+      new RegExp(earlyDate.getFullYear().toString()),
+    )
+  })
+})

--- a/src/__generated__/graphql.ts
+++ b/src/__generated__/graphql.ts
@@ -168,6 +168,15 @@ export type GarminChartPoint = {
   timestamp: Scalars['DateTime']['output'];
 };
 
+/** Earliest and latest timestamps in the Garmin activities table. */
+export type GarminDateRange = {
+  __typename?: 'GarminDateRange';
+  /** Latest Garmin activity timestamp (ISO 8601) */
+  max_date: Scalars['DateTime']['output'];
+  /** Earliest Garmin activity timestamp (ISO 8601) */
+  min_date: Scalars['DateTime']['output'];
+};
+
 /** Result payload returned when triggering an on-demand Garmin sync. */
 export type GarminSyncTriggerResult = {
   __typename?: 'GarminSyncTriggerResult';
@@ -360,9 +369,9 @@ export type LocationCount = {
 export type LocationDateRange = {
   __typename?: 'LocationDateRange';
   /** Latest location timestamp (ISO 8601) */
-  max_date: Scalars['String']['output'];
+  max_date: Scalars['DateTime']['output'];
   /** Earliest location timestamp (ISO 8601) */
-  min_date: Scalars['String']['output'];
+  min_date: Scalars['DateTime']['output'];
 };
 
 /** Full location detail including the original OwnTracks JSON payload. */
@@ -464,6 +473,8 @@ export type Query = {
   garminActivity?: Maybe<GarminActivity>;
   /** Retrieve chart-optimised track points for a Garmin activity. */
   garminChartData: Array<GarminChartPoint>;
+  /** Get the earliest and latest Garmin activity timestamps. */
+  garminDateRange: GarminDateRange;
   /** List all distinct sport types with activity counts. */
   garminSports: Array<SportInfo>;
   /** Retrieve paginated GPS track points for a Garmin activity. */
@@ -725,6 +736,11 @@ export type GarminTrackPointsQueryVariables = Exact<{
 
 
 export type GarminTrackPointsQuery = { __typename?: 'Query', garminTrackPoints: { __typename?: 'GarminTrackPointConnection', total: number, limit: number, offset: number, items: Array<{ __typename?: 'GarminTrackPoint', id: number, activity_id: string, latitude: number, longitude: number, timestamp: string, altitude?: number | null, distance_from_start_km?: number | null, speed_kmh?: number | null, heart_rate?: number | null, cadence?: number | null, temperature_c?: number | null, created_at?: string | null }> } };
+
+export type GarminDateRangeQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+export type GarminDateRangeQuery = { __typename?: 'Query', garminDateRange: { __typename?: 'GarminDateRange', min_date: string, max_date: string } };
 
 export type GarminSportsQueryVariables = Exact<{ [key: string]: never; }>;
 
@@ -1096,6 +1112,49 @@ export type GarminTrackPointsQueryHookResult = ReturnType<typeof useGarminTrackP
 export type GarminTrackPointsLazyQueryHookResult = ReturnType<typeof useGarminTrackPointsLazyQuery>;
 export type GarminTrackPointsSuspenseQueryHookResult = ReturnType<typeof useGarminTrackPointsSuspenseQuery>;
 export type GarminTrackPointsQueryResult = ApolloReactCommon.QueryResult<GarminTrackPointsQuery, GarminTrackPointsQueryVariables>;
+export const GarminDateRangeDocument = gql`
+    query GarminDateRange {
+  garminDateRange {
+    min_date
+    max_date
+  }
+}
+    `;
+
+/**
+ * __useGarminDateRangeQuery__
+ *
+ * To run a query within a React component, call `useGarminDateRangeQuery` and pass it any options that fit your needs.
+ * When your component renders, `useGarminDateRangeQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useGarminDateRangeQuery({
+ *   variables: {
+ *   },
+ * });
+ */
+export function useGarminDateRangeQuery(baseOptions?: ApolloReactHooks.QueryHookOptions<GarminDateRangeQuery, GarminDateRangeQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return ApolloReactHooks.useQuery<GarminDateRangeQuery, GarminDateRangeQueryVariables>(GarminDateRangeDocument, options);
+      }
+export function useGarminDateRangeLazyQuery(baseOptions?: ApolloReactHooks.LazyQueryHookOptions<GarminDateRangeQuery, GarminDateRangeQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return ApolloReactHooks.useLazyQuery<GarminDateRangeQuery, GarminDateRangeQueryVariables>(GarminDateRangeDocument, options);
+        }
+// @ts-ignore
+export function useGarminDateRangeSuspenseQuery(baseOptions?: ApolloReactHooks.SuspenseQueryHookOptions<GarminDateRangeQuery, GarminDateRangeQueryVariables>): ApolloReactHooks.UseSuspenseQueryResult<GarminDateRangeQuery, GarminDateRangeQueryVariables>;
+export function useGarminDateRangeSuspenseQuery(baseOptions?: ApolloReactHooks.SkipToken | ApolloReactHooks.SuspenseQueryHookOptions<GarminDateRangeQuery, GarminDateRangeQueryVariables>): ApolloReactHooks.UseSuspenseQueryResult<GarminDateRangeQuery | undefined, GarminDateRangeQueryVariables>;
+export function useGarminDateRangeSuspenseQuery(baseOptions?: ApolloReactHooks.SkipToken | ApolloReactHooks.SuspenseQueryHookOptions<GarminDateRangeQuery, GarminDateRangeQueryVariables>) {
+          const options = baseOptions === ApolloReactHooks.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
+          return ApolloReactHooks.useSuspenseQuery<GarminDateRangeQuery, GarminDateRangeQueryVariables>(GarminDateRangeDocument, options);
+        }
+export type GarminDateRangeQueryHookResult = ReturnType<typeof useGarminDateRangeQuery>;
+export type GarminDateRangeLazyQueryHookResult = ReturnType<typeof useGarminDateRangeLazyQuery>;
+export type GarminDateRangeSuspenseQueryHookResult = ReturnType<typeof useGarminDateRangeSuspenseQuery>;
+export type GarminDateRangeQueryResult = ApolloReactCommon.QueryResult<GarminDateRangeQuery, GarminDateRangeQueryVariables>;
 export const GarminSportsDocument = gql`
     query GarminSports {
   garminSports {

--- a/src/graphql/garmin.ts
+++ b/src/graphql/garmin.ts
@@ -122,6 +122,15 @@ export const GARMIN_TRACK_POINTS_QUERY = gql`
   }
 `
 
+export const GARMIN_DATE_RANGE_QUERY = gql`
+  query GarminDateRange {
+    garminDateRange {
+      min_date
+      max_date
+    }
+  }
+`
+
 export const GARMIN_SPORTS_QUERY = gql`
   query GarminSports {
     garminSports {

--- a/src/lib/date-range.test.ts
+++ b/src/lib/date-range.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest'
+import { parseDateRangeParams, toLocalDate } from './date-range'
+
+describe('parseDateRangeParams', () => {
+  const bounds = {
+    minDate: new Date(2025, 0, 1),
+    maxDate: new Date(2026, 5, 1),
+  }
+
+  it('returns undefined when no params are provided', () => {
+    const result = parseDateRangeParams(null, null, bounds)
+    expect(result.dateFrom).toBeUndefined()
+    expect(result.dateTo).toBeUndefined()
+    expect(result.dateFromParam).toBeUndefined()
+    expect(result.dateToParam).toBeUndefined()
+  })
+
+  it('parses valid date strings within bounds', () => {
+    const result = parseDateRangeParams('2025-06-15', '2026-03-01', bounds)
+    expect(result.dateFromParam).toBe('2025-06-15')
+    expect(result.dateToParam).toBe('2026-03-01')
+  })
+
+  it('clamps dates before minDate to minDate', () => {
+    const result = parseDateRangeParams('2024-01-01', null, bounds)
+    expect(result.dateFromParam).toBe('2025-01-01')
+  })
+
+  it('clamps dates after maxDate to maxDate', () => {
+    const result = parseDateRangeParams('2027-01-01', null, bounds)
+    expect(result.dateFromParam).toBe('2026-06-01')
+  })
+
+  it('swaps from and to when from > to', () => {
+    const result = parseDateRangeParams('2026-03-15', '2025-06-01', bounds)
+    expect(result.dateFromParam).toBe('2025-06-01')
+    expect(result.dateToParam).toBe('2026-03-15')
+  })
+
+  it('ignores invalid date strings', () => {
+    const result = parseDateRangeParams('not-a-date', 'also-bad', bounds)
+    expect(result.dateFrom).toBeUndefined()
+    expect(result.dateTo).toBeUndefined()
+  })
+
+  it('works without minDate in bounds', () => {
+    const boundsNoMin = { maxDate: new Date(2026, 5, 1) }
+    const result = parseDateRangeParams('2020-01-01', null, boundsNoMin)
+    expect(result.dateFromParam).toBe('2020-01-01')
+  })
+
+  it('converts UTC ISO timestamp to local date via toLocalDate', () => {
+    const date = toLocalDate('2025-01-01T00:00:00Z')
+    expect(date.getFullYear()).toBe(2025)
+    expect(date.getMonth()).toBe(0)
+    expect(date.getDate()).toBe(1)
+  })
+})

--- a/src/lib/date-range.ts
+++ b/src/lib/date-range.ts
@@ -1,0 +1,71 @@
+import { parseISO, isValid, format } from 'date-fns'
+
+interface DateRangeBounds {
+  minDate?: Date
+  maxDate: Date
+}
+
+interface ParsedDateRange {
+  dateFrom: Date | undefined
+  dateTo: Date | undefined
+  dateFromParam: string | undefined
+  dateToParam: string | undefined
+}
+
+function clampDate(
+  date: Date | undefined,
+  min: Date | undefined,
+  max: Date,
+): Date | undefined {
+  if (!date) return undefined
+  if (min && date < min) return min
+  if (date > max) return max
+  return date
+}
+
+/**
+ * Convert a UTC ISO timestamp (e.g. "2025-01-01T00:00:00Z") to a local
+ * midnight Date for its date portion, avoiding timezone off-by-one issues
+ * where a UTC midnight timestamp maps to the prior local day.
+ */
+export function toLocalDate(isoTimestamp: string): Date {
+  return parseISO(isoTimestamp.substring(0, 10))
+}
+
+/**
+ * Parse, validate, and clamp date range URL parameters against API-provided
+ * bounds. Swaps from/to when from > to.
+ *
+ * Bounds should be created with toLocalDate() to avoid timezone off-by-one.
+ * Returns clamped Date values for the UI picker plus formatted yyyy-MM-dd
+ * strings suitable for query variables.
+ */
+export function parseDateRangeParams(
+  dateFromRaw: string | null,
+  dateToRaw: string | null,
+  bounds: DateRangeBounds,
+): ParsedDateRange {
+  const { minDate, maxDate } = bounds
+
+  const dateFromParsed = dateFromRaw ? parseISO(dateFromRaw) : undefined
+  const dateFromValid =
+    dateFromParsed && isValid(dateFromParsed) ? dateFromParsed : undefined
+
+  const dateToParsed = dateToRaw ? parseISO(dateToRaw) : undefined
+  const dateToValid =
+    dateToParsed && isValid(dateToParsed) ? dateToParsed : undefined
+
+  let dateFrom = clampDate(dateFromValid, minDate, maxDate)
+  let dateTo = clampDate(dateToValid, minDate, maxDate)
+
+  if (dateFrom && dateTo && dateFrom > dateTo) {
+    ;[dateFrom, dateTo] = [dateTo, dateFrom]
+  }
+
+  return {
+    dateFrom,
+    dateTo,
+    dateFromParam: dateFrom ? format(dateFrom, 'yyyy-MM-dd') : undefined,
+    dateToParam: dateTo ? format(dateTo, 'yyyy-MM-dd') : undefined,
+  }
+}

--- a/src/pages/GarminPage.test.tsx
+++ b/src/pages/GarminPage.test.tsx
@@ -49,8 +49,6 @@ describe('GarminPage', () => {
           sport?: string
           date_from?: string
           date_to?: string
-          date_from?: string
-          date_to?: string
           order: string
           sort: string
         }
@@ -108,8 +106,6 @@ describe('GarminPage', () => {
     expect(garminHooks.useGarminActivitiesQuery).toHaveBeenLastCalledWith({
       variables: {
         limit: 25,
-        date_from: undefined,
-        date_to: undefined,
         offset: 25,
         sport: 'cycling',
         date_from: undefined,

--- a/src/pages/GarminPage.test.tsx
+++ b/src/pages/GarminPage.test.tsx
@@ -47,6 +47,10 @@ describe('GarminPage', () => {
           limit: number
           offset: number
           sport?: string
+          date_from?: string
+          date_to?: string
+          date_from?: string
+          date_to?: string
           order: string
           sort: string
         }
@@ -104,8 +108,12 @@ describe('GarminPage', () => {
     expect(garminHooks.useGarminActivitiesQuery).toHaveBeenLastCalledWith({
       variables: {
         limit: 25,
+        date_from: undefined,
+        date_to: undefined,
         offset: 25,
         sport: 'cycling',
+        date_from: undefined,
+        date_to: undefined,
         order: 'desc',
         sort: 'start_time',
       },
@@ -132,6 +140,8 @@ describe('GarminPage', () => {
         limit: 25,
         offset: 0,
         sport: 'running',
+        date_from: undefined,
+        date_to: undefined,
         order: 'desc',
         sort: 'start_time',
       },

--- a/src/pages/GarminPage.test.tsx
+++ b/src/pages/GarminPage.test.tsx
@@ -8,6 +8,7 @@ import { renderWithRouter } from '@/test/renderWithRouter'
 const garminHooks = vi.hoisted(() => ({
   useGarminActivitiesQuery: vi.fn(),
   useGarminSportsQuery: vi.fn(),
+  useGarminDateRangeQuery: vi.fn(),
 }))
 
 vi.mock('@/__generated__/graphql', () => garminHooks)
@@ -18,6 +19,16 @@ describe('GarminPage', () => {
   beforeEach(() => {
     garminHooks.useGarminActivitiesQuery.mockReset()
     garminHooks.useGarminSportsQuery.mockReset()
+    garminHooks.useGarminDateRangeQuery.mockReset()
+
+    garminHooks.useGarminDateRangeQuery.mockReturnValue({
+      data: {
+        garminDateRange: {
+          min_date: '2025-01-01T00:00:00Z',
+          max_date: '2026-06-01T00:00:00Z',
+        },
+      },
+    })
 
     garminHooks.useGarminSportsQuery.mockReturnValue({
       data: {

--- a/src/pages/GarminPage.tsx
+++ b/src/pages/GarminPage.tsx
@@ -20,7 +20,8 @@ import {
 } from '@/components/ui/table'
 import { ChevronLeft, ChevronRight } from 'lucide-react'
 import { setNRCustomAttribute } from '@/lib/newrelic-browser'
-import { parseISO, isValid, format as formatDate } from 'date-fns'
+import { parseDateRangeParams, toLocalDate } from '@/lib/date-range'
+import { format as formatDate } from 'date-fns'
 
 const PAGE_SIZE = 25
 
@@ -45,31 +46,20 @@ export function GarminPage() {
   const dateToParam = searchParams.get('date_to')
   const { data: dateRangeData } = useGarminDateRangeQuery()
   const DATA_MIN_DATE = dateRangeData?.garminDateRange?.min_date
-    ? new Date(dateRangeData.garminDateRange.min_date)
+    ? toLocalDate(dateRangeData.garminDateRange.min_date)
     : undefined
   const DATA_MAX_DATE = dateRangeData?.garminDateRange?.max_date
-    ? new Date(dateRangeData.garminDateRange.max_date)
+    ? toLocalDate(dateRangeData.garminDateRange.max_date)
     : new Date()
-  const dateFromParsed = dateFromParam ? parseISO(dateFromParam) : undefined
-  const dateFromValid =
-    dateFromParsed && isValid(dateFromParsed) ? dateFromParsed : undefined
-  const dateFrom = dateFromValid
-    ? DATA_MIN_DATE && dateFromValid < DATA_MIN_DATE
-      ? DATA_MIN_DATE
-      : dateFromValid > DATA_MAX_DATE
-        ? DATA_MAX_DATE
-        : dateFromValid
-    : undefined
-  const dateToParsed = dateToParam ? parseISO(dateToParam) : undefined
-  const dateToValid =
-    dateToParsed && isValid(dateToParsed) ? dateToParsed : undefined
-  const dateTo = dateToValid
-    ? DATA_MIN_DATE && dateToValid < DATA_MIN_DATE
-      ? DATA_MIN_DATE
-      : dateToValid > DATA_MAX_DATE
-        ? DATA_MAX_DATE
-        : dateToValid
-    : undefined
+  const {
+    dateFrom,
+    dateTo,
+    dateFromParam: dateFromStr,
+    dateToParam: dateToStr,
+  } = parseDateRangeParams(dateFromParam, dateToParam, {
+    minDate: DATA_MIN_DATE,
+    maxDate: DATA_MAX_DATE,
+  })
   const offset = (page - 1) * PAGE_SIZE
 
   const { data: sportsData } = useGarminSportsQuery()
@@ -78,8 +68,8 @@ export function GarminPage() {
       limit: PAGE_SIZE,
       offset,
       sport: sportFilter,
-      date_from: dateFromParam || undefined,
-      date_to: dateToParam || undefined,
+      date_from: dateFromStr,
+      date_to: dateToStr,
       order: 'desc',
       sort: 'start_time',
     },

--- a/src/pages/GarminPage.tsx
+++ b/src/pages/GarminPage.tsx
@@ -1,11 +1,13 @@
 import {
   useGarminActivitiesQuery,
   useGarminSportsQuery,
+  useGarminDateRangeQuery,
 } from '@/__generated__/graphql'
 import { Link, useSearchParams } from 'react-router-dom'
 import { useEffect } from 'react'
 import { LoadingState } from '@/components/shared/LoadingState'
 import { ErrorState } from '@/components/shared/ErrorState'
+import { DateRangePicker } from '@/components/shared/DateRangePicker'
 import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
 import {
@@ -18,6 +20,7 @@ import {
 } from '@/components/ui/table'
 import { ChevronLeft, ChevronRight } from 'lucide-react'
 import { setNRCustomAttribute } from '@/lib/newrelic-browser'
+import { parseISO, isValid, format as formatDate } from 'date-fns'
 
 const PAGE_SIZE = 25
 
@@ -38,6 +41,35 @@ export function GarminPage() {
     setNRCustomAttribute('garmin.flow', true)
   }, [])
   const sportFilter = searchParams.get('sport') || undefined
+  const dateFromParam = searchParams.get('date_from')
+  const dateToParam = searchParams.get('date_to')
+  const { data: dateRangeData } = useGarminDateRangeQuery()
+  const DATA_MIN_DATE = dateRangeData?.garminDateRange?.min_date
+    ? new Date(dateRangeData.garminDateRange.min_date)
+    : undefined
+  const DATA_MAX_DATE = dateRangeData?.garminDateRange?.max_date
+    ? new Date(dateRangeData.garminDateRange.max_date)
+    : new Date()
+  const dateFromParsed = dateFromParam ? parseISO(dateFromParam) : undefined
+  const dateFromValid =
+    dateFromParsed && isValid(dateFromParsed) ? dateFromParsed : undefined
+  const dateFrom = dateFromValid
+    ? DATA_MIN_DATE && dateFromValid < DATA_MIN_DATE
+      ? DATA_MIN_DATE
+      : dateFromValid > DATA_MAX_DATE
+        ? DATA_MAX_DATE
+        : dateFromValid
+    : undefined
+  const dateToParsed = dateToParam ? parseISO(dateToParam) : undefined
+  const dateToValid =
+    dateToParsed && isValid(dateToParsed) ? dateToParsed : undefined
+  const dateTo = dateToValid
+    ? DATA_MIN_DATE && dateToValid < DATA_MIN_DATE
+      ? DATA_MIN_DATE
+      : dateToValid > DATA_MAX_DATE
+        ? DATA_MAX_DATE
+        : dateToValid
+    : undefined
   const offset = (page - 1) * PAGE_SIZE
 
   const { data: sportsData } = useGarminSportsQuery()
@@ -46,6 +78,8 @@ export function GarminPage() {
       limit: PAGE_SIZE,
       offset,
       sport: sportFilter,
+      date_from: dateFromParam || undefined,
+      date_to: dateToParam || undefined,
       order: 'desc',
       sort: 'start_time',
     },
@@ -68,11 +102,16 @@ export function GarminPage() {
       </div>
 
       {/* Sport filter */}
-      <div className="flex flex-wrap gap-2">
+      <div className="flex flex-wrap items-center gap-2">
         <Button
           variant={!sportFilter ? 'default' : 'outline'}
           size="sm"
-          onClick={() => setSearchParams({})}
+          onClick={() => {
+            const params = new URLSearchParams(searchParams)
+            params.delete('sport')
+            params.delete('page')
+            setSearchParams(params)
+          }}
         >
           All
         </Button>
@@ -82,7 +121,12 @@ export function GarminPage() {
               key={s.sport}
               variant={sportFilter === s.sport ? 'default' : 'outline'}
               size="sm"
-              onClick={() => setSearchParams({ sport: s.sport })}
+              onClick={() => {
+                const params = new URLSearchParams(searchParams)
+                params.set('sport', s.sport)
+                params.delete('page')
+                setSearchParams(params)
+              }}
             >
               <span className="capitalize">{s.sport}</span>
               <Badge variant="secondary" className="ml-1">
@@ -91,6 +135,24 @@ export function GarminPage() {
             </Button>
           ),
         )}
+
+        <div className="ml-auto">
+          <DateRangePicker
+            dateFrom={dateFrom}
+            dateTo={dateTo}
+            minDate={DATA_MIN_DATE}
+            maxDate={DATA_MAX_DATE}
+            onRangeChange={(from, to) => {
+              const params = new URLSearchParams(searchParams)
+              if (from) params.set('date_from', formatDate(from, 'yyyy-MM-dd'))
+              else params.delete('date_from')
+              if (to) params.set('date_to', formatDate(to, 'yyyy-MM-dd'))
+              else params.delete('date_to')
+              params.delete('page')
+              setSearchParams(params)
+            }}
+          />
+        </div>
       </div>
 
       {/* Table */}

--- a/src/pages/LocationsPage.tsx
+++ b/src/pages/LocationsPage.tsx
@@ -18,7 +18,8 @@ import {
 } from '@/components/ui/table'
 import { ChevronLeft, ChevronRight } from 'lucide-react'
 import { Link, useSearchParams } from 'react-router-dom'
-import { parseISO, isValid, format as formatDate } from 'date-fns'
+import { parseDateRangeParams, toLocalDate } from '@/lib/date-range'
+import { format as formatDate } from 'date-fns'
 
 const PAGE_SIZE = 25
 
@@ -31,31 +32,20 @@ export function LocationsPage() {
   const dateToParam = searchParams.get('date_to')
   const { data: dateRangeData } = useLocationDateRangeQuery()
   const DATA_MIN_DATE = dateRangeData?.locationDateRange?.min_date
-    ? new Date(dateRangeData.locationDateRange.min_date)
+    ? toLocalDate(dateRangeData.locationDateRange.min_date)
     : undefined
   const DATA_MAX_DATE = dateRangeData?.locationDateRange?.max_date
-    ? new Date(dateRangeData.locationDateRange.max_date)
+    ? toLocalDate(dateRangeData.locationDateRange.max_date)
     : new Date()
-  const dateFromParsed = dateFromParam ? parseISO(dateFromParam) : undefined
-  const dateFromValid =
-    dateFromParsed && isValid(dateFromParsed) ? dateFromParsed : undefined
-  const dateFrom = dateFromValid
-    ? DATA_MIN_DATE && dateFromValid < DATA_MIN_DATE
-      ? DATA_MIN_DATE
-      : dateFromValid > DATA_MAX_DATE
-        ? DATA_MAX_DATE
-        : dateFromValid
-    : undefined
-  const dateToParsed = dateToParam ? parseISO(dateToParam) : undefined
-  const dateToValid =
-    dateToParsed && isValid(dateToParsed) ? dateToParsed : undefined
-  const dateTo = dateToValid
-    ? DATA_MIN_DATE && dateToValid < DATA_MIN_DATE
-      ? DATA_MIN_DATE
-      : dateToValid > DATA_MAX_DATE
-        ? DATA_MAX_DATE
-        : dateToValid
-    : undefined
+  const {
+    dateFrom,
+    dateTo,
+    dateFromParam: dateFromStr,
+    dateToParam: dateToStr,
+  } = parseDateRangeParams(dateFromParam, dateToParam, {
+    minDate: DATA_MIN_DATE,
+    maxDate: DATA_MAX_DATE,
+  })
   const offset = (page - 1) * PAGE_SIZE
 
   const { data: devicesData } = useDevicesQuery()
@@ -64,8 +54,8 @@ export function LocationsPage() {
       limit: PAGE_SIZE,
       offset,
       device_id: deviceFilter,
-      date_from: dateFromParam || undefined,
-      date_to: dateToParam || undefined,
+      date_from: dateFromStr,
+      date_to: dateToStr,
       order: 'desc',
       sort: 'timestamp',
     },


### PR DESCRIPTION
## Summary

Add date range filtering to the Garmin Activities page using the `DateRangePicker` component with calendar date bounds from the `garminDateRange` GraphQL query.

## Changes

- **`src/graphql/garmin.ts`** — Add `GARMIN_DATE_RANGE_QUERY` GraphQL query
- **`src/pages/GarminPage.tsx`** — Integrate `DateRangePicker` with `date_from`/`date_to` URL params, date clamping, and query variable filtering
- **`src/pages/GarminPage.test.tsx`** — Add `useGarminDateRangeQuery` mock to existing tests
- **`src/__generated__/graphql.ts`** — Regenerated codegen types
- **`e2e/garmin-date-range-bounds.spec.ts`** — Add 3 Playwright e2e tests for date range bounds validation

## Context

This mirrors the existing location date range filtering (#59) but for the Garmin Activities page. Depends on:
- otel-data-api: stuartshay/otel-data-api#84
- otel-data-gateway: stuartshay/otel-data-gateway#53