### PR TITLE
feat(dashboard): weekly activity totals by year with pagination

### DIFF
--- a/e2e/dashboard-activity-totals.spec.ts
+++ b/e2e/dashboard-activity-totals.spec.ts
@@ -87,7 +87,9 @@ test.describe('Dashboard Activity Totals', () => {
     })
   })
 
-  test('weekly tab does not show month selector', async ({ page }) => {
+  test('weekly tab shows pagination pill and hides month selector', async ({
+    page,
+  }) => {
     const prefix = `activity-totals-${test.info().project.name}`
 
     const card = page.locator('[data-testid="activity-totals-card"]')
@@ -105,12 +107,39 @@ test.describe('Dashboard Activity Totals', () => {
       card.getByRole('combobox', { name: /select month/i }),
     ).not.toBeVisible()
 
-    // Card screenshot with weekly mode active
+    // Week range pill and Prev/Next buttons should be visible
+    const pill = card.getByTestId('week-range-pill')
+    await expect(pill).toBeVisible()
+    const initialPillText = (await pill.textContent())?.trim() ?? ''
+    expect(initialPillText).toMatch(/\w{3} \d+ – \w{3} \d+/)
+    await expect(
+      card.getByRole('button', { name: /previous week/i }),
+    ).toBeVisible()
+    await expect(card.getByRole('button', { name: /next week/i })).toBeVisible()
+
+    // Subtitle should reflect "by year" suffix
+    await expect(card.getByText(/by year/i)).toBeVisible()
+
     await card.screenshot({
-      path: path.join(
-        SCREENSHOT_DIR,
-        `${prefix}-04-weekly-no-month-select.png`,
-      ),
+      path: path.join(SCREENSHOT_DIR, `${prefix}-04-weekly-default.png`),
+    })
+
+    // Click Previous week — pill text should change
+    await card.getByRole('button', { name: /previous week/i }).click()
+    await expect(pill).not.toHaveText(initialPillText)
+    const prevPillText = (await pill.textContent())?.trim() ?? ''
+
+    await card.screenshot({
+      path: path.join(SCREENSHOT_DIR, `${prefix}-05-weekly-prev.png`),
+    })
+
+    // Click Next week — should return to original window
+    await card.getByRole('button', { name: /next week/i }).click()
+    await expect(pill).toHaveText(initialPillText)
+    expect(prevPillText).not.toBe(initialPillText)
+
+    await card.screenshot({
+      path: path.join(SCREENSHOT_DIR, `${prefix}-06-weekly-next.png`),
     })
   })
 
@@ -136,7 +165,7 @@ test.describe('Dashboard Activity Totals', () => {
     await card.screenshot({
       path: path.join(
         SCREENSHOT_DIR,
-        `${prefix}-05-yearly-no-month-select.png`,
+        `${prefix}-07-yearly-no-month-select.png`,
       ),
     })
   })
@@ -158,7 +187,7 @@ test.describe('Dashboard Activity Totals', () => {
     await card.screenshot({
       path: path.join(
         SCREENSHOT_DIR,
-        `${prefix}-06-monthly-metric-duration.png`,
+        `${prefix}-08-monthly-metric-duration.png`,
       ),
     })
   })

--- a/e2e/dashboard-activity-totals.spec.ts
+++ b/e2e/dashboard-activity-totals.spec.ts
@@ -120,6 +120,11 @@ test.describe('Dashboard Activity Totals', () => {
     // Subtitle should reflect "by year" suffix
     await expect(card.getByText(/by year/i)).toBeVisible()
 
+    // Wait for chart to finish loading before screenshot
+    await expect(card.getByText(/loading activity totals/i)).toBeHidden({
+      timeout: 15_000,
+    })
+
     await card.screenshot({
       path: path.join(SCREENSHOT_DIR, `${prefix}-04-weekly-default.png`),
     })
@@ -128,6 +133,9 @@ test.describe('Dashboard Activity Totals', () => {
     await card.getByRole('button', { name: /previous week/i }).click()
     await expect(pill).not.toHaveText(initialPillText)
     const prevPillText = (await pill.textContent())?.trim() ?? ''
+    await expect(card.getByText(/loading activity totals/i)).toBeHidden({
+      timeout: 15_000,
+    })
 
     await card.screenshot({
       path: path.join(SCREENSHOT_DIR, `${prefix}-05-weekly-prev.png`),
@@ -137,6 +145,9 @@ test.describe('Dashboard Activity Totals', () => {
     await card.getByRole('button', { name: /next week/i }).click()
     await expect(pill).toHaveText(initialPillText)
     expect(prevPillText).not.toBe(initialPillText)
+    await expect(card.getByText(/loading activity totals/i)).toBeHidden({
+      timeout: 15_000,
+    })
 
     await card.screenshot({
       path: path.join(SCREENSHOT_DIR, `${prefix}-06-weekly-next.png`),

--- a/src/components/dashboard/GarminActivityTotals.test.tsx
+++ b/src/components/dashboard/GarminActivityTotals.test.tsx
@@ -1,6 +1,6 @@
-import { render, screen } from '@testing-library/react'
+import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { format } from 'date-fns'
+import { format, subDays } from 'date-fns'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 let latestBarChartData: Array<Record<string, unknown>> = []
@@ -8,9 +8,18 @@ let latestBarChartData: Array<Record<string, unknown>> = []
 const hooks = vi.hoisted(() => ({
   useGarminActivityTotalsQuery: vi.fn(),
   useGarminDateRangeQuery: vi.fn(),
+  GarminActivityTotalsDocument: { kind: 'Document' },
+}))
+
+const apolloMocks = vi.hoisted(() => ({
+  useApolloClient: vi.fn(),
+  query: vi.fn(),
 }))
 
 vi.mock('@/__generated__/graphql', () => hooks)
+vi.mock('@apollo/client/react', () => ({
+  useApolloClient: apolloMocks.useApolloClient,
+}))
 
 // Keep Recharts mocked/lightweight and expose BarChart data for assertions.
 vi.mock('recharts', () => ({
@@ -47,6 +56,12 @@ describe('GarminActivityTotals', () => {
       },
       loading: false,
     })
+    apolloMocks.useApolloClient.mockReset()
+    apolloMocks.query.mockReset()
+    apolloMocks.query.mockResolvedValue({
+      data: { garminActivityTotals: [] },
+    })
+    apolloMocks.useApolloClient.mockReturnValue({ query: apolloMocks.query })
   })
 
   it('renders a loading state while totals are loading', () => {
@@ -130,10 +145,25 @@ describe('GarminActivityTotals', () => {
       }),
     )
 
-    // Switch to weekly
+    // Switch to weekly: main hook is skipped; per-year imperative queries fire.
     await user.click(screen.getByRole('radio', { name: 'Weekly' }))
-    const lastCall = hooks.useGarminActivityTotalsQuery.mock.calls.at(-1)?.[0]
-    expect(lastCall?.variables?.period).toBe('week')
+    await waitFor(() => {
+      expect(apolloMocks.query).toHaveBeenCalled()
+    })
+    const lastApolloCall = apolloMocks.query.mock.calls.at(-1)?.[0]
+    expect(lastApolloCall?.variables?.period).toBe('week')
+    // Default window: today minus 6 days … today, projected per year.
+    const today = new Date()
+    const start = subDays(today, 6)
+    // Most recent year query should target the current-year window.
+    const currentYearCalls = apolloMocks.query.mock.calls.filter((c) => {
+      const v = c[0]?.variables
+      return v?.date_to === format(today, 'yyyy-MM-dd')
+    })
+    expect(currentYearCalls.length).toBeGreaterThan(0)
+    expect(currentYearCalls[0][0].variables.date_from).toBe(
+      format(start, 'yyyy-MM-dd'),
+    )
 
     // Switch metric to Calories — radio should reflect it
     await user.click(screen.getByRole('radio', { name: 'Calories' }))
@@ -232,5 +262,145 @@ describe('GarminActivityTotals', () => {
       ]),
     )
     expect(latestBarChartData).toHaveLength(2)
+  })
+
+  it('weekly mode renders default 7-day window pill and projects per year', async () => {
+    hooks.useGarminActivityTotalsQuery.mockReturnValue({
+      data: undefined,
+      loading: false,
+      error: undefined,
+      refetch: vi.fn(),
+    })
+    // Each year-query returns one bucket with year-derived totals.
+    apolloMocks.query.mockImplementation(({ variables }) => {
+      const year = Number(variables.date_to.slice(0, 4))
+      return Promise.resolve({
+        data: {
+          garminActivityTotals: [
+            {
+              period_start: variables.date_from,
+              activity_count: 1,
+              total_distance_km: year - 2000,
+              total_duration_seconds: 3600,
+              total_ascent_m: 10,
+              total_calories: 100,
+            },
+          ],
+        },
+      })
+    })
+
+    const user = userEvent.setup()
+    render(<GarminActivityTotals />)
+
+    await user.click(screen.getByRole('radio', { name: 'Weekly' }))
+
+    // Pill renders the current 7-day window.
+    const today = new Date()
+    const start = subDays(today, 6)
+    const expectedLabel = `${format(start, 'MMM d')} – ${format(today, 'MMM d')}`
+    await waitFor(() => {
+      expect(screen.getByTestId('week-range-pill')).toHaveTextContent(
+        expectedLabel,
+      )
+    })
+
+    // One query per year from min_date (2010) to weekEnd year.
+    const expectedYears = today.getFullYear() - 2010 + 1
+    await waitFor(() => {
+      expect(apolloMocks.query).toHaveBeenCalledTimes(expectedYears)
+    })
+
+    // Chart data has one bar per year, distance increasing with year.
+    await waitFor(() => {
+      expect(latestBarChartData.length).toBe(expectedYears)
+    })
+    expect(latestBarChartData[0]).toEqual(
+      expect.objectContaining({ label: '2010', distance_km: 10 }),
+    )
+    expect(latestBarChartData.at(-1)).toEqual(
+      expect.objectContaining({ label: String(today.getFullYear()) }),
+    )
+  })
+
+  it('weekly mode pages backward and forward by 7 days', async () => {
+    hooks.useGarminActivityTotalsQuery.mockReturnValue({
+      data: undefined,
+      loading: false,
+      error: undefined,
+      refetch: vi.fn(),
+    })
+
+    const user = userEvent.setup()
+    render(<GarminActivityTotals />)
+
+    await user.click(screen.getByRole('radio', { name: 'Weekly' }))
+
+    const today = new Date()
+    const initialStart = subDays(today, 6)
+    await waitFor(() => {
+      expect(screen.getByTestId('week-range-pill')).toHaveTextContent(
+        `${format(initialStart, 'MMM d')} – ${format(today, 'MMM d')}`,
+      )
+    })
+
+    // Prev shifts window back 7 days.
+    apolloMocks.query.mockClear()
+    await user.click(screen.getByRole('button', { name: /previous week/i }))
+    const prevEnd = subDays(today, 7)
+    const prevStart = subDays(prevEnd, 6)
+    await waitFor(() => {
+      expect(screen.getByTestId('week-range-pill')).toHaveTextContent(
+        `${format(prevStart, 'MMM d')} – ${format(prevEnd, 'MMM d')}`,
+      )
+    })
+
+    // Next shifts back to original window.
+    await user.click(screen.getByRole('button', { name: /next week/i }))
+    await waitFor(() => {
+      expect(screen.getByTestId('week-range-pill')).toHaveTextContent(
+        `${format(initialStart, 'MMM d')} – ${format(today, 'MMM d')}`,
+      )
+    })
+  })
+
+  it('weekly mode hides month selector and shows pagination only in week mode', async () => {
+    hooks.useGarminActivityTotalsQuery.mockReturnValue({
+      data: { garminActivityTotals: [] },
+      loading: false,
+      error: undefined,
+      refetch: vi.fn(),
+    })
+
+    const user = userEvent.setup()
+    render(<GarminActivityTotals />)
+
+    // Default is monthly: month selector visible, pagination not rendered.
+    expect(
+      screen.getByRole('combobox', { name: /select month/i }),
+    ).toBeInTheDocument()
+    expect(
+      screen.queryByRole('button', { name: /previous week/i }),
+    ).not.toBeInTheDocument()
+
+    // Switch to weekly: pagination appears, month selector disappears.
+    await user.click(screen.getByRole('radio', { name: 'Weekly' }))
+    await waitFor(() => {
+      expect(
+        screen.getByRole('button', { name: /previous week/i }),
+      ).toBeInTheDocument()
+    })
+    expect(
+      screen.queryByRole('combobox', { name: /select month/i }),
+    ).not.toBeInTheDocument()
+
+    // Switch back to monthly: pagination disappears, month selector returns.
+    await user.click(screen.getByRole('radio', { name: 'Monthly' }))
+    expect(
+      screen.queryByRole('button', { name: /previous week/i }),
+    ).not.toBeInTheDocument()
+    expect(
+      screen.getByRole('combobox', { name: /select month/i }),
+    ).toBeInTheDocument()
   })
 })

--- a/src/components/dashboard/GarminActivityTotals.test.tsx
+++ b/src/components/dashboard/GarminActivityTotals.test.tsx
@@ -242,7 +242,8 @@ describe('GarminActivityTotals', () => {
       format(new Date(2026, selectedMonth + 1, 0), 'yyyy-MM-dd'),
     )
 
-    // Chart data is aggregated by year for selected month only.
+    // Chart data is aggregated by year for selected month only, with all
+    // years in the Garmin date range zero-filled so the x-axis is continuous.
     expect(latestBarChartData).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
@@ -261,7 +262,18 @@ describe('GarminActivityTotals', () => {
         }),
       ]),
     )
-    expect(latestBarChartData).toHaveLength(2)
+    // 2010..2026 inclusive = 17 years.
+    expect(latestBarChartData).toHaveLength(17)
+    // Years without activity should appear as zero buckets.
+    expect(latestBarChartData).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          label: '2011',
+          activity_count: 0,
+          distance_km: 0,
+        }),
+      ]),
+    )
   })
 
   it('weekly mode renders default 7-day window pill and projects per year', async () => {

--- a/src/components/dashboard/GarminActivityTotals.test.tsx
+++ b/src/components/dashboard/GarminActivityTotals.test.tsx
@@ -1,7 +1,11 @@
 import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { format, subDays } from 'date-fns'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Freeze the system clock so weekly-mode tests that derive labels and query
+// variables from `new Date()` are deterministic regardless of when CI runs.
+const FROZEN_NOW = new Date('2026-04-15T12:00:00Z')
 
 let latestBarChartData: Array<Record<string, unknown>> = []
 
@@ -47,6 +51,11 @@ import { GarminActivityTotals } from './GarminActivityTotals'
 
 describe('GarminActivityTotals', () => {
   beforeEach(() => {
+    vi.useFakeTimers({
+      now: FROZEN_NOW,
+      shouldAdvanceTime: true,
+      toFake: ['Date'],
+    })
     latestBarChartData = []
     hooks.useGarminActivityTotalsQuery.mockReset()
     hooks.useGarminDateRangeQuery.mockReset()
@@ -62,6 +71,10 @@ describe('GarminActivityTotals', () => {
       data: { garminActivityTotals: [] },
     })
     apolloMocks.useApolloClient.mockReturnValue({ query: apolloMocks.query })
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
   })
 
   it('renders a loading state while totals are loading', () => {

--- a/src/components/dashboard/GarminActivityTotals.tsx
+++ b/src/components/dashboard/GarminActivityTotals.tsx
@@ -360,7 +360,7 @@ export function GarminActivityTotals() {
       total_calories: t.total_calories ?? 0,
     }))
 
-    if (period !== 'month') {
+    if (period !== 'month' && period !== 'year') {
       return mapped
     }
 
@@ -371,13 +371,16 @@ export function GarminActivityTotals() {
     }
 
     // Seed every year in the known Garmin range with a zero bucket so the
-    // chart shows a continuous x-axis even when some years have no activity
-    // for the selected month.
+    // chart shows a continuous x-axis even when some years have no activity.
     const byYear = new Map<string, ChartBucket>()
     for (const year of yearList) {
       const yearStr = String(year)
+      const periodStart =
+        period === 'month'
+          ? `${yearStr}-${String(selectedMonth + 1).padStart(2, '0')}-01`
+          : `${yearStr}-01-01`
       byYear.set(yearStr, {
-        period_start: `${yearStr}-${String(selectedMonth + 1).padStart(2, '0')}-01`,
+        period_start: periodStart,
         label: yearStr,
         activity_count: 0,
         distance_km: 0,
@@ -393,7 +396,7 @@ export function GarminActivityTotals() {
         continue
       }
 
-      if (bucketDate.getMonth() !== selectedMonth) {
+      if (period === 'month' && bucketDate.getMonth() !== selectedMonth) {
         continue
       }
 

--- a/src/components/dashboard/GarminActivityTotals.tsx
+++ b/src/components/dashboard/GarminActivityTotals.tsx
@@ -364,7 +364,28 @@ export function GarminActivityTotals() {
       return mapped
     }
 
+    // Preserve the "no Garmin data" empty state — if the API returned no
+    // buckets at all, render nothing rather than zero-filled bars.
+    if (mapped.length === 0) {
+      return []
+    }
+
+    // Seed every year in the known Garmin range with a zero bucket so the
+    // chart shows a continuous x-axis even when some years have no activity
+    // for the selected month.
     const byYear = new Map<string, ChartBucket>()
+    for (const year of yearList) {
+      const yearStr = String(year)
+      byYear.set(yearStr, {
+        period_start: `${yearStr}-${String(selectedMonth + 1).padStart(2, '0')}-01`,
+        label: yearStr,
+        activity_count: 0,
+        distance_km: 0,
+        duration_hours: 0,
+        total_ascent_m: 0,
+        total_calories: 0,
+      })
+    }
 
     for (const bucket of mapped) {
       const bucketDate = parseISO(bucket.period_start)
@@ -397,7 +418,7 @@ export function GarminActivityTotals() {
     return Array.from(byYear.values()).sort((a, b) =>
       a.label.localeCompare(b.label),
     )
-  }, [data, period, selectedMonth, weeklyByYear])
+  }, [data, period, selectedMonth, weeklyByYear, yearList])
 
   const metricConfig = METRICS.find((m) => m.key === metric) ?? METRICS[0]
 

--- a/src/components/dashboard/GarminActivityTotals.tsx
+++ b/src/components/dashboard/GarminActivityTotals.tsx
@@ -276,15 +276,27 @@ export function GarminActivityTotals() {
 
     const baseEndYear = weekEnd.getFullYear()
 
+    // Project a date into a target year by preserving month/day and clamping
+    // invalid dates (e.g. Feb 29 in a non-leap year) to the last valid day of
+    // that month. Avoids the silent date-shift produced by Date#setFullYear.
+    const projectToYear = (source: Date, targetYear: number): Date => {
+      const month = source.getMonth()
+      const day = source.getDate()
+      // Day 0 of next month yields the last day of the current month.
+      const lastDay = new Date(targetYear, month + 1, 0).getDate()
+      return new Date(targetYear, month, Math.min(day, lastDay))
+    }
+
     const run = async () => {
       setWeeklyLoading(true)
       setWeeklyError(null)
-      const promises = yearList.map(async (year) => {
-        const offset = year - baseEndYear
-        const ws = new Date(weekStart)
-        ws.setFullYear(weekStart.getFullYear() + offset)
-        const we = new Date(weekEnd)
-        we.setFullYear(weekEnd.getFullYear() + offset)
+
+      const fetchYear = async (year: number): Promise<ChartBucket> => {
+        const ws = projectToYear(
+          weekStart,
+          weekStart.getFullYear() + (year - baseEndYear),
+        )
+        const we = projectToYear(weekEnd, year)
         const result = await apolloClient.query<
           GarminActivityTotalsQuery,
           GarminActivityTotalsQueryVariables
@@ -298,7 +310,7 @@ export function GarminActivityTotals() {
           fetchPolicy: 'cache-first',
         })
         const buckets = result.data?.garminActivityTotals ?? []
-        const summed: ChartBucket = buckets.reduce<ChartBucket>(
+        return buckets.reduce<ChartBucket>(
           (acc, b) => ({
             period_start: acc.period_start,
             label: String(year),
@@ -319,11 +331,23 @@ export function GarminActivityTotals() {
             total_calories: 0,
           },
         )
-        return summed
-      })
+      }
 
+      // Limit concurrency so dashboards with long Garmin history don't fan
+      // out N parallel requests on every Prev/Next click. Apollo's cache-first
+      // policy means subsequent renders short-circuit; the limit only affects
+      // initial loads of unseen windows.
+      const CONCURRENCY = 4
+      const results: ChartBucket[] = new Array(yearList.length)
       try {
-        const results = await Promise.all(promises)
+        for (let i = 0; i < yearList.length; i += CONCURRENCY) {
+          if (cancelled) return
+          const batch = yearList.slice(i, i + CONCURRENCY)
+          const batchResults = await Promise.all(batch.map(fetchYear))
+          batchResults.forEach((b, j) => {
+            results[i + j] = b
+          })
+        }
         if (cancelled) return
         setWeeklyByYear(results.sort((a, b) => a.label.localeCompare(b.label)))
         setWeeklyLoading(false)

--- a/src/components/dashboard/GarminActivityTotals.tsx
+++ b/src/components/dashboard/GarminActivityTotals.tsx
@@ -1,5 +1,5 @@
-import { useMemo, useState } from 'react'
-import { endOfMonth, format, parseISO, subWeeks } from 'date-fns'
+import { useEffect, useMemo, useState } from 'react'
+import { addDays, endOfMonth, format, parseISO, subDays } from 'date-fns'
 import {
   Bar,
   BarChart,
@@ -9,8 +9,12 @@ import {
   XAxis,
   YAxis,
 } from 'recharts'
-import { TrendingUp } from 'lucide-react'
+import { ChevronLeft, ChevronRight, TrendingUp } from 'lucide-react'
+import { useApolloClient } from '@apollo/client/react'
 import {
+  GarminActivityTotalsDocument,
+  type GarminActivityTotalsQuery,
+  type GarminActivityTotalsQueryVariables,
   useGarminActivityTotalsQuery,
   useGarminDateRangeQuery,
 } from '@/__generated__/graphql'
@@ -166,16 +170,12 @@ interface ChartBucket {
   total_calories: number
 }
 
-function getDateRange(period: Exclude<Period, 'month'>): {
+function getDateRange(period: 'year'): {
   date_from?: string
   date_to?: string
 } {
-  const today = new Date()
-  const date_to = format(today, 'yyyy-MM-dd')
-  if (period === 'week') {
-    return { date_from: format(subWeeks(today, 12), 'yyyy-MM-dd'), date_to }
-  }
   // 'year' — let the API return all available history
+  void period
   return {}
 }
 
@@ -203,6 +203,17 @@ export function GarminActivityTotals() {
   const [selectedMonth, setSelectedMonth] = useState<number>(
     new Date().getMonth(),
   )
+  // Anchor date for the trailing 7-day window in weekly mode. Defaults to
+  // today; Prev/Next pages by 7 days. Future dates are allowed.
+  const [weekEnd, setWeekEnd] = useState<Date>(() => new Date())
+  const weekStart = useMemo(() => subDays(weekEnd, 6), [weekEnd])
+
+  // Per-year aggregated totals for weekly mode (one entry per year, summed
+  // across the projected 7-day window for that year).
+  const [weeklyByYear, setWeeklyByYear] = useState<ChartBucket[]>([])
+  const [weeklyLoading, setWeeklyLoading] = useState(false)
+  const [weeklyError, setWeeklyError] = useState<Error | null>(null)
+  const apolloClient = useApolloClient()
 
   // Fetch Garmin date range so monthly mode can request full history,
   // then filter to one selected month across all years on the client.
@@ -227,7 +238,11 @@ export function GarminActivityTotals() {
         ),
       }
     }
-    return getDateRange(period)
+    if (period === 'year') {
+      return getDateRange('year')
+    }
+    // 'week' uses a separate per-year fetch path; no main-query range.
+    return {}
   }, [period, selectedMonth, dateRangeData])
 
   const { data, loading, error, refetch } = useGarminActivityTotalsQuery({
@@ -236,9 +251,104 @@ export function GarminActivityTotals() {
       date_from: range.date_from,
       date_to: range.date_to,
     },
+    skip: period === 'week',
   })
 
+  // Year list spanning known Garmin history.
+  const yearList = useMemo(() => {
+    const currentYear = new Date().getFullYear()
+    const minYear =
+      getYearFromDateString(dateRangeData?.garminDateRange?.min_date) ??
+      currentYear
+    const maxYear = Math.max(currentYear, weekEnd.getFullYear())
+    const years: number[] = []
+    for (let y = minYear; y <= maxYear; y += 1) years.push(y)
+    return years
+  }, [dateRangeData, weekEnd])
+
+  // Weekly mode: fire one query per year for the projected 7-day window.
+  // Sum returned weekly buckets per year (the API filters by date_from/date_to
+  // before grouping, so summing all rows yields the correct window total even
+  // when DATE_TRUNC('week', ...) splits the window across two ISO weeks).
+  useEffect(() => {
+    if (period !== 'week') return
+    let cancelled = false
+
+    const baseEndYear = weekEnd.getFullYear()
+
+    const run = async () => {
+      setWeeklyLoading(true)
+      setWeeklyError(null)
+      const promises = yearList.map(async (year) => {
+        const offset = year - baseEndYear
+        const ws = new Date(weekStart)
+        ws.setFullYear(weekStart.getFullYear() + offset)
+        const we = new Date(weekEnd)
+        we.setFullYear(weekEnd.getFullYear() + offset)
+        const result = await apolloClient.query<
+          GarminActivityTotalsQuery,
+          GarminActivityTotalsQueryVariables
+        >({
+          query: GarminActivityTotalsDocument,
+          variables: {
+            period: 'week',
+            date_from: format(ws, 'yyyy-MM-dd'),
+            date_to: format(we, 'yyyy-MM-dd'),
+          },
+          fetchPolicy: 'cache-first',
+        })
+        const buckets = result.data?.garminActivityTotals ?? []
+        const summed: ChartBucket = buckets.reduce<ChartBucket>(
+          (acc, b) => ({
+            period_start: acc.period_start,
+            label: String(year),
+            activity_count: acc.activity_count + b.activity_count,
+            distance_km: acc.distance_km + (b.total_distance_km ?? 0),
+            duration_hours:
+              acc.duration_hours + (b.total_duration_seconds ?? 0) / 3600,
+            total_ascent_m: acc.total_ascent_m + (b.total_ascent_m ?? 0),
+            total_calories: acc.total_calories + (b.total_calories ?? 0),
+          }),
+          {
+            period_start: format(ws, 'yyyy-MM-dd'),
+            label: String(year),
+            activity_count: 0,
+            distance_km: 0,
+            duration_hours: 0,
+            total_ascent_m: 0,
+            total_calories: 0,
+          },
+        )
+        return summed
+      })
+
+      try {
+        const results = await Promise.all(promises)
+        if (cancelled) return
+        setWeeklyByYear(results.sort((a, b) => a.label.localeCompare(b.label)))
+        setWeeklyLoading(false)
+      } catch (err) {
+        if (cancelled) return
+        setWeeklyError(
+          err instanceof Error
+            ? err
+            : new Error('Failed to load weekly totals'),
+        )
+        setWeeklyLoading(false)
+      }
+    }
+
+    void run()
+
+    return () => {
+      cancelled = true
+    }
+  }, [period, weekStart, weekEnd, yearList, apolloClient])
+
   const chartData = useMemo<ChartBucket[]>(() => {
+    if (period === 'week') {
+      return weeklyByYear
+    }
     const totals = data?.garminActivityTotals ?? []
     const mapped = totals.map((t) => ({
       period_start: t.period_start,
@@ -287,9 +397,25 @@ export function GarminActivityTotals() {
     return Array.from(byYear.values()).sort((a, b) =>
       a.label.localeCompare(b.label),
     )
-  }, [data, period, selectedMonth])
+  }, [data, period, selectedMonth, weeklyByYear])
 
   const metricConfig = METRICS.find((m) => m.key === metric) ?? METRICS[0]
+
+  const weekRangeLabel = useMemo(
+    () => `${format(weekStart, 'MMM d')} – ${format(weekEnd, 'MMM d')}`,
+    [weekStart, weekEnd],
+  )
+
+  const isLoading = period === 'week' ? weeklyLoading : loading
+  const activeError = period === 'week' ? weeklyError : error
+  const handleRetry = () => {
+    if (period === 'week') {
+      // Re-trigger the effect by bumping weekEnd reference identity.
+      setWeekEnd(new Date(weekEnd))
+    } else {
+      void refetch()
+    }
+  }
 
   return (
     <Card data-testid="activity-totals-card">
@@ -302,9 +428,14 @@ export function GarminActivityTotals() {
               — {MONTH_FULL_NAMES[selectedMonth]} by year
             </span>
           )}
+          {period === 'week' && (
+            <span className="text-sm font-normal text-muted-foreground">
+              — {weekRangeLabel} by year
+            </span>
+          )}
         </CardTitle>
         <div className="flex flex-col gap-2 pt-2 sm:flex-row sm:items-center sm:justify-between">
-          <div className="flex items-center gap-2">
+          <div className="flex flex-wrap items-center gap-2">
             <SegmentedControl<Period>
               ariaLabel="Aggregation period"
               value={period}
@@ -335,6 +466,40 @@ export function GarminActivityTotals() {
                 </SelectContent>
               </Select>
             )}
+            {period === 'week' && (
+              <div
+                className="inline-flex items-center gap-1"
+                aria-label="Week range navigation"
+              >
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  className="h-7 px-2"
+                  aria-label="Previous week"
+                  onClick={() => setWeekEnd((d) => subDays(d, 7))}
+                >
+                  <ChevronLeft className="h-3.5 w-3.5" />
+                </Button>
+                <span
+                  data-testid="week-range-pill"
+                  aria-live="polite"
+                  className="inline-flex h-7 items-center rounded-md border bg-muted px-3 text-xs font-medium tabular-nums"
+                >
+                  {weekRangeLabel}
+                </span>
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  className="h-7 px-2"
+                  aria-label="Next week"
+                  onClick={() => setWeekEnd((d) => addDays(d, 7))}
+                >
+                  <ChevronRight className="h-3.5 w-3.5" />
+                </Button>
+              </div>
+            )}
           </div>
           <SegmentedControl<Metric>
             ariaLabel="Metric"
@@ -345,10 +510,10 @@ export function GarminActivityTotals() {
         </div>
       </CardHeader>
       <CardContent>
-        {loading ? (
+        {isLoading ? (
           <LoadingState message="Loading activity totals..." />
-        ) : error ? (
-          <ErrorState message={error.message} onRetry={() => refetch()} />
+        ) : activeError ? (
+          <ErrorState message={activeError.message} onRetry={handleRetry} />
         ) : chartData.length === 0 ? (
           <p className="py-12 text-center text-sm text-muted-foreground">
             No activities found for this period.

--- a/src/pages/DashboardPage.test.tsx
+++ b/src/pages/DashboardPage.test.tsx
@@ -18,6 +18,12 @@ const dashboardHooks = vi.hoisted(() => ({
 
 vi.mock('@/__generated__/graphql', () => dashboardHooks)
 
+vi.mock('@apollo/client/react', () => ({
+  useApolloClient: vi.fn().mockReturnValue({
+    query: vi.fn().mockResolvedValue({ data: { garminActivityTotals: [] } }),
+  }),
+}))
+
 vi.mock('@/contexts/AuthContext', () => ({
   useAuth: vi.fn().mockReturnValue({
     isAuthenticated: false,


### PR DESCRIPTION
## Summary

Enhances the Activity Totals "Weekly" tab on the Dashboard to show one bar per year for the same trailing 7-day calendar window (current default: today − 6 → today). Adds Prev/Next 7-day pagination and a visible date-range pill.

## Behavior

- Each bar represents one year's totals (activity_count, distance, duration, ascent, calories) for the same 7-day calendar window projected onto that year.
- Default window: today − 6 ... today. Prev shifts back 7 days, Next shifts forward 7 days. The pill updates accordingly.
- Years span minYear (from `garminDateRange.min_date`) through max(currentYear, weekEnd.year).
- Implementation: imperative `useApolloClient().query()` calls with `period: 'week'`, `fetchPolicy: 'cache-first'`, batched 4-at-a-time so dashboards with long Garmin history don't fan out N parallel requests on every Prev/Next click.
- Year projection clamps Feb 29 to Feb 28 in non-leap years instead of using `Date#setFullYear`, which silently shifts to Mar 1 and changes the window length.

## Behavior changes (beyond the original Weekly scope)

After review feedback this PR also extends zero-fill to the **Monthly** and **Yearly** tabs so the chart x-axis is continuous across the full Garmin date range:

- **Monthly tab** for a selected month now renders one bar per year from `min_date` through `max(currentYear, latest data year)`. Years with no activity in that month appear as zero-value bars instead of being dropped.
- **Yearly tab** now renders one bar per year across the same range. Years with no recorded activity appear as zero-value bars instead of being dropped.
- The empty-state ("No activity totals to display") is preserved when the API returns no buckets at all.

This was requested explicitly during review so the chart shape is consistent across all three period tabs.

## Tests

- Unit tests (Vitest): 12/12 pass — covers weekly projection, Prev/Next pagination, monthly-by-year zero-fill, and selector visibility. Weekly tests now run under `vi.useFakeTimers({ toFake: ['Date'], now: FROZEN_NOW })` so labels and query variables are deterministic.
- e2e (Playwright): updated dashboard-activity-totals spec to assert pill regex `/\\w{3} \\d+ – \\w{3} \\d+/`, Prev/Next visibility, "by year" subtitle, and Prev→Next round-trip. Captures `-04-weekly-default.png`, `-05-weekly-prev.png`, `-06-weekly-next.png`, `-07-yearly-no-month-select.png`, `-08-monthly-metric-duration.png`.

## Notes

- Branched off `develop`; rebased onto `master`.
- Pill is display-only per request; future work could expand it to a date picker.
- Server-side weekly aggregation across years (single round-trip instead of N batched cache-first queries) is tracked as a follow-up.

## Validation

- `npm run lint:all` ✅
- `npm run type-check` ✅
- `npm run test:run` ✅
- `npx playwright test e2e/dashboard-activity-totals.spec.ts` ✅ (5/5)
