### PR TITLE
fix(map): initialize Leaflet via callback ref so map renders on first load

### DIFF
--- a/e2e/map-first-load.spec.ts
+++ b/e2e/map-first-load.spec.ts
@@ -19,6 +19,13 @@ test.describe('Unified Map first-load rendering', () => {
     const heading = page.getByRole('heading', { name: 'Unified Map' })
     await heading.waitFor({ timeout: 15_000 })
 
+    // Wait for the GraphQL query to resolve — the map div is only mounted
+    // after the loading state unmounts, so the leaflet container cannot
+    // exist until the point-count summary renders.
+    await expect(page.getByText(/[\d,]+ of [\d,]+ points/)).toBeVisible({
+      timeout: 20_000,
+    })
+
     const mapContainer = page.getByTestId('unified-map-container')
     await expect(mapContainer).toBeVisible()
 
@@ -28,13 +35,15 @@ test.describe('Unified Map first-load rendering', () => {
     expect(box!.width).toBeGreaterThan(100)
     expect(box!.height).toBeGreaterThan(100)
 
-    // Leaflet injects a .leaflet-container once the map is initialized.
-    const leafletContainer = mapContainer.locator('.leaflet-container')
-    await expect(leafletContainer).toBeVisible({ timeout: 10_000 })
+    // Leaflet adds the .leaflet-container class to the container element itself
+    // (the div we passed to L.map()), not as a descendant.
+    await expect(mapContainer).toHaveClass(/leaflet-container/, {
+      timeout: 20_000,
+    })
 
     // Tile images must be loaded inside the tile pane. This is what was
     // missing on first load before the invalidateSize() fix.
-    const tileImages = leafletContainer.locator(
+    const tileImages = mapContainer.locator(
       '.leaflet-tile-pane img.leaflet-tile',
     )
     await expect(tileImages.first()).toBeVisible({ timeout: 15_000 })
@@ -43,7 +52,7 @@ test.describe('Unified Map first-load rendering', () => {
 
     // At least one tile should be fully loaded (class "leaflet-tile-loaded").
     await expect(
-      leafletContainer
+      mapContainer
         .locator('.leaflet-tile-pane img.leaflet-tile-loaded')
         .first(),
     ).toBeVisible({ timeout: 20_000 })

--- a/src/pages/MapPage.tsx
+++ b/src/pages/MapPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { format } from 'date-fns'
 import { CalendarIcon } from 'lucide-react'
 import {
@@ -19,8 +19,8 @@ import L from 'leaflet'
 import 'leaflet/dist/leaflet.css'
 
 export function MapPage() {
-  const mapRef = useRef<HTMLDivElement>(null)
   const mapInstanceRef = useRef<L.Map | null>(null)
+  const cleanupRef = useRef<(() => void) | null>(null)
   const [selectedDate, setSelectedDate] = useState<Date>(new Date())
   const [calendarOpen, setCalendarOpen] = useState(false)
 
@@ -62,10 +62,22 @@ export function MapPage() {
     },
   })
 
-  useEffect(() => {
-    if (!mapRef.current || mapInstanceRef.current) return
+  // Callback ref initializes Leaflet as soon as the map div is attached to the
+  // DOM. Using a callback ref (instead of useEffect + useRef) is critical:
+  // MapPage returns <LoadingState /> on the first render while data is
+  // fetching, so a mount-time useEffect with [] deps would fire once with a
+  // null ref and never re-run when the real <div> finally mounts — leaving
+  // the map permanently uninitialized on first load.
+  const mapContainerRef = useCallback((container: HTMLDivElement | null) => {
+    // Tear down any previous instance (StrictMode double-mount, or ref
+    // detach on unmount).
+    if (cleanupRef.current) {
+      cleanupRef.current()
+      cleanupRef.current = null
+    }
 
-    const container = mapRef.current
+    if (!container) return
+
     const map = L.map(container).setView([40.736, -74.039], 12)
     mapInstanceRef.current = map
 
@@ -74,19 +86,14 @@ export function MapPage() {
     }).addTo(map)
 
     // Leaflet computes tile layout from the container's size at init time.
-    // On the first visit the container may not yet have its final dimensions
-    // (parent layout still settling after the LoadingState unmount), which
-    // leaves the map blank until a resize/navigation forces a redraw.
     // Force a size recalculation once layout is stable and whenever the
-    // container resizes.
+    // container resizes, so tiles render on first paint.
     let disposed = false
     const invalidate = () => {
       if (disposed) return
       map.invalidateSize()
     }
     // Double rAF ensures layout/styles have been applied before measuring.
-    // Track both handles so cleanup can cancel either callback if the
-    // component unmounts between the two frames.
     let innerRafId = 0
     const outerRafId = requestAnimationFrame(() => {
       innerRafId = requestAnimationFrame(invalidate)
@@ -98,13 +105,23 @@ export function MapPage() {
       resizeObserver.observe(container)
     }
 
-    return () => {
+    cleanupRef.current = () => {
       disposed = true
       cancelAnimationFrame(outerRafId)
       cancelAnimationFrame(innerRafId)
       resizeObserver?.disconnect()
       map.remove()
       mapInstanceRef.current = null
+    }
+  }, [])
+
+  // Ensure the map is cleaned up if MapPage itself unmounts.
+  useEffect(() => {
+    return () => {
+      if (cleanupRef.current) {
+        cleanupRef.current()
+        cleanupRef.current = null
+      }
     }
   }, [])
 
@@ -222,7 +239,7 @@ export function MapPage() {
       </div>
 
       <div
-        ref={mapRef}
+        ref={mapContainerRef}
         data-testid="unified-map-container"
         className="relative z-0 h-[calc(100vh-14rem)] w-full rounded-lg border"
       />


### PR DESCRIPTION
## Summary

Follow-up to #70. Version 1.0.181 shipped an `invalidateSize()` / `ResizeObserver` patch, but end-to-end validation against the deployed cluster (https://data-ui.lab.informationcart.com) proved the bug was **not** fixed — the map still never rendered on first direct navigation to `/map`. The prior validation comment on #70 was incorrect and is being superseded.

## Root cause

`MapPage` returns `<LoadingState />` while the initial GraphQL query resolves. The mount effect (`useEffect(..., [])`) fired on the first render **before** the map `<div>` existed, so `mapRef.current` was `null` and the effect early-returned. With empty deps the effect never re-ran after the div finally mounted, so `L.map()` was never called. Navigating away and back appeared to work only because cached data let the div render in the first pass.

## Fix

Replace the `useRef` + mount `useEffect` pattern with a **callback ref**. React invokes callback refs the moment the DOM node attaches (after `LoadingState` unmounts) and with `null` on detach, so Leaflet initialization runs exactly when the container is available. Teardown is stored in a `cleanupRef` so both ref-detach and full component-unmount paths dispose the map correctly. The `requestAnimationFrame` + `ResizeObserver` logic from 1.0.181 is retained inside the new init flow.

## Test fix

The regression spec had a second latent bug: Leaflet applies `.leaflet-container` to the element passed to `L.map()`, not as a descendant. `getByTestId('unified-map-container').locator('.leaflet-container')` therefore found zero elements even when the map rendered visually. Updated to use `toHaveClass(/leaflet-container/)` on the test-id element itself and to wait for the point-count summary before asserting.

## Validation

Local against the production gateway (`http://localhost:5174` to `https://gateway.lab.informationcart.com`):

- `npm run type-check` — PASS
- `npm run lint` — PASS
- `npm run test:run` — 107/107 unit tests PASS
- `BASE_URL=http://localhost:5174 npx playwright test e2e/map-first-load.spec.ts`:
  - `map renders tiles on direct navigation to /map` — PASS
  - `map renders data point markers on first load` — skipped (no data for current date window; skip is correct by design)
  - `map remains rendered after navigating away and back` — PASS

Cluster validation will follow after this merges, Docker builds, and Argo CD syncs the new version. Issue #70 will be reopened and closed manually only after that live validation.

Refs #70
