### PR TITLE
chore(renovate): bundle dependency updates into consolidated groups

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -10,7 +10,7 @@
   "packageRules": [
     {
       "description": "Disable Renovate for stuartshay packages (managed by update-types.yml)",
-      "matchPackagePatterns": ["^@stuartshay/"],
+      "matchPackageNames": ["/^@stuartshay//"],
       "enabled": false
     },
     {
@@ -21,25 +21,48 @@
       "automergeType": "pr"
     },
     {
-      "description": "Group React ecosystem",
+      "description": "Group React ecosystem (majors stay bundled with minors)",
       "matchPackageNames": [
         "react",
         "react-dom",
         "@types/react",
-        "@types/react-dom"
+        "@types/react-dom",
+        "react-router-dom",
+        "react-day-picker",
+        "react-calendar-heatmap",
+        "@types/react-calendar-heatmap"
       ],
       "groupName": "react",
-      "groupSlug": "react"
+      "groupSlug": "react",
+      "separateMajorMinor": false
+    },
+    {
+      "description": "Group Radix UI primitives",
+      "matchPackageNames": ["/^@radix-ui//", "radix-ui"],
+      "groupName": "radix-ui",
+      "groupSlug": "radix-ui",
+      "separateMajorMinor": false
     },
     {
       "description": "Group Tailwind CSS ecosystem",
       "matchPackageNames": [
         "tailwindcss",
         "@tailwindcss/vite",
-        "tailwind-merge"
+        "tailwind-merge",
+        "tw-animate-css",
+        "class-variance-authority",
+        "clsx"
       ],
       "groupName": "tailwindcss",
-      "groupSlug": "tailwindcss"
+      "groupSlug": "tailwindcss",
+      "separateMajorMinor": false
+    },
+    {
+      "description": "Group Vite build toolchain",
+      "matchPackageNames": ["vite", "@vitejs/plugin-react"],
+      "groupName": "vite-build",
+      "groupSlug": "vite-build",
+      "separateMajorMinor": false
     },
     {
       "description": "Group ESLint ecosystem",
@@ -48,47 +71,55 @@
         "@eslint/js",
         "typescript-eslint",
         "eslint-plugin-react-hooks",
-        "eslint-plugin-react-refresh"
+        "eslint-plugin-react-refresh",
+        "globals"
       ],
       "groupName": "eslint",
-      "groupSlug": "eslint"
+      "groupSlug": "eslint",
+      "separateMajorMinor": false
     },
     {
-      "description": "Group formatting tools",
+      "description": "Group formatting and linting tools",
       "matchPackageNames": [
         "prettier",
         "markdownlint-cli2",
         "husky",
         "lint-staged",
-        "cspell"
+        "cspell",
+        "shadcn"
       ],
       "groupName": "formatting-tools",
-      "groupSlug": "formatting-tools"
+      "groupSlug": "formatting-tools",
+      "separateMajorMinor": false
     },
     {
       "description": "Group Apollo GraphQL",
       "matchPackageNames": ["@apollo/client", "graphql"],
       "groupName": "apollo-graphql",
-      "groupSlug": "apollo-graphql"
+      "groupSlug": "apollo-graphql",
+      "separateMajorMinor": false
     },
     {
       "description": "Group Leaflet mapping",
       "matchPackageNames": ["leaflet", "react-leaflet", "@types/leaflet"],
       "groupName": "leaflet",
-      "groupSlug": "leaflet"
+      "groupSlug": "leaflet",
+      "separateMajorMinor": false
     },
     {
-      "description": "Group Vitest and testing tools",
+      "description": "Group testing tools (Vitest + Playwright + Testing Library)",
       "matchPackageNames": [
         "vitest",
         "@vitest/coverage-v8",
         "@testing-library/react",
         "@testing-library/jest-dom",
         "@testing-library/user-event",
-        "jsdom"
+        "jsdom",
+        "@playwright/test"
       ],
-      "groupName": "vitest-testing",
-      "groupSlug": "vitest-testing"
+      "groupName": "testing",
+      "groupSlug": "testing",
+      "separateMajorMinor": false
     },
     {
       "description": "Group GraphQL Codegen",
@@ -99,12 +130,44 @@
         "@graphql-codegen/typescript-react-apollo"
       ],
       "groupName": "graphql-codegen",
-      "groupSlug": "graphql-codegen"
+      "groupSlug": "graphql-codegen",
+      "separateMajorMinor": false
+    },
+    {
+      "description": "Group New Relic monitoring",
+      "matchPackageNames": ["/^@newrelic//"],
+      "groupName": "newrelic",
+      "groupSlug": "newrelic",
+      "separateMajorMinor": false
+    },
+    {
+      "description": "Group icon libraries",
+      "matchPackageNames": ["lucide-react"],
+      "groupName": "icons",
+      "groupSlug": "icons",
+      "separateMajorMinor": false
+    },
+    {
+      "description": "Group TypeScript compiler",
+      "matchPackageNames": ["typescript"],
+      "groupName": "typescript",
+      "groupSlug": "typescript",
+      "separateMajorMinor": false
+    },
+    {
+      "description": "Catch-all bundle for any remaining npm minor/patch updates",
+      "matchManagers": ["npm"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "npm-minor-patch",
+      "groupSlug": "npm-minor-patch",
+      "priority": -1
     },
     {
       "description": "Docker base image updates",
       "matchManagers": ["dockerfile"],
       "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "docker",
+      "groupSlug": "docker",
       "automerge": true
     },
     {


### PR DESCRIPTION
## Summary

Consolidates Renovate package rules to reduce PR fragmentation. Going forward, weekly runs should produce a small number of grouped PRs (e.g. `react`, `eslint`, `testing`, `vite-build`, `tailwindcss`, `radix-ui`, `npm-minor-patch`) instead of ~13 individual PRs.

## Key changes

- **Keep majors bundled with minors** per group via `separateMajorMinor: false`, so e.g. `eslint` v10 no longer produces a separate `major-eslint` branch from the `eslint` minor group.
- **New groups**: `radix-ui`, `vite-build` (vite + @vitejs/plugin-react), `newrelic`, `icons` (lucide-react), `typescript` (compiler).
- **Expanded groups**:
  - `react` now includes `react-router-dom`, `react-day-picker`, `react-calendar-heatmap`, `@types/react-calendar-heatmap`
  - `tailwindcss` now includes `tw-animate-css`, `class-variance-authority`, `clsx`
  - `eslint` now includes `globals`
  - `formatting-tools` now includes `shadcn`
  - `testing` (renamed from `vitest-testing`) now includes `@playwright/test`
- **Catch-all**: `npm-minor-patch` group (priority -1) collects any remaining ungrouped minor/patch npm updates into a single weekly PR.
- **Cleanup**: replaced deprecated `matchPackagePatterns` with `matchPackageNames` regex syntax; named the `docker` group.

## Effect on open PRs

Once this merges, the following fragmented PRs should be closed so Renovate can regenerate them under the new grouping on the next run:

- #73 react-router-dom -> will fold into `react`
- #74 @newrelic/browser-agent -> will fold into `newrelic`
- #75 shadcn -> will fold into `formatting-tools`
- #76 eslint + #84 eslint v10 -> will fold into single `eslint` PR
- #77 formatting-tools (will be regenerated with shadcn included)
- #78 graphql-codegen (will be regenerated)
- #79 @vitejs/plugin-react v6 + #83 vite v8 -> will fold into single `vite-build` PR
- #80 cspell v10 -> will fold into `formatting-tools`
- #81 jsdom v29 -> will fold into `testing`
- #82 typescript v6 -> will fold into `typescript` group
- #85 lucide-react v1 -> will fold into `icons`

## Validation

- `python3 -m json.tool renovate.json` -> valid
- `npx renovate-config-validator --strict renovate.json` -> no errors
- `npm run lint:all` -> pass