### PR TITLE
feat(ui): show empty state when Garmin/Locations have no data

### DIFF
--- a/e2e/empty-state.spec.ts
+++ b/e2e/empty-state.spec.ts
@@ -1,21 +1,24 @@
 import { test, expect } from '@playwright/test'
+import fs from 'node:fs'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 /**
  * Captures PNG screenshots of the new "No data available" empty state on
- * the Garmin Activities and Locations pages by selecting a future date
- * range that is guaranteed to contain no records.
+ * the Garmin Activities and Locations pages by applying impossible filter
+ * values that are guaranteed to return no records without relying on
+ * future dates, which the pages clamp to the data's max date.
  */
 
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = path.dirname(__filename)
 const SCREENSHOT_DIR = path.join(__dirname, 'screenshots', 'empty-state')
-// Far-future date range with no data.
-// Filters chosen to be guaranteed empty without relying on date clamping
-// (the pages clamp future dates to the data's max date).
+// Filter values chosen to be guaranteed empty.
+// This avoids depending on date parameters or future-date clamping behavior.
 const EMPTY_SPORT = '__no_such_sport__'
 const EMPTY_DEVICE = '__no_such_device__'
+
+fs.mkdirSync(SCREENSHOT_DIR, { recursive: true })
 
 test.describe('Empty state screenshots', () => {
   test('Garmin Activities - empty state', async ({ page }) => {

--- a/e2e/empty-state.spec.ts
+++ b/e2e/empty-state.spec.ts
@@ -1,0 +1,47 @@
+import { test, expect } from '@playwright/test'
+import path from 'node:path'
+
+/**
+ * Captures PNG screenshots of the new "No data available" empty state on
+ * the Garmin Activities and Locations pages by selecting a future date
+ * range that is guaranteed to contain no records.
+ */
+
+const SCREENSHOT_DIR = path.join(__dirname, 'screenshots', 'empty-state')
+// Far-future date range with no data.
+const FUTURE_FROM = '2099-01-01'
+const FUTURE_TO = '2099-01-07'
+
+test.describe('Empty state screenshots', () => {
+  test('Garmin Activities - empty state', async ({ page }) => {
+    await page.goto(`/garmin?date_from=${FUTURE_FROM}&date_to=${FUTURE_TO}`)
+
+    await expect(page.getByText('No data available')).toBeVisible({
+      timeout: 15_000,
+    })
+    await expect(
+      page.getByRole('button', { name: /clear filters/i }),
+    ).toBeVisible()
+
+    await page.screenshot({
+      path: path.join(SCREENSHOT_DIR, 'garmin-empty.png'),
+      fullPage: true,
+    })
+  })
+
+  test('Locations - empty state', async ({ page }) => {
+    await page.goto(`/locations?date_from=${FUTURE_FROM}&date_to=${FUTURE_TO}`)
+
+    await expect(page.getByText('No data available')).toBeVisible({
+      timeout: 15_000,
+    })
+    await expect(
+      page.getByRole('button', { name: /clear filters/i }),
+    ).toBeVisible()
+
+    await page.screenshot({
+      path: path.join(SCREENSHOT_DIR, 'locations-empty.png'),
+      fullPage: true,
+    })
+  })
+})

--- a/e2e/empty-state.spec.ts
+++ b/e2e/empty-state.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect } from '@playwright/test'
 import path from 'node:path'
+import { fileURLToPath } from 'node:url'
 
 /**
  * Captures PNG screenshots of the new "No data available" empty state on
@@ -7,14 +8,18 @@ import path from 'node:path'
  * range that is guaranteed to contain no records.
  */
 
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
 const SCREENSHOT_DIR = path.join(__dirname, 'screenshots', 'empty-state')
 // Far-future date range with no data.
-const FUTURE_FROM = '2099-01-01'
-const FUTURE_TO = '2099-01-07'
+// Filters chosen to be guaranteed empty without relying on date clamping
+// (the pages clamp future dates to the data's max date).
+const EMPTY_SPORT = '__no_such_sport__'
+const EMPTY_DEVICE = '__no_such_device__'
 
 test.describe('Empty state screenshots', () => {
   test('Garmin Activities - empty state', async ({ page }) => {
-    await page.goto(`/garmin?date_from=${FUTURE_FROM}&date_to=${FUTURE_TO}`)
+    await page.goto(`/garmin?sport=${EMPTY_SPORT}`)
 
     await expect(page.getByText('No data available')).toBeVisible({
       timeout: 15_000,
@@ -30,7 +35,7 @@ test.describe('Empty state screenshots', () => {
   })
 
   test('Locations - empty state', async ({ page }) => {
-    await page.goto(`/locations?date_from=${FUTURE_FROM}&date_to=${FUTURE_TO}`)
+    await page.goto(`/locations?device=${EMPTY_DEVICE}`)
 
     await expect(page.getByText('No data available')).toBeVisible({
       timeout: 15_000,

--- a/src/components/shared/EmptyState.tsx
+++ b/src/components/shared/EmptyState.tsx
@@ -1,0 +1,29 @@
+import { Inbox } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+
+export function EmptyState({
+  title = 'No data available',
+  message,
+  onReset,
+  resetLabel = 'Clear filters',
+}: {
+  title?: string
+  message?: string
+  onReset?: () => void
+  resetLabel?: string
+}) {
+  return (
+    <div className="flex flex-col items-center justify-center py-12 text-center">
+      <Inbox className="h-8 w-8 text-muted-foreground" />
+      <p className="mt-2 text-sm font-medium">{title}</p>
+      {message && (
+        <p className="mt-1 text-sm text-muted-foreground">{message}</p>
+      )}
+      {onReset && (
+        <Button variant="outline" size="sm" className="mt-4" onClick={onReset}>
+          {resetLabel}
+        </Button>
+      )}
+    </div>
+  )
+}

--- a/src/pages/GarminPage.tsx
+++ b/src/pages/GarminPage.tsx
@@ -7,6 +7,7 @@ import { Link, useSearchParams } from 'react-router-dom'
 import { useEffect } from 'react'
 import { LoadingState } from '@/components/shared/LoadingState'
 import { ErrorState } from '@/components/shared/ErrorState'
+import { EmptyState } from '@/components/shared/EmptyState'
 import { DateRangePicker } from '@/components/shared/DateRangePicker'
 import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
@@ -138,89 +139,124 @@ export function GarminPage() {
       </div>
 
       {/* Table */}
-      <div className="rounded-md border">
-        <Table>
-          <TableHeader>
-            <TableRow>
-              <TableHead>Sport</TableHead>
-              <TableHead>Distance</TableHead>
-              <TableHead>Duration</TableHead>
-              <TableHead>Avg HR</TableHead>
-              <TableHead>Calories</TableHead>
-              <TableHead>Points</TableHead>
-              <TableHead>Date</TableHead>
-            </TableRow>
-          </TableHeader>
-          <TableBody>
-            {activities.map((a) => (
-              <TableRow key={a.activity_id}>
-                <TableCell>
-                  <Link
-                    to={`/garmin/${a.activity_id}`}
-                    state={{ garminListSearch: searchParams.toString() }}
-                    className="font-medium capitalize text-primary hover:underline"
-                  >
-                    {a.sport}
-                  </Link>
-                </TableCell>
-                <TableCell>
-                  {a.distance_km != null
-                    ? `${a.distance_km.toFixed(2)} km`
-                    : '—'}
-                </TableCell>
-                <TableCell>{formatDurationShort(a.duration_seconds)}</TableCell>
-                <TableCell>
-                  {a.avg_heart_rate != null ? `${a.avg_heart_rate} bpm` : '—'}
-                </TableCell>
-                <TableCell>{a.calories != null ? a.calories : '—'}</TableCell>
-                <TableCell>
-                  {a.track_point_count != null
-                    ? a.track_point_count.toLocaleString()
-                    : '—'}
-                </TableCell>
-                <TableCell className="text-xs">
-                  {a.start_time ? new Date(a.start_time).toLocaleString() : '—'}
-                </TableCell>
-              </TableRow>
-            ))}
-          </TableBody>
-        </Table>
-      </div>
-
-      {/* Pagination */}
-      <div className="flex items-center justify-between">
-        <p className="text-sm text-muted-foreground">
-          Showing {offset + 1}–{Math.min(offset + PAGE_SIZE, total)} of{' '}
-          {total.toLocaleString()}
-        </p>
-        <div className="flex gap-2">
-          <Button
-            variant="outline"
-            size="sm"
-            disabled={page <= 1}
-            onClick={() => {
-              const params = new URLSearchParams(searchParams)
-              if (page - 1 <= 1) params.delete('page')
-              else params.set('page', String(page - 1))
-              setSearchParams(params)
-            }}
-          >
-            <ChevronLeft className="h-4 w-4" /> Prev
-          </Button>
-          <Button
-            variant="outline"
-            size="sm"
-            disabled={offset + PAGE_SIZE >= total}
-            onClick={() => {
-              const params = new URLSearchParams(searchParams)
-              params.set('page', String(page + 1))
-              setSearchParams(params)
-            }}
-          >
-            Next <ChevronRight className="h-4 w-4" />
-          </Button>
+      {total === 0 ? (
+        <div className="rounded-md border">
+          <EmptyState
+            title="No data available"
+            message={
+              sportFilter || dateFromStr || dateToStr
+                ? 'No Garmin activities match the selected filters. Try a different date range or sport.'
+                : 'No Garmin activities have been recorded yet.'
+            }
+            onReset={
+              sportFilter || dateFromStr || dateToStr
+                ? () => {
+                    const params = new URLSearchParams(searchParams)
+                    params.delete('sport')
+                    params.delete('date_from')
+                    params.delete('date_to')
+                    params.delete('page')
+                    setSearchParams(params)
+                  }
+                : undefined
+            }
+          />
         </div>
-      </div>
+      ) : (
+        <>
+          <div className="rounded-md border">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Sport</TableHead>
+                  <TableHead>Distance</TableHead>
+                  <TableHead>Duration</TableHead>
+                  <TableHead>Avg HR</TableHead>
+                  <TableHead>Calories</TableHead>
+                  <TableHead>Points</TableHead>
+                  <TableHead>Date</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {activities.map((a) => (
+                  <TableRow key={a.activity_id}>
+                    <TableCell>
+                      <Link
+                        to={`/garmin/${a.activity_id}`}
+                        state={{ garminListSearch: searchParams.toString() }}
+                        className="font-medium capitalize text-primary hover:underline"
+                      >
+                        {a.sport}
+                      </Link>
+                    </TableCell>
+                    <TableCell>
+                      {a.distance_km != null
+                        ? `${a.distance_km.toFixed(2)} km`
+                        : '—'}
+                    </TableCell>
+                    <TableCell>
+                      {formatDurationShort(a.duration_seconds)}
+                    </TableCell>
+                    <TableCell>
+                      {a.avg_heart_rate != null
+                        ? `${a.avg_heart_rate} bpm`
+                        : '—'}
+                    </TableCell>
+                    <TableCell>
+                      {a.calories != null ? a.calories : '—'}
+                    </TableCell>
+                    <TableCell>
+                      {a.track_point_count != null
+                        ? a.track_point_count.toLocaleString()
+                        : '—'}
+                    </TableCell>
+                    <TableCell className="text-xs">
+                      {a.start_time
+                        ? new Date(a.start_time).toLocaleString()
+                        : '—'}
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </div>
+
+          {/* Pagination */}
+          <div className="flex items-center justify-between">
+            <p className="text-sm text-muted-foreground">
+              Showing {offset + 1}–{Math.min(offset + PAGE_SIZE, total)} of{' '}
+              {total.toLocaleString()}
+            </p>
+            <div className="flex gap-2">
+              <Button
+                variant="outline"
+                size="sm"
+                disabled={page <= 1}
+                onClick={() => {
+                  const params = new URLSearchParams(searchParams)
+                  if (page - 1 <= 1) params.delete('page')
+                  else params.set('page', String(page - 1))
+                  setSearchParams(params)
+                }}
+              >
+                <ChevronLeft className="h-4 w-4" /> Prev
+              </Button>
+              <Button
+                variant="outline"
+                size="sm"
+                disabled={offset + PAGE_SIZE >= total}
+                onClick={() => {
+                  const params = new URLSearchParams(searchParams)
+                  params.set('page', String(page + 1))
+                  setSearchParams(params)
+                }}
+              >
+                Next <ChevronRight className="h-4 w-4" />
+              </Button>
+            </div>
+          </div>
+        </>
+      )}
     </div>
   )
 }

--- a/src/pages/LocationsPage.tsx
+++ b/src/pages/LocationsPage.tsx
@@ -5,6 +5,7 @@ import {
 } from '@/__generated__/graphql'
 import { LoadingState } from '@/components/shared/LoadingState'
 import { ErrorState } from '@/components/shared/ErrorState'
+import { EmptyState } from '@/components/shared/EmptyState'
 import { DateRangePicker } from '@/components/shared/DateRangePicker'
 import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
@@ -127,92 +128,121 @@ export function LocationsPage() {
       </div>
 
       {/* Table */}
-      <div className="rounded-md border">
-        <Table>
-          <TableHeader>
-            <TableRow>
-              <TableHead>ID</TableHead>
-              <TableHead>Device</TableHead>
-              <TableHead>Lat / Lon</TableHead>
-              <TableHead>Battery</TableHead>
-              <TableHead>Accuracy</TableHead>
-              <TableHead>Address</TableHead>
-              <TableHead>Timestamp</TableHead>
-            </TableRow>
-          </TableHeader>
-          <TableBody>
-            {locations.map((loc) => (
-              <TableRow key={loc.id}>
-                <TableCell>
-                  <Link
-                    to={`/locations/${loc.id}`}
-                    state={{ locationsListSearch: searchParams.toString() }}
-                    className="font-medium text-primary hover:underline"
-                  >
-                    {loc.id}
-                  </Link>
-                </TableCell>
-                <TableCell>
-                  <Badge variant="outline">{loc.device_id}</Badge>
-                </TableCell>
-                <TableCell className="font-mono text-xs">
-                  {loc.latitude.toFixed(6)}, {loc.longitude.toFixed(6)}
-                </TableCell>
-                <TableCell>
-                  {loc.battery != null ? `${loc.battery}%` : '—'}
-                </TableCell>
-                <TableCell>
-                  {loc.accuracy != null ? `${loc.accuracy.toFixed(0)}m` : '—'}
-                </TableCell>
-                <TableCell
-                  className="max-w-50 truncate text-xs"
-                  title={loc.display_address ?? undefined}
-                >
-                  {loc.display_address ?? '—'}
-                </TableCell>
-                <TableCell className="text-xs">
-                  {new Date(loc.timestamp).toLocaleString()}
-                </TableCell>
-              </TableRow>
-            ))}
-          </TableBody>
-        </Table>
-      </div>
-
-      {/* Pagination */}
-      <div className="flex items-center justify-between">
-        <p className="text-sm text-muted-foreground">
-          Showing {offset + 1}–{Math.min(offset + PAGE_SIZE, total)} of{' '}
-          {total.toLocaleString()}
-        </p>
-        <div className="flex gap-2">
-          <Button
-            variant="outline"
-            size="sm"
-            disabled={page <= 1}
-            onClick={() => {
-              const params = new URLSearchParams(searchParams)
-              if (page - 1 <= 1) params.delete('page')
-              else params.set('page', String(page - 1))
-              setSearchParams(params)
-            }}
-          >
-            <ChevronLeft className="h-4 w-4" /> Prev
-          </Button>
-          <Button
-            variant="outline"
-            size="sm"
-            disabled={offset + PAGE_SIZE >= total}
-            onClick={() => {
-              const params = new URLSearchParams(searchParams)
-              params.set('page', String(page + 1))
-              setSearchParams(params)
-            }}
-          >
-            Next <ChevronRight className="h-4 w-4" />
-          </Button>
+      {total === 0 ? (
+        <div className="rounded-md border">
+          <EmptyState
+            title="No data available"
+            message={
+              deviceFilter || dateFromStr || dateToStr
+                ? 'No locations match the selected filters. Try a different date range or device.'
+                : 'No OwnTracks GPS points have been recorded yet.'
+            }
+            onReset={
+              deviceFilter || dateFromStr || dateToStr
+                ? () => {
+                    const params = new URLSearchParams(searchParams)
+                    params.delete('device')
+                    params.delete('date_from')
+                    params.delete('date_to')
+                    params.delete('page')
+                    setSearchParams(params)
+                  }
+                : undefined
+            }
+          />
         </div>
-      </div>
+      ) : (
+        <>
+          <div className="rounded-md border">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>ID</TableHead>
+                  <TableHead>Device</TableHead>
+                  <TableHead>Lat / Lon</TableHead>
+                  <TableHead>Battery</TableHead>
+                  <TableHead>Accuracy</TableHead>
+                  <TableHead>Address</TableHead>
+                  <TableHead>Timestamp</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {locations.map((loc) => (
+                  <TableRow key={loc.id}>
+                    <TableCell>
+                      <Link
+                        to={`/locations/${loc.id}`}
+                        state={{ locationsListSearch: searchParams.toString() }}
+                        className="font-medium text-primary hover:underline"
+                      >
+                        {loc.id}
+                      </Link>
+                    </TableCell>
+                    <TableCell>
+                      <Badge variant="outline">{loc.device_id}</Badge>
+                    </TableCell>
+                    <TableCell className="font-mono text-xs">
+                      {loc.latitude.toFixed(6)}, {loc.longitude.toFixed(6)}
+                    </TableCell>
+                    <TableCell>
+                      {loc.battery != null ? `${loc.battery}%` : '—'}
+                    </TableCell>
+                    <TableCell>
+                      {loc.accuracy != null
+                        ? `${loc.accuracy.toFixed(0)}m`
+                        : '—'}
+                    </TableCell>
+                    <TableCell
+                      className="max-w-50 truncate text-xs"
+                      title={loc.display_address ?? undefined}
+                    >
+                      {loc.display_address ?? '—'}
+                    </TableCell>
+                    <TableCell className="text-xs">
+                      {new Date(loc.timestamp).toLocaleString()}
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </div>
+
+          {/* Pagination */}
+          <div className="flex items-center justify-between">
+            <p className="text-sm text-muted-foreground">
+              Showing {offset + 1}–{Math.min(offset + PAGE_SIZE, total)} of{' '}
+              {total.toLocaleString()}
+            </p>
+            <div className="flex gap-2">
+              <Button
+                variant="outline"
+                size="sm"
+                disabled={page <= 1}
+                onClick={() => {
+                  const params = new URLSearchParams(searchParams)
+                  if (page - 1 <= 1) params.delete('page')
+                  else params.set('page', String(page - 1))
+                  setSearchParams(params)
+                }}
+              >
+                <ChevronLeft className="h-4 w-4" /> Prev
+              </Button>
+              <Button
+                variant="outline"
+                size="sm"
+                disabled={offset + PAGE_SIZE >= total}
+                onClick={() => {
+                  const params = new URLSearchParams(searchParams)
+                  params.set('page', String(page + 1))
+                  setSearchParams(params)
+                }}
+              >
+                Next <ChevronRight className="h-4 w-4" />
+              </Button>
+            </div>
+          </div>
+        </>
+      )}
     </div>
   )
 }


### PR DESCRIPTION
## Summary

Adds a friendly "No data available" empty state to the **Garmin Activities** and **Locations** pages so users get clear feedback when a filter/date range returns no rows, instead of seeing an empty grid.

## Changes

- **New shared component**: \`src/components/shared/EmptyState.tsx\` — reusable card with Inbox icon, title, message, and optional reset button (matches \`LoadingState\`/\`ErrorState\` style).
- **\`GarminPage\`**: renders \`EmptyState\` when \`total === 0\`; message is context-aware (mentions active filters vs. no data recorded); "Clear filters" button resets \`sport\`, \`date_from\`, \`date_to\`, \`page\`. Table + pagination are hidden when empty.
- **\`LocationsPage\`**: same pattern for \`device\` + date filters.
- **Playwright e2e test** (\`e2e/empty-state.spec.ts\`): captures PNG screenshots of the empty state on both pages. Uses impossible filter values so the state reliably renders regardless of DB contents. ESM-safe \`__dirname\` via \`fileURLToPath\`.

## Validation

- \`npm run type-check\` ✅
- \`npm run test:run\` — 107/107 ✅
- Playwright e2e (local, \`BASE_URL=http://localhost:5173\`) — 2/2 ✅
  - \`e2e/screenshots/empty-state/garmin-empty.png\` (39.8 KB)
  - \`e2e/screenshots/empty-state/locations-empty.png\` (38.5 KB)

Screenshots are gitignored (\`e2e/screenshots/\`); reproduce locally with:

\`\`\`bash
make dev  # in another terminal
BASE_URL=http://localhost:5173 npx playwright test e2e/empty-state.spec.ts
\`\`\`

## Notes

- No GraphQL schema or API changes.
- No linked issue yet — happy to add \`Refs #NN\` if one exists.