### PR TITLE
feat(dashboard): Garmin Activity Totals widget

### DIFF
--- a/src/__generated__/graphql.ts
+++ b/src/__generated__/graphql.ts
@@ -145,6 +145,23 @@ export type GarminActivityConnection = {
   total: Scalars['Int']['output'];
 };
 
+/** Aggregated Garmin activity totals for a single time bucket (week, month, or year). */
+export type GarminActivityTotal = {
+  __typename?: 'GarminActivityTotal';
+  /** Number of activities in the period */
+  activity_count: Scalars['Int']['output'];
+  /** Start date of the period bucket (DATE_TRUNC of week/month/year) */
+  period_start: Scalars['String']['output'];
+  /** Sum of elevation gain in meters */
+  total_ascent_m?: Maybe<Scalars['Int']['output']>;
+  /** Sum of calories burned */
+  total_calories?: Maybe<Scalars['Int']['output']>;
+  /** Sum of distance in kilometres */
+  total_distance_km?: Maybe<Scalars['Float']['output']>;
+  /** Sum of active duration in seconds (excludes pauses) */
+  total_duration_seconds?: Maybe<Scalars['Int']['output']>;
+};
+
 /** Lightweight track point optimised for time-series chart rendering. */
 export type GarminChartPoint = {
   __typename?: 'GarminChartPoint';
@@ -471,6 +488,8 @@ export type Query = {
   garminActivities: GarminActivityConnection;
   /** Retrieve a single Garmin activity by its ID. */
   garminActivity?: Maybe<GarminActivity>;
+  /** Aggregate Garmin activity totals grouped by week, month, or year. */
+  garminActivityTotals: Array<GarminActivityTotal>;
   /** Retrieve chart-optimised track points for a Garmin activity. */
   garminChartData: Array<GarminChartPoint>;
   /** Get the earliest and latest Garmin activity timestamps. */
@@ -534,6 +553,14 @@ export type QueryGarminActivitiesArgs = {
 
 export type QueryGarminActivityArgs = {
   activity_id: Scalars['String']['input'];
+};
+
+
+export type QueryGarminActivityTotalsArgs = {
+  date_from?: InputMaybe<Scalars['String']['input']>;
+  date_to?: InputMaybe<Scalars['String']['input']>;
+  period: Scalars['String']['input'];
+  sport?: InputMaybe<Scalars['String']['input']>;
 };
 
 
@@ -746,6 +773,16 @@ export type GarminSportsQueryVariables = Exact<{ [key: string]: never; }>;
 
 
 export type GarminSportsQuery = { __typename?: 'Query', garminSports: Array<{ __typename?: 'SportInfo', sport: string, activity_count: number }> };
+
+export type GarminActivityTotalsQueryVariables = Exact<{
+  period: Scalars['String']['input'];
+  date_from?: InputMaybe<Scalars['String']['input']>;
+  date_to?: InputMaybe<Scalars['String']['input']>;
+  sport?: InputMaybe<Scalars['String']['input']>;
+}>;
+
+
+export type GarminActivityTotalsQuery = { __typename?: 'Query', garminActivityTotals: Array<{ __typename?: 'GarminActivityTotal', period_start: string, activity_count: number, total_distance_km?: number | null, total_duration_seconds?: number | null, total_ascent_m?: number | null, total_calories?: number | null }> };
 
 export type GarminChartDataQueryVariables = Exact<{
   activity_id: Scalars['String']['input'];
@@ -1198,6 +1235,62 @@ export type GarminSportsQueryHookResult = ReturnType<typeof useGarminSportsQuery
 export type GarminSportsLazyQueryHookResult = ReturnType<typeof useGarminSportsLazyQuery>;
 export type GarminSportsSuspenseQueryHookResult = ReturnType<typeof useGarminSportsSuspenseQuery>;
 export type GarminSportsQueryResult = ApolloReactCommon.QueryResult<GarminSportsQuery, GarminSportsQueryVariables>;
+export const GarminActivityTotalsDocument = gql`
+    query GarminActivityTotals($period: String!, $date_from: String, $date_to: String, $sport: String) {
+  garminActivityTotals(
+    period: $period
+    date_from: $date_from
+    date_to: $date_to
+    sport: $sport
+  ) {
+    period_start
+    activity_count
+    total_distance_km
+    total_duration_seconds
+    total_ascent_m
+    total_calories
+  }
+}
+    `;
+
+/**
+ * __useGarminActivityTotalsQuery__
+ *
+ * To run a query within a React component, call `useGarminActivityTotalsQuery` and pass it any options that fit your needs.
+ * When your component renders, `useGarminActivityTotalsQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useGarminActivityTotalsQuery({
+ *   variables: {
+ *      period: // value for 'period'
+ *      date_from: // value for 'date_from'
+ *      date_to: // value for 'date_to'
+ *      sport: // value for 'sport'
+ *   },
+ * });
+ */
+export function useGarminActivityTotalsQuery(baseOptions: ApolloReactHooks.QueryHookOptions<GarminActivityTotalsQuery, GarminActivityTotalsQueryVariables> & ({ variables: GarminActivityTotalsQueryVariables; skip?: boolean; } | { skip: boolean; }) ) {
+        const options = {...defaultOptions, ...baseOptions}
+        return ApolloReactHooks.useQuery<GarminActivityTotalsQuery, GarminActivityTotalsQueryVariables>(GarminActivityTotalsDocument, options);
+      }
+export function useGarminActivityTotalsLazyQuery(baseOptions?: ApolloReactHooks.LazyQueryHookOptions<GarminActivityTotalsQuery, GarminActivityTotalsQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return ApolloReactHooks.useLazyQuery<GarminActivityTotalsQuery, GarminActivityTotalsQueryVariables>(GarminActivityTotalsDocument, options);
+        }
+// @ts-ignore
+export function useGarminActivityTotalsSuspenseQuery(baseOptions?: ApolloReactHooks.SuspenseQueryHookOptions<GarminActivityTotalsQuery, GarminActivityTotalsQueryVariables>): ApolloReactHooks.UseSuspenseQueryResult<GarminActivityTotalsQuery, GarminActivityTotalsQueryVariables>;
+export function useGarminActivityTotalsSuspenseQuery(baseOptions?: ApolloReactHooks.SkipToken | ApolloReactHooks.SuspenseQueryHookOptions<GarminActivityTotalsQuery, GarminActivityTotalsQueryVariables>): ApolloReactHooks.UseSuspenseQueryResult<GarminActivityTotalsQuery | undefined, GarminActivityTotalsQueryVariables>;
+export function useGarminActivityTotalsSuspenseQuery(baseOptions?: ApolloReactHooks.SkipToken | ApolloReactHooks.SuspenseQueryHookOptions<GarminActivityTotalsQuery, GarminActivityTotalsQueryVariables>) {
+          const options = baseOptions === ApolloReactHooks.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
+          return ApolloReactHooks.useSuspenseQuery<GarminActivityTotalsQuery, GarminActivityTotalsQueryVariables>(GarminActivityTotalsDocument, options);
+        }
+export type GarminActivityTotalsQueryHookResult = ReturnType<typeof useGarminActivityTotalsQuery>;
+export type GarminActivityTotalsLazyQueryHookResult = ReturnType<typeof useGarminActivityTotalsLazyQuery>;
+export type GarminActivityTotalsSuspenseQueryHookResult = ReturnType<typeof useGarminActivityTotalsSuspenseQuery>;
+export type GarminActivityTotalsQueryResult = ApolloReactCommon.QueryResult<GarminActivityTotalsQuery, GarminActivityTotalsQueryVariables>;
 export const GarminChartDataDocument = gql`
     query GarminChartData($activity_id: String!) {
   garminChartData(activity_id: $activity_id) {

--- a/src/components/dashboard/GarminActivityTotals.test.tsx
+++ b/src/components/dashboard/GarminActivityTotals.test.tsx
@@ -1,0 +1,115 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const hooks = vi.hoisted(() => ({
+  useGarminActivityTotalsQuery: vi.fn(),
+}))
+
+vi.mock('@/__generated__/graphql', () => hooks)
+
+// Recharts uses ResponsiveContainer which needs a sized parent in jsdom; stub it.
+vi.mock('recharts', async () => {
+  const actual = await vi.importActual<typeof import('recharts')>('recharts')
+  return {
+    ...actual,
+    ResponsiveContainer: ({ children }: { children: React.ReactNode }) => (
+      <div style={{ width: 800, height: 400 }}>{children}</div>
+    ),
+  }
+})
+
+import { GarminActivityTotals } from './GarminActivityTotals'
+
+describe('GarminActivityTotals', () => {
+  beforeEach(() => {
+    hooks.useGarminActivityTotalsQuery.mockReset()
+  })
+
+  it('renders a loading state while totals are loading', () => {
+    hooks.useGarminActivityTotalsQuery.mockReturnValue({
+      data: undefined,
+      loading: true,
+      error: undefined,
+      refetch: vi.fn(),
+    })
+
+    render(<GarminActivityTotals />)
+
+    expect(screen.getByText(/Loading activity totals/i)).toBeInTheDocument()
+  })
+
+  it('renders an error state and retries on click', async () => {
+    const user = userEvent.setup()
+    const refetch = vi.fn()
+    hooks.useGarminActivityTotalsQuery.mockReturnValue({
+      data: undefined,
+      loading: false,
+      error: new Error('totals failed'),
+      refetch,
+    })
+
+    render(<GarminActivityTotals />)
+
+    expect(screen.getByText(/totals failed/i)).toBeInTheDocument()
+    await user.click(screen.getByRole('button', { name: /retry/i }))
+    expect(refetch).toHaveBeenCalled()
+  })
+
+  it('renders an empty state when no buckets are returned', () => {
+    hooks.useGarminActivityTotalsQuery.mockReturnValue({
+      data: { garminActivityTotals: [] },
+      loading: false,
+      error: undefined,
+      refetch: vi.fn(),
+    })
+
+    render(<GarminActivityTotals />)
+
+    expect(
+      screen.getByText(/No activities found for this period/i),
+    ).toBeInTheDocument()
+  })
+
+  it('passes the selected period to the query and switches metric', async () => {
+    const user = userEvent.setup()
+    hooks.useGarminActivityTotalsQuery.mockReturnValue({
+      data: {
+        garminActivityTotals: [
+          {
+            period_start: '2026-03-01',
+            activity_count: 3,
+            total_distance_km: 42.5,
+            total_duration_seconds: 7200,
+            total_ascent_m: 150,
+            total_calories: 1800,
+          },
+        ],
+      },
+      loading: false,
+      error: undefined,
+      refetch: vi.fn(),
+    })
+
+    render(<GarminActivityTotals />)
+
+    // Default: month period, distance metric
+    expect(hooks.useGarminActivityTotalsQuery).toHaveBeenCalledWith(
+      expect.objectContaining({
+        variables: expect.objectContaining({ period: 'month' }),
+      }),
+    )
+
+    // Switch to weekly
+    await user.click(screen.getByRole('radio', { name: 'Weekly' }))
+    const lastCall = hooks.useGarminActivityTotalsQuery.mock.calls.at(-1)?.[0]
+    expect(lastCall?.variables?.period).toBe('week')
+
+    // Switch metric to Calories — radio should reflect it
+    await user.click(screen.getByRole('radio', { name: 'Calories' }))
+    expect(screen.getByRole('radio', { name: 'Calories' })).toHaveAttribute(
+      'aria-checked',
+      'true',
+    )
+  })
+})

--- a/src/components/dashboard/GarminActivityTotals.tsx
+++ b/src/components/dashboard/GarminActivityTotals.tsx
@@ -12,9 +12,58 @@ import {
 import { TrendingUp } from 'lucide-react'
 import { useGarminActivityTotalsQuery } from '@/__generated__/graphql'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
-import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs'
+import { Button } from '@/components/ui/button'
 import { LoadingState } from '@/components/shared/LoadingState'
 import { ErrorState } from '@/components/shared/ErrorState'
+import { cn } from '@/lib/utils'
+
+interface SegmentOption<T extends string> {
+  value: T
+  label: string
+}
+
+interface SegmentedControlProps<T extends string> {
+  ariaLabel: string
+  value: T
+  onChange: (value: T) => void
+  options: SegmentOption<T>[]
+}
+
+function SegmentedControl<T extends string>({
+  ariaLabel,
+  value,
+  onChange,
+  options,
+}: SegmentedControlProps<T>) {
+  return (
+    <div
+      role="radiogroup"
+      aria-label={ariaLabel}
+      className="inline-flex rounded-md border bg-muted p-0.5"
+    >
+      {options.map((opt) => {
+        const selected = opt.value === value
+        return (
+          <Button
+            key={opt.value}
+            type="button"
+            role="radio"
+            aria-checked={selected}
+            variant={selected ? 'default' : 'ghost'}
+            size="sm"
+            onClick={() => onChange(opt.value)}
+            className={cn(
+              'h-7 px-3 text-xs',
+              !selected && 'bg-transparent shadow-none',
+            )}
+          >
+            {opt.label}
+          </Button>
+        )
+      })}
+    </div>
+  )
+}
 
 type Period = 'week' | 'month' | 'year'
 type Metric = 'distance' | 'duration' | 'ascent' | 'calories'
@@ -130,8 +179,7 @@ export function GarminActivityTotals() {
     }))
   }, [data, period])
 
-  const metricConfig =
-    METRICS.find((m) => m.key === metric) ?? METRICS[0]
+  const metricConfig = METRICS.find((m) => m.key === metric) ?? METRICS[0]
 
   return (
     <Card>
@@ -141,28 +189,22 @@ export function GarminActivityTotals() {
           Activity Totals
         </CardTitle>
         <div className="flex flex-col gap-2 pt-2 sm:flex-row sm:items-center sm:justify-between">
-          <Tabs
+          <SegmentedControl<Period>
+            ariaLabel="Aggregation period"
             value={period}
-            onValueChange={(v) => setPeriod(v as Period)}
-          >
-            <TabsList>
-              <TabsTrigger value="week">Weekly</TabsTrigger>
-              <TabsTrigger value="month">Monthly</TabsTrigger>
-              <TabsTrigger value="year">Yearly</TabsTrigger>
-            </TabsList>
-          </Tabs>
-          <Tabs
+            onChange={setPeriod}
+            options={[
+              { value: 'week', label: 'Weekly' },
+              { value: 'month', label: 'Monthly' },
+              { value: 'year', label: 'Yearly' },
+            ]}
+          />
+          <SegmentedControl<Metric>
+            ariaLabel="Metric"
             value={metric}
-            onValueChange={(v) => setMetric(v as Metric)}
-          >
-            <TabsList>
-              {METRICS.map((m) => (
-                <TabsTrigger key={m.key} value={m.key}>
-                  {m.label}
-                </TabsTrigger>
-              ))}
-            </TabsList>
-          </Tabs>
+            onChange={setMetric}
+            options={METRICS.map((m) => ({ value: m.key, label: m.label }))}
+          />
         </div>
       </CardHeader>
       <CardContent>
@@ -181,10 +223,7 @@ export function GarminActivityTotals() {
                 data={chartData}
                 margin={{ top: 10, right: 16, left: 0, bottom: 0 }}
               >
-                <CartesianGrid
-                  strokeDasharray="3 3"
-                  className="stroke-muted"
-                />
+                <CartesianGrid strokeDasharray="3 3" className="stroke-muted" />
                 <XAxis
                   dataKey="label"
                   tick={{ fontSize: 12 }}
@@ -204,7 +243,8 @@ export function GarminActivityTotals() {
                 />
                 <Tooltip
                   formatter={(value) => {
-                    const num = typeof value === 'number' ? value : Number(value)
+                    const num =
+                      typeof value === 'number' ? value : Number(value)
                     return [
                       `${num.toFixed(metricConfig.precision)} ${metricConfig.unit}`,
                       metricConfig.label,

--- a/src/components/dashboard/GarminActivityTotals.tsx
+++ b/src/components/dashboard/GarminActivityTotals.tsx
@@ -1,0 +1,234 @@
+import { useMemo, useState } from 'react'
+import { format, subMonths, subWeeks, parseISO } from 'date-fns'
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts'
+import { TrendingUp } from 'lucide-react'
+import { useGarminActivityTotalsQuery } from '@/__generated__/graphql'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs'
+import { LoadingState } from '@/components/shared/LoadingState'
+import { ErrorState } from '@/components/shared/ErrorState'
+
+type Period = 'week' | 'month' | 'year'
+type Metric = 'distance' | 'duration' | 'ascent' | 'calories'
+
+interface MetricConfig {
+  key: Metric
+  label: string
+  /** Recharts dataKey on the transformed bucket. */
+  dataKey: string
+  /** Friendly Y axis / tooltip unit label. */
+  unit: string
+  /** Bar color (Tailwind-friendly hex). */
+  color: string
+  /** Number of decimals for tooltip / Y axis ticks. */
+  precision: number
+}
+
+const METRICS: MetricConfig[] = [
+  {
+    key: 'distance',
+    label: 'Distance',
+    dataKey: 'distance_km',
+    unit: 'km',
+    color: '#2563eb',
+    precision: 1,
+  },
+  {
+    key: 'duration',
+    label: 'Duration',
+    dataKey: 'duration_hours',
+    unit: 'hr',
+    color: '#16a34a',
+    precision: 1,
+  },
+  {
+    key: 'ascent',
+    label: 'Ascent',
+    dataKey: 'total_ascent_m',
+    unit: 'm',
+    color: '#f97316',
+    precision: 0,
+  },
+  {
+    key: 'calories',
+    label: 'Calories',
+    dataKey: 'total_calories',
+    unit: 'kcal',
+    color: '#dc2626',
+    precision: 0,
+  },
+]
+
+interface ChartBucket {
+  period_start: string
+  label: string
+  activity_count: number
+  distance_km: number
+  duration_hours: number
+  total_ascent_m: number
+  total_calories: number
+}
+
+function getDateRange(period: Period): {
+  date_from?: string
+  date_to?: string
+} {
+  const today = new Date()
+  const date_to = format(today, 'yyyy-MM-dd')
+  if (period === 'week') {
+    return { date_from: format(subWeeks(today, 12), 'yyyy-MM-dd'), date_to }
+  }
+  if (period === 'month') {
+    return { date_from: format(subMonths(today, 12), 'yyyy-MM-dd'), date_to }
+  }
+  // 'year' — let the API return all available history
+  return {}
+}
+
+function formatBucketLabel(period_start: string, period: Period): string {
+  try {
+    const date = parseISO(period_start)
+    if (period === 'year') return format(date, 'yyyy')
+    if (period === 'month') return format(date, "MMM ''yy")
+    return format(date, 'MMM d')
+  } catch {
+    return period_start
+  }
+}
+
+export function GarminActivityTotals() {
+  const [period, setPeriod] = useState<Period>('month')
+  const [metric, setMetric] = useState<Metric>('distance')
+
+  const range = getDateRange(period)
+  const { data, loading, error, refetch } = useGarminActivityTotalsQuery({
+    variables: {
+      period,
+      date_from: range.date_from,
+      date_to: range.date_to,
+    },
+  })
+
+  const chartData = useMemo<ChartBucket[]>(() => {
+    const totals = data?.garminActivityTotals ?? []
+    return totals.map((t) => ({
+      period_start: t.period_start,
+      label: formatBucketLabel(t.period_start, period),
+      activity_count: t.activity_count,
+      distance_km: t.total_distance_km ?? 0,
+      duration_hours: (t.total_duration_seconds ?? 0) / 3600,
+      total_ascent_m: t.total_ascent_m ?? 0,
+      total_calories: t.total_calories ?? 0,
+    }))
+  }, [data, period])
+
+  const metricConfig =
+    METRICS.find((m) => m.key === metric) ?? METRICS[0]
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <TrendingUp className="h-5 w-5" />
+          Activity Totals
+        </CardTitle>
+        <div className="flex flex-col gap-2 pt-2 sm:flex-row sm:items-center sm:justify-between">
+          <Tabs
+            value={period}
+            onValueChange={(v) => setPeriod(v as Period)}
+          >
+            <TabsList>
+              <TabsTrigger value="week">Weekly</TabsTrigger>
+              <TabsTrigger value="month">Monthly</TabsTrigger>
+              <TabsTrigger value="year">Yearly</TabsTrigger>
+            </TabsList>
+          </Tabs>
+          <Tabs
+            value={metric}
+            onValueChange={(v) => setMetric(v as Metric)}
+          >
+            <TabsList>
+              {METRICS.map((m) => (
+                <TabsTrigger key={m.key} value={m.key}>
+                  {m.label}
+                </TabsTrigger>
+              ))}
+            </TabsList>
+          </Tabs>
+        </div>
+      </CardHeader>
+      <CardContent>
+        {loading ? (
+          <LoadingState message="Loading activity totals..." />
+        ) : error ? (
+          <ErrorState message={error.message} onRetry={() => refetch()} />
+        ) : chartData.length === 0 ? (
+          <p className="py-12 text-center text-sm text-muted-foreground">
+            No activities found for this period.
+          </p>
+        ) : (
+          <div className="h-80 w-full">
+            <ResponsiveContainer width="100%" height="100%">
+              <BarChart
+                data={chartData}
+                margin={{ top: 10, right: 16, left: 0, bottom: 0 }}
+              >
+                <CartesianGrid
+                  strokeDasharray="3 3"
+                  className="stroke-muted"
+                />
+                <XAxis
+                  dataKey="label"
+                  tick={{ fontSize: 12 }}
+                  interval="preserveStartEnd"
+                />
+                <YAxis
+                  tick={{ fontSize: 12 }}
+                  tickFormatter={(v: number) =>
+                    v.toFixed(metricConfig.precision)
+                  }
+                  label={{
+                    value: metricConfig.unit,
+                    angle: -90,
+                    position: 'insideLeft',
+                    style: { fontSize: 12 },
+                  }}
+                />
+                <Tooltip
+                  formatter={(value) => {
+                    const num = typeof value === 'number' ? value : Number(value)
+                    return [
+                      `${num.toFixed(metricConfig.precision)} ${metricConfig.unit}`,
+                      metricConfig.label,
+                    ]
+                  }}
+                  labelFormatter={(label, payload) => {
+                    const count =
+                      (payload?.[0]?.payload as ChartBucket | undefined)
+                        ?.activity_count ?? 0
+                    return `${label} — ${count} ${
+                      count === 1 ? 'activity' : 'activities'
+                    }`
+                  }}
+                />
+                <Bar
+                  dataKey={metricConfig.dataKey}
+                  fill={metricConfig.color}
+                  radius={[4, 4, 0, 0]}
+                />
+              </BarChart>
+            </ResponsiveContainer>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  )
+}

--- a/src/graphql/garmin.ts
+++ b/src/graphql/garmin.ts
@@ -140,6 +140,29 @@ export const GARMIN_SPORTS_QUERY = gql`
   }
 `
 
+export const GARMIN_ACTIVITY_TOTALS_QUERY = gql`
+  query GarminActivityTotals(
+    $period: String!
+    $date_from: String
+    $date_to: String
+    $sport: String
+  ) {
+    garminActivityTotals(
+      period: $period
+      date_from: $date_from
+      date_to: $date_to
+      sport: $sport
+    ) {
+      period_start
+      activity_count
+      total_distance_km
+      total_duration_seconds
+      total_ascent_m
+      total_calories
+    }
+  }
+`
+
 export const GARMIN_CHART_DATA_QUERY = gql`
   query GarminChartData($activity_id: String!) {
     garminChartData(activity_id: $activity_id) {

--- a/src/pages/DashboardPage.test.tsx
+++ b/src/pages/DashboardPage.test.tsx
@@ -9,6 +9,7 @@ const dashboardHooks = vi.hoisted(() => ({
   useGarminSportsQuery: vi.fn(),
   useDailySummaryQuery: vi.fn(),
   useGarminActivitiesQuery: vi.fn(),
+  useGarminActivityTotalsQuery: vi.fn(),
   useTriggerGarminSyncMutation: vi
     .fn()
     .mockReturnValue([vi.fn(), { loading: false }]),
@@ -42,6 +43,11 @@ describe('DashboardPage', () => {
     dashboardHooks.useGarminActivitiesQuery.mockReturnValue({
       data: undefined,
       loading: false,
+    })
+    dashboardHooks.useGarminActivityTotalsQuery.mockReturnValue({
+      data: undefined,
+      loading: false,
+      refetch: vi.fn(),
     })
   })
 

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -12,6 +12,7 @@ import { Badge } from '@/components/ui/badge'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { GarminSyncCard } from '@/components/dashboard/GarminSyncCard'
 import { GarminActivityHeatmap } from '@/components/dashboard/GarminActivityHeatmap'
+import { GarminActivityTotals } from '@/components/dashboard/GarminActivityTotals'
 
 export function DashboardPage() {
   const { data: healthData, loading: healthLoading } = useHealthQuery()
@@ -130,6 +131,8 @@ export function DashboardPage() {
       </div>
 
       <GarminActivityHeatmap />
+
+      <GarminActivityTotals />
     </div>
   )
 }


### PR DESCRIPTION
## Summary

Adds a new dashboard widget that visualizes aggregated Garmin activity totals using the `garminActivityTotals` GraphQL query (delivered in otel-data-api PR #97 and otel-data-gateway PR #67).

## What's included

- New component: `src/components/dashboard/GarminActivityTotals.tsx`
  - Recharts `BarChart` rendering aggregated totals
  - Period tabs: **week** (last 12 weeks) / **month** (last 12 months) / **year**
  - Metric tabs: **distance** (km) / **duration** (hr) / **ascent** (m) / **calories** (kcal)
  - Tooltip shows formatted value plus per-bucket activity count
  - Loading / error / empty states use existing shared components
- New GraphQL query in `src/graphql/garmin.ts`
- Regenerated `src/__generated__/graphql.ts` (uses `useGarminActivityTotalsQuery`)
- Wired into `DashboardPage` directly below the activity heatmap
- Updated `DashboardPage.test.tsx` to mock the new hook

## Validation

- `npm run lint:all` ✅
- `npm run type-check` ✅
- `npm run build` ✅
- `npm run test:run` ✅ (107/107)

## Notes

- Codegen was run against the local `otel-data-gateway` schema because the published `@stuartshay/otel-graphql-types` package has not yet been republished with the new query. The generated file is committed so CI does not depend on the stale npm package.
- Distance is displayed in km to match the API; a future change can add a unit toggle.

Refs #97