### PR TITLE
fix(renovate): remove deprecated priority field causing Mend 'undefined' repo error

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -21,6 +21,13 @@
       "automergeType": "pr"
     },
     {
+      "description": "Catch-all bundle for any remaining npm minor/patch updates (specific groups below override this via last-match-wins)",
+      "matchManagers": ["npm"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "npm-minor-patch",
+      "groupSlug": "npm-minor-patch"
+    },
+    {
       "description": "Group React ecosystem (majors stay bundled with minors)",
       "matchPackageNames": [
         "react",
@@ -153,14 +160,6 @@
       "groupName": "typescript",
       "groupSlug": "typescript",
       "separateMajorMinor": false
-    },
-    {
-      "description": "Catch-all bundle for any remaining npm minor/patch updates",
-      "matchManagers": ["npm"],
-      "matchUpdateTypes": ["minor", "patch"],
-      "groupName": "npm-minor-patch",
-      "groupSlug": "npm-minor-patch",
-      "priority": -1
     },
     {
       "description": "Docker base image updates",


### PR DESCRIPTION
## Problem

After PR #86 merged the consolidated Renovate config, the Mend dashboard started reporting:

```
Repository problems
Reason: undefined
Message: undefined
```

## Root Cause

Local dry-run (`renovate --platform=local --dry-run=full`) surfaces the real error that Mend's UI masks:

```
Invalid configuration option: packageRules[15].priority
```

The `priority` field was removed from `packageRules` in recent Renovate versions. `renovate-config-validator --strict` does not flag it, but the runtime `config-validation` step fails, aborting the whole repo run before any PRs are created.

## Fix

- Remove `priority: -1` from the `npm-minor-patch` catch-all rule.
- Move the catch-all rule **before** the specific group rules so Renovate's last-match-wins evaluation still lets specific groups (`react`, `eslint`, `testing`, `typescript`, `vite-build`, `newrelic`, `icons`, `radix-ui`, `formatting-tools`, etc.) override the catch-all grouping — same behavior `priority: -1` was emulating, just expressed through ordering.

## Validation

```bash
npx renovate --platform=local --dry-run=full
# No more 'Invalid configuration option' errors
# Only benign 'GitHub token is required' warning remains (expected for local dry-run)
```

## Next Steps

Once merged, re-trigger the Renovate scan from the Mend dashboard. Expect grouped PRs for outstanding majors (eslint v10, vite v8, cspell v10, jsdom v29, lucide-react v1, typescript v6, markdownlint-cli2 v0.22, @vitejs/plugin-react v6) plus the `npm-minor-patch` catch-all for anything else.