### PR TITLE
fix: Cap heatmap daily summary limit to 365

### DIFF
--- a/src/components/dashboard/GarminActivityHeatmap.tsx
+++ b/src/components/dashboard/GarminActivityHeatmap.tsx
@@ -55,13 +55,8 @@ export function GarminActivityHeatmap() {
       ? format(new Date(), 'yyyy-MM-dd')
       : format(endDate, 'yyyy-MM-dd')
 
-  const daySpan =
-    Math.ceil(
-      (endDate.getTime() - startDate.getTime()) / (1000 * 60 * 60 * 24),
-    ) + 1
-
   const { data, loading, error } = useDailySummaryQuery({
-    variables: { date_from: dateFrom, date_to: dateTo, limit: daySpan * 5 },
+    variables: { date_from: dateFrom, date_to: dateTo, limit: 365 },
   })
 
   const heatmapValues = useMemo<HeatmapValue[]>(() => {


### PR DESCRIPTION
## Summary

Fix "Failed to load activity data" error in the Garmin Activity heatmap when viewing any year.

## Problem

PR #62 changed `limit: 30` → `limit: daySpan * 5`, which computes to ~1825 for a full-year query. The REST API enforces `limit ≤ 365` validation, causing a **422 Unprocessable Content** error and rendering "Failed to load activity data" / "0 activities over 0 days".

## Fix

Replace `daySpan * 5` with the API maximum of `365`, which covers all daily summaries for any year range. The `daySpan` calculation is no longer needed and has been removed.

## Validation

- All 5 Playwright e2e heatmap tests pass (`BASE_URL=http://localhost:5173`)
- TypeScript type-check passes
- Unit tests pass
- Production build succeeds

Refs #62