### PR TITLE
chore(renovate): auto-merge minor updates for dev-only tooling

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -21,6 +21,38 @@
       "automergeType": "pr"
     },
     {
+      "description": "Auto-merge minor updates for dev-only tooling (no runtime impact)",
+      "matchManagers": ["npm"],
+      "matchUpdateTypes": ["minor"],
+      "matchPackageNames": [
+        "vitest",
+        "@vitest/coverage-v8",
+        "@testing-library/react",
+        "@testing-library/jest-dom",
+        "@testing-library/user-event",
+        "jsdom",
+        "@playwright/test",
+        "eslint",
+        "@eslint/js",
+        "typescript-eslint",
+        "eslint-plugin-react-hooks",
+        "eslint-plugin-react-refresh",
+        "globals",
+        "prettier",
+        "markdownlint-cli2",
+        "husky",
+        "lint-staged",
+        "cspell",
+        "shadcn",
+        "@graphql-codegen/cli",
+        "@graphql-codegen/typescript",
+        "@graphql-codegen/typescript-operations",
+        "@graphql-codegen/typescript-react-apollo"
+      ],
+      "automerge": true,
+      "automergeType": "pr"
+    },
+    {
       "description": "Catch-all bundle for any remaining npm minor/patch updates (specific groups below override this via last-match-wins)",
       "matchManagers": ["npm"],
       "matchUpdateTypes": ["minor", "patch"],

--- a/renovate.json
+++ b/renovate.json
@@ -23,6 +23,7 @@
     {
       "description": "Auto-merge minor updates for dev-only tooling (no runtime impact)",
       "matchManagers": ["npm"],
+      "matchDepTypes": ["devDependencies"],
       "matchUpdateTypes": ["minor"],
       "matchPackageNames": [
         "vitest",


### PR DESCRIPTION
## Summary

Expands Renovate auto-merge to cover **minor** updates for dev-only packages, in addition to the existing **patch** auto-merge for all npm deps.

## Affected groups (minor + patch auto-merge)

- **testing**: vitest, @vitest/coverage-v8, jsdom, @testing-library/*, @playwright/test
- **eslint**: eslint, @eslint/js, typescript-eslint, eslint-plugin-react-*, globals
- **formatting-tools**: prettier, markdownlint-cli2, husky, lint-staged, cspell, shadcn (CLI)
- **graphql-codegen**: @graphql-codegen/* (codegen-time only)

## Unchanged

- Runtime packages (react, apollo, vite, tailwind, radix, leaflet, lucide-react) still require manual review on minor bumps.
- **All major updates** still require manual approval everywhere.
- Patch auto-merge for all npm deps remains.

## Rationale

These devDeps never ship in the production bundle, so minor bumps that pass CI (lint + type-check + tests + build) are safe to merge automatically. Reduces PR review noise.