### PR TITLE
feat(dashboard): fix monthly activity totals month-by-year behavior

### DIFF
--- a/.github/skills/ui-feature-planning/SKILL.md
+++ b/.github/skills/ui-feature-planning/SKILL.md
@@ -1,0 +1,213 @@
+---
+name: ui-feature-planning
+description: 'Plan UI component enhancements from annotated screenshots. Use when: a screenshot shows visual annotation notes, when adding controls to existing dashboard components, when a chart or card needs new filter/selector behavior, when Playwright e2e tests with screenshot output are required as part of feature delivery. Covers: screenshot analysis, codebase exploration, requirements clarification, phased implementation plan with Playwright spec and unit test steps.'
+---
+
+# UI Feature Planning from Screenshot
+
+## When to Use
+
+Load this skill when:
+
+- A user attaches a screenshot with annotation notes describing desired changes to a UI component
+- You need to plan enhancements to existing React dashboard cards (charts, filters, toggles, selectors)
+- The task requires a Playwright e2e test with screenshot output as part of deliverables
+- You need to produce an actionable, phased plan before implementation begins
+
+## Workflow
+
+## Completion Gate (Mandatory)
+
+Before declaring any UI feature task complete, you must do both:
+
+1. Run the relevant Playwright spec(s) for the changed feature.
+2. Produce screenshot artifact(s) for examination in `e2e/screenshots/<feature>/`.
+
+Do not mark the task as complete if Playwright was not run or if screenshots were not generated.
+
+### Phase 1 — Screenshot Analysis
+
+Read the screenshot annotations carefully:
+
+1. Identify the **component name** from the screenshot title or card header
+2. List each annotation as a discrete requirement (label, control, behavior, data range)
+3. Note which behaviors are conditional (e.g. "only show when X tab is active")
+4. Note any deferred items explicitly called out ("will be different", "future")
+
+### Phase 2 — Codebase Discovery
+
+Launch an _Explore_ subagent (or parallel subagents for multi-area tasks) targeting `src/components/dashboard/` and related files. Request:
+
+1. Exact file path of the component and its key exported function/symbol
+2. How existing toggles/controls are implemented (state, component type)
+3. What GraphQL query/hook drives the component and its variable shape
+4. Whether a similar selector pattern already exists in another component (to reuse)
+5. Existing Playwright test files in `e2e/` that cover this page — note the screenshot pattern used
+6. Generated types in `src/__generated__/graphql.ts` for the relevant query
+
+Key reference files in otel-data-ui:
+
+- `src/components/dashboard/GarminActivityHeatmap.tsx` — canonical year-select + compact header Select pattern
+- `e2e/dashboard-activity-heatmap.spec.ts` — canonical Playwright pattern: `mkdirSync` screenshot dir at top, `test.setTimeout(60_000)`, `beforeEach` page load wait, `element.screenshot()` + `page.screenshot()` for named PNGs
+- `playwright.config.ts` — base URL (`https://data-ui.lab.informationcart.com`), chromium only, screenshots on failure
+
+### Phase 3 — Requirements Clarification
+
+Use `vscode_askQuestions` to resolve ambiguities before planning. Typical questions for dashboard chart enhancements:
+
+1. **Mode behavior**: When control X is active, what exactly should the chart show? (one bar per year? rolling window? all history?)
+2. **Control placement**: Where in the card header should the new control appear? (next to which existing control?)
+3. **Data range source**: Should range bounds be fixed values or derived from the API's min/max dates?
+4. **Chart labeling**: What should x-axis labels and any subtitle/header text say to communicate the selected context?
+5. **Scope boundary**: Which existing tabs/modes should stay unchanged for this change?
+
+### Phase 4 — Plan Construction
+
+Build a phased plan with these standard sections:
+
+#### Required Steps (always include)
+
+1. **Data semantics** — confirm query variable shape and expected API response for new mode. Identify any backend changes needed.
+2. **UI state + controls** — add state variables, conditional rendering of new controls, defaults.
+3. **Data fetching** — derive dynamic parameters (date bounds, year range) from API or computed values; include fallback behavior.
+4. **Chart labels + context** — update axis labels, tooltips, titles to communicate the selected context.
+5. **Non-regressing modes** — explicitly preserve all other tab/mode behaviors.
+6. **Unit tests** — cover: new default state, user interaction updating query vars, regression on unchanged modes.
+7. **Playwright e2e spec** — `e2e/dashboard-<feature>.spec.ts` with screenshots to `e2e/screenshots/<feature>/`. Must cover:
+   - New control visible in correct mode, default value correct; full-card screenshot
+   - Control change re-renders chart; element-level screenshot of chart card
+   - Other tabs/modes do not show the new control; element screenshot per tab
+   - Metric or secondary toggle still works in new mode; screenshot
+8. **Validation** — `npm run lint:all`, `npm run type-check`, `npm run test:run`, `npx playwright test e2e/dashboard-<feature>.spec.ts`; review screenshots.
+9. **Completion gate check** — confirm Playwright run passed (or document failures with evidence) and confirm screenshot files exist in `e2e/screenshots/<feature>/` before final handoff.
+
+#### Playwright Spec Template
+
+```typescript
+import { test, expect } from '@playwright/test'
+import fs from 'fs'
+import path from 'path'
+
+const SCREENSHOT_DIR = path.join('e2e', 'screenshots', '<feature-name>')
+fs.mkdirSync(SCREENSHOT_DIR, { recursive: true })
+
+test.describe('<Component> — <Feature>', () => {
+  test.setTimeout(60_000)
+
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/', { waitUntil: 'domcontentloaded' })
+    await expect(page.getByText('Total Locations')).toBeVisible({
+      timeout: 30_000,
+    })
+  })
+
+  test('default state renders correctly', async ({ page }) => {
+    const prefix = `<feature>-${test.info().project.name}`
+    // assert default control value
+    // full dashboard screenshot
+    await page.screenshot({
+      path: path.join(SCREENSHOT_DIR, `${prefix}-01-default.png`),
+      fullPage: true,
+    })
+  })
+
+  test('control change updates chart', async ({ page }) => {
+    const prefix = `<feature>-${test.info().project.name}`
+    // interact with control
+    // assert chart update
+    // element screenshot
+    const card = page.locator('[data-testid="<card-testid>"]')
+    await card.screenshot({
+      path: path.join(SCREENSHOT_DIR, `${prefix}-02-after-change.png`),
+    })
+  })
+
+  test('other tabs do not show new control', async ({ page }) => {
+    const prefix = `<feature>-${test.info().project.name}`
+    // click other tab
+    // assert new control not visible
+    await page.screenshot({
+      path: path.join(SCREENSHOT_DIR, `${prefix}-03-other-tab.png`),
+    })
+  })
+})
+```
+
+#### Scope Boundary Template
+
+Always document explicitly:
+
+- **Included**: what this plan changes
+- **Excluded**: what is deliberately deferred (note as follow-up)
+
+### Phase 5 — Plan Review & Save
+
+1. Save the complete plan to `/memories/session/plan.md` via the `memory` tool
+2. Present the plan to the user (the memory file is for persistence only — always show it)
+3. Iterate on feedback before handing off to implementation
+
+## Component Patterns Quick Reference
+
+### Conditional control rendering (only show on one tab)
+
+```tsx
+{period === 'month' && (
+  <Select value={...} onValueChange={...}>
+    ...
+  </Select>
+)}
+```
+
+### Compact header Select (matches heatmap style)
+
+```tsx
+<Select value={String(selected)} onValueChange={(v) => setSelected(Number(v))}>
+  <SelectTrigger className="h-7 w-24 text-xs">
+    <SelectValue />
+  </SelectTrigger>
+  <SelectContent>
+    {OPTIONS.map((opt) => (
+      <SelectItem key={opt.value} value={String(opt.value)}>
+        {opt.label}
+      </SelectItem>
+    ))}
+  </SelectContent>
+</Select>
+```
+
+### API-derived year range (matches heatmap pattern)
+
+```typescript
+const OLDEST_YEAR = minDateYear // from garminDateRange query
+const CURRENT_YEAR = new Date().getFullYear()
+const YEAR_OPTIONS = Array.from(
+  { length: CURRENT_YEAR - OLDEST_YEAR + 1 },
+  (_, i) => CURRENT_YEAR - i,
+)
+```
+
+### Monthly-by-year date range computation
+
+```typescript
+// First day of selected month across all available years
+const date_from = format(new Date(minYear, selectedMonth, 1), 'yyyy-MM-dd')
+// Last day of selected month in current/max year
+const date_to = format(
+  endOfMonth(new Date(maxYear, selectedMonth, 1)),
+  'yyyy-MM-dd',
+)
+```
+
+## Verification Checklist
+
+Before marking a plan ready for implementation, confirm:
+
+- [ ] Every screenshot annotation maps to at least one plan step
+- [ ] Component file and key symbols are identified (not just directory)
+- [ ] GraphQL query variable shapes are confirmed against `__generated__/graphql.ts`
+- [ ] Playwright spec file name follows `e2e/dashboard-<feature>.spec.ts` convention
+- [ ] Screenshot output path follows `e2e/screenshots/<feature>/` convention
+- [ ] Playwright spec was actually executed for the feature before completion
+- [ ] Screenshot artifacts were generated and available for examination
+- [ ] Excluded/deferred items are explicitly noted in scope decisions
+- [ ] Plan saved to `/memories/session/plan.md`

--- a/e2e/dashboard-activity-totals.spec.ts
+++ b/e2e/dashboard-activity-totals.spec.ts
@@ -1,0 +1,165 @@
+import { test, expect } from '@playwright/test'
+import fs from 'fs'
+import path from 'path'
+
+const SCREENSHOT_DIR = path.join('e2e', 'screenshots', 'activity-totals')
+
+fs.mkdirSync(SCREENSHOT_DIR, { recursive: true })
+
+/**
+ * Validates the Activity Totals dashboard card:
+ * - Monthly tab shows a month selector and renders bars by year
+ * - Month selector change re-renders the chart
+ * - Weekly and Yearly tabs do not show the month selector
+ * - Metric toggle works in monthly mode
+ *
+ * Screenshots are saved to e2e/screenshots/activity-totals/ for visual review.
+ */
+test.describe('Dashboard Activity Totals', () => {
+  test.setTimeout(60_000)
+
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/', { waitUntil: 'domcontentloaded' })
+    // Wait for dashboard stats to confirm page is fully loaded
+    await expect(page.getByText('Total Locations')).toBeVisible({
+      timeout: 30_000,
+    })
+  })
+
+  test('monthly tab shows month selector with current month default', async ({
+    page,
+  }) => {
+    const prefix = `activity-totals-${test.info().project.name}`
+
+    // Activity Totals card should be visible
+    const card = page.locator('[data-testid="activity-totals-card"]')
+    await expect(card).toBeVisible()
+
+    // Monthly should be the default active tab — "Monthly" button has aria-checked=true
+    const monthlyBtn = card.getByRole('radio', { name: 'Monthly' })
+    await expect(monthlyBtn).toHaveAttribute('aria-checked', 'true')
+
+    // Month selector combobox should be visible in monthly mode
+    const monthSelect = card.getByRole('combobox', { name: /select month/i })
+    await expect(monthSelect).toBeVisible()
+
+    // Subtitle should show the selected month name
+    const currentMonthName = new Date().toLocaleString('en-US', {
+      month: 'long',
+    })
+    await expect(
+      card.getByText(new RegExp(currentMonthName, 'i')),
+    ).toBeVisible()
+
+    // Full dashboard screenshot
+    await page.screenshot({
+      path: path.join(SCREENSHOT_DIR, `${prefix}-01-monthly-default.png`),
+      fullPage: true,
+    })
+
+    // Card-level screenshot
+    await card.screenshot({
+      path: path.join(SCREENSHOT_DIR, `${prefix}-02-monthly-card.png`),
+    })
+  })
+
+  test('changing month selector updates the chart', async ({ page }) => {
+    const prefix = `activity-totals-${test.info().project.name}`
+
+    const card = page.locator('[data-testid="activity-totals-card"]')
+    await expect(card).toBeVisible({ timeout: 15_000 })
+
+    // Ensure Monthly tab is active (default)
+    const monthlyBtn = card.getByRole('radio', { name: 'Monthly' })
+    await expect(monthlyBtn).toHaveAttribute('aria-checked', 'true')
+
+    // Open the month dropdown and select January
+    const monthSelect = card.getByRole('combobox', { name: /select month/i })
+    await monthSelect.click()
+    await page.getByRole('option', { name: 'Jan' }).click()
+
+    // Subtitle should now show January
+    await expect(card.getByText(/January/i)).toBeVisible({ timeout: 10_000 })
+
+    // Card screenshot after month change
+    await card.screenshot({
+      path: path.join(SCREENSHOT_DIR, `${prefix}-03-month-changed-jan.png`),
+    })
+  })
+
+  test('weekly tab does not show month selector', async ({ page }) => {
+    const prefix = `activity-totals-${test.info().project.name}`
+
+    const card = page.locator('[data-testid="activity-totals-card"]')
+    await expect(card).toBeVisible({ timeout: 15_000 })
+
+    // Click the Weekly tab
+    await card.getByRole('radio', { name: 'Weekly' }).click()
+    await expect(card.getByRole('radio', { name: 'Weekly' })).toHaveAttribute(
+      'aria-checked',
+      'true',
+    )
+
+    // Month selector should not be visible
+    await expect(
+      card.getByRole('combobox', { name: /select month/i }),
+    ).not.toBeVisible()
+
+    // Card screenshot with weekly mode active
+    await card.screenshot({
+      path: path.join(
+        SCREENSHOT_DIR,
+        `${prefix}-04-weekly-no-month-select.png`,
+      ),
+    })
+  })
+
+  test('yearly tab does not show month selector', async ({ page }) => {
+    const prefix = `activity-totals-${test.info().project.name}`
+
+    const card = page.locator('[data-testid="activity-totals-card"]')
+    await expect(card).toBeVisible({ timeout: 15_000 })
+
+    // Click the Yearly tab
+    await card.getByRole('radio', { name: 'Yearly' }).click()
+    await expect(card.getByRole('radio', { name: 'Yearly' })).toHaveAttribute(
+      'aria-checked',
+      'true',
+    )
+
+    // Month selector should not be visible
+    await expect(
+      card.getByRole('combobox', { name: /select month/i }),
+    ).not.toBeVisible()
+
+    // Card screenshot with yearly mode active
+    await card.screenshot({
+      path: path.join(
+        SCREENSHOT_DIR,
+        `${prefix}-05-yearly-no-month-select.png`,
+      ),
+    })
+  })
+
+  test('metric toggle works in monthly mode', async ({ page }) => {
+    const prefix = `activity-totals-${test.info().project.name}`
+
+    const card = page.locator('[data-testid="activity-totals-card"]')
+    await expect(card).toBeVisible({ timeout: 15_000 })
+
+    // Monthly is default — switch metric to Duration
+    await card.getByRole('radio', { name: 'Duration' }).click()
+    await expect(card.getByRole('radio', { name: 'Duration' })).toHaveAttribute(
+      'aria-checked',
+      'true',
+    )
+
+    // Card screenshot showing Duration metric in monthly mode
+    await card.screenshot({
+      path: path.join(
+        SCREENSHOT_DIR,
+        `${prefix}-06-monthly-metric-duration.png`,
+      ),
+    })
+  })
+})

--- a/src/components/dashboard/GarminActivityTotals.test.tsx
+++ b/src/components/dashboard/GarminActivityTotals.test.tsx
@@ -1,6 +1,9 @@
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
+import { format } from 'date-fns'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+let latestBarChartData: Array<Record<string, unknown>> = []
 
 const hooks = vi.hoisted(() => ({
   useGarminActivityTotalsQuery: vi.fn(),
@@ -9,22 +12,35 @@ const hooks = vi.hoisted(() => ({
 
 vi.mock('@/__generated__/graphql', () => hooks)
 
-// Recharts uses ResponsiveContainer which needs a sized parent in jsdom; stub it.
-vi.mock('recharts', async () => {
-  const actual = await vi.importActual<typeof import('recharts')>('recharts')
-  return {
-    ...actual,
-    ResponsiveContainer: ({ children }: { children: React.ReactNode }) => (
-      <div style={{ width: 800, height: 400 }}>{children}</div>
-    ),
-  }
-})
+// Keep Recharts mocked/lightweight and expose BarChart data for assertions.
+vi.mock('recharts', () => ({
+  ResponsiveContainer: ({ children }: { children: React.ReactNode }) => (
+    <div style={{ width: 800, height: 400 }}>{children}</div>
+  ),
+  BarChart: ({
+    data,
+    children,
+  }: {
+    data?: Array<Record<string, unknown>>
+    children?: React.ReactNode
+  }) => {
+    latestBarChartData = data ?? []
+    return <div data-testid="bar-chart">{children}</div>
+  },
+  CartesianGrid: () => null,
+  XAxis: () => null,
+  YAxis: () => null,
+  Tooltip: () => null,
+  Bar: () => null,
+}))
 
 import { GarminActivityTotals } from './GarminActivityTotals'
 
 describe('GarminActivityTotals', () => {
   beforeEach(() => {
+    latestBarChartData = []
     hooks.useGarminActivityTotalsQuery.mockReset()
+    hooks.useGarminDateRangeQuery.mockReset()
     hooks.useGarminDateRangeQuery.mockReturnValue({
       data: {
         garminDateRange: { min_date: '2010-01-01', max_date: '2026-12-31' },
@@ -101,12 +117,15 @@ describe('GarminActivityTotals', () => {
     render(<GarminActivityTotals />)
 
     // Default: month period, distance metric
+    const currentMonth = new Date().getMonth()
+    const expectedFrom = `2010-${String(currentMonth + 1).padStart(2, '0')}-01`
+    const expectedTo = format(new Date(2026, currentMonth + 1, 0), 'yyyy-MM-dd')
     expect(hooks.useGarminActivityTotalsQuery).toHaveBeenCalledWith(
       expect.objectContaining({
         variables: expect.objectContaining({
           period: 'month',
-          date_from: '2010-01-01',
-          date_to: '2026-12-31',
+          date_from: expectedFrom,
+          date_to: expectedTo,
         }),
       }),
     )
@@ -122,5 +141,96 @@ describe('GarminActivityTotals', () => {
       'aria-checked',
       'true',
     )
+  })
+
+  it('shows month selector and aggregates selected month buckets by year', () => {
+    const selectedMonth = new Date().getMonth()
+    const currentMonth = String(selectedMonth + 1).padStart(2, '0')
+    const excludedMonth = String(((selectedMonth + 1) % 12) + 1).padStart(
+      2,
+      '0',
+    )
+    const currentMonthName = new Date().toLocaleString('en-US', {
+      month: 'long',
+    })
+
+    hooks.useGarminActivityTotalsQuery.mockReturnValue({
+      data: {
+        garminActivityTotals: [
+          {
+            period_start: `2024-${currentMonth}-01`,
+            activity_count: 2,
+            total_distance_km: 10,
+            total_duration_seconds: 3600,
+            total_ascent_m: 100,
+            total_calories: 500,
+          },
+          {
+            period_start: `2024-${currentMonth}-15`,
+            activity_count: 1,
+            total_distance_km: 5,
+            total_duration_seconds: 1800,
+            total_ascent_m: 50,
+            total_calories: 200,
+          },
+          {
+            period_start: `2025-${currentMonth}-01`,
+            activity_count: 1,
+            total_distance_km: 7,
+            total_duration_seconds: 2400,
+            total_ascent_m: 70,
+            total_calories: 300,
+          },
+          {
+            period_start: `2025-${excludedMonth}-01`,
+            activity_count: 4,
+            total_distance_km: 99,
+            total_duration_seconds: 9999,
+            total_ascent_m: 999,
+            total_calories: 999,
+          },
+        ],
+      },
+      loading: false,
+      error: undefined,
+      refetch: vi.fn(),
+    })
+
+    render(<GarminActivityTotals />)
+
+    // Monthly mode shows the month selector and default month context.
+    const monthSelect = screen.getByRole('combobox', { name: /select month/i })
+    expect(monthSelect).toBeInTheDocument()
+    expect(
+      screen.getByText(new RegExp(`${currentMonthName} by year`, 'i')),
+    ).toBeInTheDocument()
+
+    // Date range should be constrained to selected month across min/max years.
+    const lastCall = hooks.useGarminActivityTotalsQuery.mock.calls.at(-1)?.[0]
+    expect(lastCall?.variables?.date_from).toBe(`2010-${currentMonth}-01`)
+    expect(lastCall?.variables?.date_to).toBe(
+      format(new Date(2026, selectedMonth + 1, 0), 'yyyy-MM-dd'),
+    )
+
+    // Chart data is aggregated by year for selected month only.
+    expect(latestBarChartData).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          label: '2024',
+          activity_count: 3,
+          distance_km: 15,
+          total_ascent_m: 150,
+          total_calories: 700,
+        }),
+        expect.objectContaining({
+          label: '2025',
+          activity_count: 1,
+          distance_km: 7,
+          total_ascent_m: 70,
+          total_calories: 300,
+        }),
+      ]),
+    )
+    expect(latestBarChartData).toHaveLength(2)
   })
 })

--- a/src/components/dashboard/GarminActivityTotals.test.tsx
+++ b/src/components/dashboard/GarminActivityTotals.test.tsx
@@ -4,6 +4,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const hooks = vi.hoisted(() => ({
   useGarminActivityTotalsQuery: vi.fn(),
+  useGarminDateRangeQuery: vi.fn(),
 }))
 
 vi.mock('@/__generated__/graphql', () => hooks)
@@ -24,6 +25,12 @@ import { GarminActivityTotals } from './GarminActivityTotals'
 describe('GarminActivityTotals', () => {
   beforeEach(() => {
     hooks.useGarminActivityTotalsQuery.mockReset()
+    hooks.useGarminDateRangeQuery.mockReturnValue({
+      data: {
+        garminDateRange: { min_date: '2010-01-01', max_date: '2026-12-31' },
+      },
+      loading: false,
+    })
   })
 
   it('renders a loading state while totals are loading', () => {
@@ -96,7 +103,11 @@ describe('GarminActivityTotals', () => {
     // Default: month period, distance metric
     expect(hooks.useGarminActivityTotalsQuery).toHaveBeenCalledWith(
       expect.objectContaining({
-        variables: expect.objectContaining({ period: 'month' }),
+        variables: expect.objectContaining({
+          period: 'month',
+          date_from: '2010-01-01',
+          date_to: '2026-12-31',
+        }),
       }),
     )
 

--- a/src/components/dashboard/GarminActivityTotals.tsx
+++ b/src/components/dashboard/GarminActivityTotals.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState } from 'react'
-import { format, subMonths, subWeeks, parseISO } from 'date-fns'
+import { format, parseISO, subWeeks } from 'date-fns'
 import {
   Bar,
   BarChart,
@@ -10,9 +10,19 @@ import {
   YAxis,
 } from 'recharts'
 import { TrendingUp } from 'lucide-react'
-import { useGarminActivityTotalsQuery } from '@/__generated__/graphql'
+import {
+  useGarminActivityTotalsQuery,
+  useGarminDateRangeQuery,
+} from '@/__generated__/graphql'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
 import { LoadingState } from '@/components/shared/LoadingState'
 import { ErrorState } from '@/components/shared/ErrorState'
 import { cn } from '@/lib/utils'
@@ -67,6 +77,36 @@ function SegmentedControl<T extends string>({
 
 type Period = 'week' | 'month' | 'year'
 type Metric = 'distance' | 'duration' | 'ascent' | 'calories'
+
+const MONTH_LABELS = [
+  'Jan',
+  'Feb',
+  'Mar',
+  'Apr',
+  'May',
+  'Jun',
+  'Jul',
+  'Aug',
+  'Sep',
+  'Oct',
+  'Nov',
+  'Dec',
+]
+
+const MONTH_FULL_NAMES = [
+  'January',
+  'February',
+  'March',
+  'April',
+  'May',
+  'June',
+  'July',
+  'August',
+  'September',
+  'October',
+  'November',
+  'December',
+]
 
 interface MetricConfig {
   key: Metric
@@ -126,7 +166,7 @@ interface ChartBucket {
   total_calories: number
 }
 
-function getDateRange(period: Period): {
+function getDateRange(period: Exclude<Period, 'month'>): {
   date_from?: string
   date_to?: string
 } {
@@ -135,18 +175,27 @@ function getDateRange(period: Period): {
   if (period === 'week') {
     return { date_from: format(subWeeks(today, 12), 'yyyy-MM-dd'), date_to }
   }
-  if (period === 'month') {
-    return { date_from: format(subMonths(today, 12), 'yyyy-MM-dd'), date_to }
-  }
   // 'year' — let the API return all available history
   return {}
+}
+
+function toDateOnly(value?: string | null): string | undefined {
+  if (!value) return undefined
+
+  const parsed = parseISO(value)
+  if (!Number.isNaN(parsed.getTime())) {
+    return format(parsed, 'yyyy-MM-dd')
+  }
+
+  // Fallback for already-date-like strings that parseISO rejected.
+  return value.slice(0, 10)
 }
 
 function formatBucketLabel(period_start: string, period: Period): string {
   try {
     const date = parseISO(period_start)
     if (period === 'year') return format(date, 'yyyy')
-    if (period === 'month') return format(date, "MMM ''yy")
+    if (period === 'month') return format(date, 'yyyy')
     return format(date, 'MMM d')
   } catch {
     return period_start
@@ -156,8 +205,25 @@ function formatBucketLabel(period_start: string, period: Period): string {
 export function GarminActivityTotals() {
   const [period, setPeriod] = useState<Period>('month')
   const [metric, setMetric] = useState<Metric>('distance')
+  const [selectedMonth, setSelectedMonth] = useState<number>(
+    new Date().getMonth(),
+  )
 
-  const range = getDateRange(period)
+  // Fetch Garmin date range so monthly mode can request full history,
+  // then filter to one selected month across all years on the client.
+  const { data: dateRangeData } = useGarminDateRangeQuery()
+
+  // Build query date range depending on period
+  const range = useMemo(() => {
+    if (period === 'month') {
+      return {
+        date_from: toDateOnly(dateRangeData?.garminDateRange?.min_date),
+        date_to: toDateOnly(dateRangeData?.garminDateRange?.max_date),
+      }
+    }
+    return getDateRange(period)
+  }, [period, dateRangeData])
+
   const { data, loading, error, refetch } = useGarminActivityTotalsQuery({
     variables: {
       period,
@@ -168,7 +234,7 @@ export function GarminActivityTotals() {
 
   const chartData = useMemo<ChartBucket[]>(() => {
     const totals = data?.garminActivityTotals ?? []
-    return totals.map((t) => ({
+    const mapped = totals.map((t) => ({
       period_start: t.period_start,
       label: formatBucketLabel(t.period_start, period),
       activity_count: t.activity_count,
@@ -177,28 +243,93 @@ export function GarminActivityTotals() {
       total_ascent_m: t.total_ascent_m ?? 0,
       total_calories: t.total_calories ?? 0,
     }))
-  }, [data, period])
+
+    if (period !== 'month') {
+      return mapped
+    }
+
+    const byYear = new Map<string, ChartBucket>()
+
+    for (const bucket of mapped) {
+      const bucketDate = parseISO(bucket.period_start)
+      if (Number.isNaN(bucketDate.getTime())) {
+        continue
+      }
+
+      if (bucketDate.getMonth() !== selectedMonth) {
+        continue
+      }
+
+      const year = format(bucketDate, 'yyyy')
+      const existing = byYear.get(year)
+
+      if (!existing) {
+        byYear.set(year, { ...bucket, label: year })
+        continue
+      }
+
+      byYear.set(year, {
+        ...existing,
+        activity_count: existing.activity_count + bucket.activity_count,
+        distance_km: existing.distance_km + bucket.distance_km,
+        duration_hours: existing.duration_hours + bucket.duration_hours,
+        total_ascent_m: existing.total_ascent_m + bucket.total_ascent_m,
+        total_calories: existing.total_calories + bucket.total_calories,
+      })
+    }
+
+    return Array.from(byYear.values()).sort((a, b) =>
+      a.label.localeCompare(b.label),
+    )
+  }, [data, period, selectedMonth])
 
   const metricConfig = METRICS.find((m) => m.key === metric) ?? METRICS[0]
 
   return (
-    <Card>
+    <Card data-testid="activity-totals-card">
       <CardHeader>
         <CardTitle className="flex items-center gap-2">
           <TrendingUp className="h-5 w-5" />
           Activity Totals
+          {period === 'month' && (
+            <span className="text-sm font-normal text-muted-foreground">
+              — {MONTH_FULL_NAMES[selectedMonth]} by year
+            </span>
+          )}
         </CardTitle>
         <div className="flex flex-col gap-2 pt-2 sm:flex-row sm:items-center sm:justify-between">
-          <SegmentedControl<Period>
-            ariaLabel="Aggregation period"
-            value={period}
-            onChange={setPeriod}
-            options={[
-              { value: 'week', label: 'Weekly' },
-              { value: 'month', label: 'Monthly' },
-              { value: 'year', label: 'Yearly' },
-            ]}
-          />
+          <div className="flex items-center gap-2">
+            <SegmentedControl<Period>
+              ariaLabel="Aggregation period"
+              value={period}
+              onChange={setPeriod}
+              options={[
+                { value: 'week', label: 'Weekly' },
+                { value: 'month', label: 'Monthly' },
+                { value: 'year', label: 'Yearly' },
+              ]}
+            />
+            {period === 'month' && (
+              <Select
+                value={String(selectedMonth)}
+                onValueChange={(v) => setSelectedMonth(Number(v))}
+              >
+                <SelectTrigger
+                  className="h-7 w-24 text-xs"
+                  aria-label="Select month"
+                >
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {MONTH_LABELS.map((label, index) => (
+                    <SelectItem key={index} value={String(index)}>
+                      {label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            )}
+          </div>
           <SegmentedControl<Metric>
             ariaLabel="Metric"
             value={metric}

--- a/src/components/dashboard/GarminActivityTotals.tsx
+++ b/src/components/dashboard/GarminActivityTotals.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState } from 'react'
-import { format, parseISO, subWeeks } from 'date-fns'
+import { endOfMonth, format, parseISO, subWeeks } from 'date-fns'
 import {
   Bar,
   BarChart,
@@ -179,16 +179,11 @@ function getDateRange(period: Exclude<Period, 'month'>): {
   return {}
 }
 
-function toDateOnly(value?: string | null): string | undefined {
+function getYearFromDateString(value?: string | null): number | undefined {
   if (!value) return undefined
-
-  const parsed = parseISO(value)
-  if (!Number.isNaN(parsed.getTime())) {
-    return format(parsed, 'yyyy-MM-dd')
-  }
-
-  // Fallback for already-date-like strings that parseISO rejected.
-  return value.slice(0, 10)
+  const yearPrefix = value.slice(0, 4)
+  const year = Number(yearPrefix)
+  return Number.isFinite(year) ? year : undefined
 }
 
 function formatBucketLabel(period_start: string, period: Period): string {
@@ -216,13 +211,24 @@ export function GarminActivityTotals() {
   // Build query date range depending on period
   const range = useMemo(() => {
     if (period === 'month') {
+      const currentYear = new Date().getFullYear()
+      const minYear =
+        getYearFromDateString(dateRangeData?.garminDateRange?.min_date) ??
+        currentYear
+      const maxYear =
+        getYearFromDateString(dateRangeData?.garminDateRange?.max_date) ??
+        currentYear
+
       return {
-        date_from: toDateOnly(dateRangeData?.garminDateRange?.min_date),
-        date_to: toDateOnly(dateRangeData?.garminDateRange?.max_date),
+        date_from: format(new Date(minYear, selectedMonth, 1), 'yyyy-MM-dd'),
+        date_to: format(
+          endOfMonth(new Date(maxYear, selectedMonth, 1)),
+          'yyyy-MM-dd',
+        ),
       }
     }
     return getDateRange(period)
-  }, [period, dateRangeData])
+  }, [period, selectedMonth, dateRangeData])
 
   const { data, loading, error, refetch } = useGarminActivityTotalsQuery({
     variables: {

--- a/src/pages/DashboardPage.test.tsx
+++ b/src/pages/DashboardPage.test.tsx
@@ -10,6 +10,7 @@ const dashboardHooks = vi.hoisted(() => ({
   useDailySummaryQuery: vi.fn(),
   useGarminActivitiesQuery: vi.fn(),
   useGarminActivityTotalsQuery: vi.fn(),
+  useGarminDateRangeQuery: vi.fn(),
   useTriggerGarminSyncMutation: vi
     .fn()
     .mockReturnValue([vi.fn(), { loading: false }]),
@@ -48,6 +49,12 @@ describe('DashboardPage', () => {
       data: undefined,
       loading: false,
       refetch: vi.fn(),
+    })
+    dashboardHooks.useGarminDateRangeQuery.mockReturnValue({
+      data: {
+        garminDateRange: { min_date: '2010-01-01', max_date: '2026-12-31' },
+      },
+      loading: false,
     })
   })
 


### PR DESCRIPTION
## Summary
- fix Activity Totals monthly mode to show selected month aggregated by year
- normalize Garmin date-range query params to YYYY-MM-DD to avoid 422 errors
- add/update tests and Playwright screenshot validation
- enforce skill completion gate requiring Playwright run + screenshot output

## Validation
- npm run lint:all
- npm run type-check
- npm run test:run
- npm run build
- BASE_URL=http://localhost:5174 npx playwright test e2e/dashboard-activity-totals.spec.ts --project=chromium

Refs #N/A