### PR TITLE
test(e2e): allow per-source counts in daily-summary detail header

### DIFF
--- a/e2e/dashboard-daily-summary.spec.ts
+++ b/e2e/dashboard-daily-summary.spec.ts
@@ -281,7 +281,11 @@ test.describe('Dashboard Daily Summary detail map', () => {
     await page.getByRole('button', { name: 'All' }).click()
 
     await expect(page).not.toHaveURL(/[?&]source=owntracks/)
-    await expect(page.getByText(/GPS points$/)).toBeVisible({
+    // Header text (no filter) ends with "GPS points" optionally followed by
+    // the per-source counts summary "(OwnTracks: N, Garmin: M)".
+    await expect(
+      page.getByText(/GPS points(\s*\(OwnTracks: [\d,]+, Garmin: [\d,]+\))?$/),
+    ).toBeVisible({
       timeout: 30_000,
     })
   })


### PR DESCRIPTION
Follow-up to #113.

After the day-detail header started showing '(OwnTracks: N, Garmin: M)' next to 'GPS points' when no source filter is set, the 'All' branch of `detail page paginates and filters source-limited points` (`getByText(/GPS points$/)`) stopped matching.

This widens the regex to optionally accept the per-source counts suffix:

```ts
page.getByText(/GPS points(\s*\(OwnTracks: [\d,]+, Garmin: [\d,]+\))?$/)
```

Verified locally against the live v1.0.355 deployment — all 8 `dashboard-daily-summary.spec.ts` tests now pass.