### PR TITLE
chore: Fix lint warnings and enforce zero-warning commits

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -23,7 +23,13 @@ export default defineConfig([
       '@typescript-eslint/no-explicit-any': 'warn',
       'react-refresh/only-export-components': [
         'warn',
-        { allowExportNames: ['badgeVariants', 'buttonVariants'] },
+        {
+          allowExportNames: [
+            'badgeVariants',
+            'buttonVariants',
+            'tabsListVariants',
+          ],
+        },
       ],
     },
   },

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
   },
   "lint-staged": {
     "*.{ts,tsx}": [
-      "eslint --fix",
+      "eslint --fix --max-warnings 0",
       "prettier --write"
     ],
     "*.{ts,tsx,js,md,yml,yaml,sh,html}": [

--- a/src/components/dashboard/GarminActivityHeatmap.tsx
+++ b/src/components/dashboard/GarminActivityHeatmap.tsx
@@ -98,7 +98,7 @@ export function GarminActivityHeatmap() {
             value={String(selectedYear)}
             onValueChange={(v) => setSelectedYear(Number(v))}
           >
-            <SelectTrigger className="h-7 w-[80px] text-xs">
+            <SelectTrigger className="h-7 w-20 text-xs">
               <SelectValue />
             </SelectTrigger>
             <SelectContent>

--- a/src/pages/LocationsPage.tsx
+++ b/src/pages/LocationsPage.tsx
@@ -165,7 +165,7 @@ export function LocationsPage() {
                   {loc.accuracy != null ? `${loc.accuracy.toFixed(0)}m` : '—'}
                 </TableCell>
                 <TableCell
-                  className="max-w-[200px] truncate text-xs"
+                  className="max-w-50 truncate text-xs"
                   title={loc.display_address ?? undefined}
                 >
                   {loc.display_address ?? '—'}

--- a/src/pages/MapPage.tsx
+++ b/src/pages/MapPage.tsx
@@ -25,12 +25,20 @@ export function MapPage() {
   const [calendarOpen, setCalendarOpen] = useState(false)
 
   const { data: dateRangeData } = useLocationDateRangeQuery()
-  const dataMinDate = dateRangeData?.locationDateRange?.min_date
-    ? new Date(dateRangeData.locationDateRange.min_date)
-    : undefined
-  const dataMaxDate = dateRangeData?.locationDateRange?.max_date
-    ? new Date(dateRangeData.locationDateRange.max_date)
-    : new Date()
+  const dataMinDate = useMemo(
+    () =>
+      dateRangeData?.locationDateRange?.min_date
+        ? new Date(dateRangeData.locationDateRange.min_date)
+        : undefined,
+    [dateRangeData],
+  )
+  const dataMaxDate = useMemo(
+    () =>
+      dateRangeData?.locationDateRange?.max_date
+        ? new Date(dateRangeData.locationDateRange.max_date)
+        : new Date(),
+    [dateRangeData],
+  )
 
   // Clamp selectedDate into [dataMinDate, dataMaxDate] when date-range data loads
   const clampedDate = useMemo(() => {


### PR DESCRIPTION
## Summary

- Fix 3 ESLint warnings across `tabs.tsx`, `MapPage.tsx`
- Replace Tailwind arbitrary values with canonical utility classes (`w-20`, `max-w-50`)
- Enforce zero-warning commits via `--max-warnings 0` in lint-staged

## Changes

| File | Change |
|------|--------|
| `eslint.config.js` | Add `tabsListVariants` to `allowExportNames` |
| `src/pages/MapPage.tsx` | Wrap `dataMinDate`/`dataMaxDate` in `useMemo` (exhaustive-deps) |
| `src/components/dashboard/GarminActivityHeatmap.tsx` | `w-[80px]` → `w-20` |
| `src/pages/LocationsPage.tsx` | `max-w-[200px]` → `max-w-50` |
| `package.json` | lint-staged: `eslint --fix --max-warnings 0` |

## Validation

- `npm run lint` — 0 warnings ✅
- `npm run type-check` — clean ✅
- `npm run test:run` — 102 tests pass ✅
- `npm run build` — succeeds ✅