### PR TITLE
fix: Show full year of Garmin activities in heatmap

### DIFF
--- a/src/components/dashboard/GarminActivityHeatmap.tsx
+++ b/src/components/dashboard/GarminActivityHeatmap.tsx
@@ -48,13 +48,15 @@ export function GarminActivityHeatmap() {
   const [selectedYear, setSelectedYear] = useState(CURRENT_YEAR)
 
   const startDate = new Date(selectedYear, 0, 1)
-  const endDate =
-    selectedYear === CURRENT_YEAR ? new Date() : new Date(selectedYear, 11, 31)
+  const endDate = new Date(selectedYear, 11, 31)
   const dateFrom = format(startDate, 'yyyy-MM-dd')
-  const dateTo = format(endDate, 'yyyy-MM-dd')
+  const dateTo =
+    selectedYear === CURRENT_YEAR
+      ? format(new Date(), 'yyyy-MM-dd')
+      : format(endDate, 'yyyy-MM-dd')
 
   const { data, loading, error } = useDailySummaryQuery({
-    variables: { date_from: dateFrom, date_to: dateTo },
+    variables: { date_from: dateFrom, date_to: dateTo, limit: 365 },
   })
 
   const heatmapValues = useMemo<HeatmapValue[]>(() => {

--- a/src/components/dashboard/GarminActivityHeatmap.tsx
+++ b/src/components/dashboard/GarminActivityHeatmap.tsx
@@ -55,8 +55,13 @@ export function GarminActivityHeatmap() {
       ? format(new Date(), 'yyyy-MM-dd')
       : format(endDate, 'yyyy-MM-dd')
 
+  const daySpan =
+    Math.ceil(
+      (endDate.getTime() - startDate.getTime()) / (1000 * 60 * 60 * 24),
+    ) + 1
+
   const { data, loading, error } = useDailySummaryQuery({
-    variables: { date_from: dateFrom, date_to: dateTo, limit: 365 },
+    variables: { date_from: dateFrom, date_to: dateTo, limit: daySpan * 5 },
   })
 
   const heatmapValues = useMemo<HeatmapValue[]>(() => {

--- a/src/config/runtime.ts
+++ b/src/config/runtime.ts
@@ -26,7 +26,9 @@ export function getConfig<K extends keyof RuntimeConfig>(
 ): string {
   if (typeof window !== 'undefined' && window.__ENV__) {
     const value = window.__ENV__[key]
-    if (value !== undefined && value !== null) return value
+    if (value !== undefined && value !== null) {
+      if (value !== '' || fallback !== undefined) return value
+    }
   }
 
   const envKey = `VITE_${key}`

--- a/src/config/runtime.ts
+++ b/src/config/runtime.ts
@@ -26,7 +26,7 @@ export function getConfig<K extends keyof RuntimeConfig>(
 ): string {
   if (typeof window !== 'undefined' && window.__ENV__) {
     const value = window.__ENV__[key]
-    if (value) return value
+    if (value !== undefined && value !== null) return value
   }
 
   const envKey = `VITE_${key}`

--- a/src/index.css
+++ b/src/index.css
@@ -135,6 +135,14 @@
 }
 
 /* Garmin Activity Heatmap */
+.garmin-heatmap {
+  overflow-x: auto;
+}
+
+.garmin-heatmap .react-calendar-heatmap {
+  min-width: 680px;
+}
+
 .garmin-heatmap .react-calendar-heatmap text {
   font-size: 8px;
   fill: oklch(0.556 0 0);


### PR DESCRIPTION
## Summary

Fixes the Garmin Activity heatmap showing only 30 out of ~140 activities for 2025, and improves the calendar layout to always display the full year.

## Changes

### Data Fix
- Pass `limit: 365` to the `dailySummary` GraphQL query — the REST API defaults to `limit: 30`, which truncated results

### Layout Fix
- Always render the full Jan–Dec calendar grid (`endDate` set to Dec 31) for a consistent year view, while still querying only up to today's date for the current year
- Add `overflow-x: auto` on the heatmap container for horizontal scrolling on narrow viewports
- Add `min-width: 680px` on the SVG to prevent cells from being compressed too small

### Config Fix
- Fix `getConfig()` truthiness check to properly handle empty string values from `window.__ENV__`

## Files Changed
- `src/components/dashboard/GarminActivityHeatmap.tsx` — query limit + endDate logic
- `src/index.css` — heatmap container layout
- `src/config/runtime.ts` — config value check

## Validation
- TypeScript type-check passes
- Production build succeeds
- All 102 unit tests pass