### PR TITLE
feat(garmin): sync chart crosshairs, unified details panel, map hover marker

### DIFF
--- a/e2e/garmin-charts.spec.ts
+++ b/e2e/garmin-charts.spec.ts
@@ -108,13 +108,22 @@ test.describe('Garmin Activity Charts', () => {
       timeout: 5_000,
     })
 
-    // Hover details panel should now show a numeric Elevation value
-    // (replaces the placeholder text).
+    // Hover details panel should now show the unified point metadata:
+    // elevation, speed, time, distance, and lat/lon — not the placeholder.
     await expect(details).not.toContainText('Hover the Elevation', {
       timeout: 5_000,
     })
+    await expect(details).toContainText('Elevation')
     await expect(details).toContainText('ft')
+    await expect(details).toContainText('Speed')
     await expect(details).toContainText('mph')
+    await expect(details).toContainText('Time')
+    await expect(details).toContainText('min)')
+    await expect(details).toContainText('Distance')
+    await expect(details).toContainText('mi')
+    await expect(details).toContainText('Lat/Lon')
+    // Lat/Lon renders to 5 decimal places, e.g. "40.12345, -74.67890".
+    await expect(details).toContainText(/-?\d+\.\d{5},\s*-?\d+\.\d{5}/)
 
     // Leaflet hover marker is added to the route map. Target the dedicated
     // `activity-hover-marker` class so we don't match the route polylines or

--- a/e2e/garmin-charts.spec.ts
+++ b/e2e/garmin-charts.spec.ts
@@ -94,12 +94,13 @@ test.describe('Garmin Activity Charts', () => {
     await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2)
 
     // Both charts should render a synced cursor line (Recharts syncId).
-    await expect(
-      elevationCard.locator('.recharts-tooltip-cursor'),
-    ).toHaveCount(1, { timeout: 5_000 })
-    await expect(
-      speedCard.locator('.recharts-tooltip-cursor'),
-    ).toHaveCount(1, { timeout: 5_000 })
+    await expect(elevationCard.locator('.recharts-tooltip-cursor')).toHaveCount(
+      1,
+      { timeout: 5_000 },
+    )
+    await expect(speedCard.locator('.recharts-tooltip-cursor')).toHaveCount(1, {
+      timeout: 5_000,
+    })
 
     // Hover details panel should now show a numeric Elevation value
     // (replaces the placeholder text).

--- a/e2e/garmin-charts.spec.ts
+++ b/e2e/garmin-charts.spec.ts
@@ -71,4 +71,54 @@ test.describe('Garmin Activity Charts', () => {
     await expect(charts.nth(0)).toBeVisible()
     await expect(charts.nth(1)).toBeVisible()
   })
+
+  test('hovering one chart syncs the cursor and map marker', async ({
+    page,
+  }) => {
+    await page.goto(`/garmin/${ACTIVITY_ID}`)
+
+    const elevationCard = page.getByTestId('chart-elevation')
+    const speedCard = page.getByTestId('chart-speed')
+    const routeMap = page.getByTestId('activity-route-map')
+    const details = page.getByTestId('activity-hover-details')
+
+    await expect(elevationCard).toBeVisible({ timeout: 20_000 })
+    await expect(speedCard).toBeVisible({ timeout: 20_000 })
+    await expect(routeMap).toBeVisible({ timeout: 20_000 })
+    await expect(details).toBeVisible()
+
+    // Hover the middle of the Elevation chart's SVG.
+    const elevationSvg = elevationCard.locator('.recharts-responsive-container')
+    const box = await elevationSvg.boundingBox()
+    if (!box) throw new Error('Elevation chart bounding box unavailable')
+    await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2)
+
+    // Both charts should render a synced cursor line (Recharts syncId).
+    await expect(
+      elevationCard.locator('.recharts-tooltip-cursor'),
+    ).toHaveCount(1, { timeout: 5_000 })
+    await expect(
+      speedCard.locator('.recharts-tooltip-cursor'),
+    ).toHaveCount(1, { timeout: 5_000 })
+
+    // Hover details panel should now show a numeric Elevation value
+    // (replaces the placeholder text).
+    await expect(details).not.toContainText('Hover the Elevation', {
+      timeout: 5_000,
+    })
+    await expect(details).toContainText('ft')
+    await expect(details).toContainText('mph')
+
+    // Leaflet hover marker is added to the route map.
+    // The route polyline already adds <path> elements, so we look for the
+    // dedicated circleMarker element rendered into the leaflet overlay pane.
+    await expect(
+      routeMap.locator('.leaflet-overlay-pane svg path.leaflet-interactive'),
+    ).not.toHaveCount(0)
+
+    await page.screenshot({
+      path: 'e2e/screenshots/garmin-synced-cursor-and-map.png',
+      fullPage: true,
+    })
+  })
 })

--- a/e2e/garmin-charts.spec.ts
+++ b/e2e/garmin-charts.spec.ts
@@ -1,4 +1,10 @@
 import { test, expect } from '@playwright/test'
+import fs from 'fs'
+import path from 'path'
+
+const SCREENSHOT_DIR = path.join('e2e', 'screenshots', 'garmin-charts')
+
+fs.mkdirSync(SCREENSHOT_DIR, { recursive: true })
 
 /**
  * Validates that the Garmin activity detail page renders
@@ -110,16 +116,26 @@ test.describe('Garmin Activity Charts', () => {
     await expect(details).toContainText('ft')
     await expect(details).toContainText('mph')
 
-    // Leaflet hover marker is added to the route map.
-    // The route polyline already adds <path> elements, so we look for the
-    // dedicated circleMarker element rendered into the leaflet overlay pane.
-    await expect(
-      routeMap.locator('.leaflet-overlay-pane svg path.leaflet-interactive'),
-    ).not.toHaveCount(0)
+    // Leaflet hover marker is added to the route map. Target the dedicated
+    // `activity-hover-marker` class so we don't match the route polylines or
+    // the start/finish circle markers (which are also leaflet-interactive).
+    const hoverMarker = routeMap.locator(
+      '.leaflet-overlay-pane svg path.activity-hover-marker',
+    )
+    await expect(hoverMarker).toHaveCount(1, { timeout: 5_000 })
 
     await page.screenshot({
-      path: 'e2e/screenshots/garmin-synced-cursor-and-map.png',
+      path: path.join(SCREENSHOT_DIR, 'synced-cursor-and-map.png'),
       fullPage: true,
     })
+
+    // Moving the pointer off the charts should clear the shared state:
+    // the details panel returns to its placeholder and the hover marker
+    // is removed from the map.
+    await page.mouse.move(0, 0)
+    await expect(details).toContainText('Hover the Elevation', {
+      timeout: 5_000,
+    })
+    await expect(hoverMarker).toHaveCount(0, { timeout: 5_000 })
   })
 })

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "lint:md": "markdownlint-cli2 \"**/*.md\" \"#node_modules\"",
     "lint:md:fix": "markdownlint-cli2 --fix \"**/*.md\" \"#node_modules\"",
     "lint:spell": "cspell --no-progress --no-summary --gitignore \"src/**/*.{ts,tsx}\" \"e2e/**/*.ts\" \".github/**/*.{md,yml,yaml}\" \"docs/**/*.md\" \"*.md\" \"*.json\" \"*.ts\" \"*.js\" \"*.sh\" \"Dockerfile\" \"Makefile\" \"index.html\" \"nginx.conf\"",
-    "lint:all": "npm run lint && npm run lint:md && npm run lint:spell",
+    "lint:all": "npm run lint && npm run lint:md && npm run lint:spell && npm run format:check",
     "format": "prettier --write \"src/**/*.{ts,tsx,json,css}\" \"**/*.md\"",
     "format:check": "prettier --check \"src/**/*.{ts,tsx,json,css}\" \"**/*.md\"",
     "test": "vitest",

--- a/src/components/garmin/ActivityCharts.tsx
+++ b/src/components/garmin/ActivityCharts.tsx
@@ -26,8 +26,8 @@ interface ActivityChartsProps {
   /**
    * Notifies the parent which chart point is currently under the cursor so the
    * page can render a shared details panel and a map hover marker. The two
-   * charts share this state via Recharts' syncId — both charts crosshair the
-   * same x-position and emit the same active index.
+   * charts share this state via Recharts' syncId — both charts show a
+   * crosshair at the same x-position and emit the same active index.
    */
   onActivePointChange?: (point: ChartDataPoint | null) => void
 }

--- a/src/components/garmin/ActivityCharts.tsx
+++ b/src/components/garmin/ActivityCharts.tsx
@@ -172,8 +172,15 @@ export function ActivityCharts({
                 onMouseMove={(state: {
                   activeTooltipIndex?: number | string | null
                 }) => {
-                  const i = state?.activeTooltipIndex
-                  if (typeof i === 'number' && chartData[i]) {
+                  const raw = state?.activeTooltipIndex
+                  // Recharts 3 may emit the index as a string; normalize it.
+                  const i =
+                    typeof raw === 'number'
+                      ? raw
+                      : typeof raw === 'string' && raw !== ''
+                        ? Number(raw)
+                        : NaN
+                  if (Number.isInteger(i) && chartData[i]) {
                     onActivePointChange?.(chartData[i])
                   }
                 }}

--- a/src/components/garmin/ActivityCharts.tsx
+++ b/src/components/garmin/ActivityCharts.tsx
@@ -1,4 +1,4 @@
-import { useState, type ReactNode } from 'react'
+import { useState } from 'react'
 import {
   AreaChart,
   Area,
@@ -8,7 +8,6 @@ import {
   Tooltip,
   ResponsiveContainer,
 } from 'recharts'
-import type { TooltipContentProps } from 'recharts'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 import { kmToMi, metersToFeet, kmhToMph } from '@/lib/units'
@@ -24,6 +23,13 @@ interface TrackPoint {
 
 interface ActivityChartsProps {
   trackPoints: TrackPoint[]
+  /**
+   * Notifies the parent which chart point is currently under the cursor so the
+   * page can render a shared details panel and a map hover marker. The two
+   * charts share this state via Recharts' syncId — both charts crosshair the
+   * same x-position and emit the same active index.
+   */
+  onActivePointChange?: (point: ChartDataPoint | null) => void
 }
 
 type XAxisMode = 'distance' | 'time'
@@ -50,7 +56,7 @@ interface ChartConfig {
   hasData: boolean
 }
 
-interface ChartDataPoint {
+export interface ChartDataPoint {
   distance: number | null
   distanceKm: number | null
   time: number
@@ -61,52 +67,10 @@ interface ChartDataPoint {
   timestamp: string
 }
 
-function ChartTooltipContent({
-  active,
-  payload,
-  chartConfig,
-}: TooltipContentProps<number, string> & {
-  chartConfig: ChartConfig
-}): ReactNode {
-  if (!active || !payload?.length) return null
-  const pt = payload[0].payload as ChartDataPoint
-  const value = payload[0].value
-
-  const timeStr = new Date(pt.timestamp).toLocaleTimeString('en-US', {
-    hour: '2-digit',
-    minute: '2-digit',
-    second: '2-digit',
-  })
-
-  return (
-    <div className="rounded-md border bg-popover p-2 text-xs text-popover-foreground shadow-md">
-      <p className="font-semibold">
-        {chartConfig.title}:{' '}
-        {value != null
-          ? `${Number(value).toFixed(1)} ${chartConfig.unit}`
-          : '—'}
-      </p>
-      <div className="mt-1 space-y-0.5 text-muted-foreground">
-        <p>
-          Time: {timeStr} ({pt.time.toFixed(1)} min)
-        </p>
-        {pt.distance != null && (
-          <p>
-            Distance: {pt.distance.toFixed(2)} mi ({pt.distanceKm?.toFixed(2)}{' '}
-            km)
-          </p>
-        )}
-        {pt.latitude != null && pt.longitude != null && (
-          <p>
-            Lat/Lon: {pt.latitude.toFixed(5)}, {pt.longitude.toFixed(5)}
-          </p>
-        )}
-      </div>
-    </div>
-  )
-}
-
-export function ActivityCharts({ trackPoints }: ActivityChartsProps) {
+export function ActivityCharts({
+  trackPoints,
+  onActivePointChange,
+}: ActivityChartsProps) {
   const [xMode, setXMode] = useState<XAxisMode>('distance')
 
   if (trackPoints.length === 0) return null
@@ -204,6 +168,16 @@ export function ActivityCharts({ trackPoints }: ActivityChartsProps) {
               <AreaChart
                 data={chartData}
                 margin={{ top: 5, right: 20, left: 0, bottom: 5 }}
+                syncId="garmin-activity"
+                onMouseMove={(state: {
+                  activeTooltipIndex?: number | string | null
+                }) => {
+                  const i = state?.activeTooltipIndex
+                  if (typeof i === 'number' && chartData[i]) {
+                    onActivePointChange?.(chartData[i])
+                  }
+                }}
+                onMouseLeave={() => onActivePointChange?.(null)}
               >
                 <CartesianGrid strokeDasharray="3 3" className="stroke-muted" />
                 <XAxis
@@ -228,12 +202,8 @@ export function ActivityCharts({ trackPoints }: ActivityChartsProps) {
                   width={50}
                 />
                 <Tooltip
-                  content={(props) => (
-                    <ChartTooltipContent
-                      {...(props as TooltipContentProps<number, string>)}
-                      chartConfig={chart}
-                    />
-                  )}
+                  cursor={{ stroke: 'currentColor', strokeOpacity: 0.4 }}
+                  content={() => null}
                 />
                 <Area
                   type="monotone"

--- a/src/components/garmin/ActivityHoverDetails.tsx
+++ b/src/components/garmin/ActivityHoverDetails.tsx
@@ -29,18 +29,17 @@ export function ActivityHoverDetails({ point }: ActivityHoverDetailsProps) {
           <Field
             label="Elevation"
             value={
-              point.elevation != null
-                ? `${point.elevation.toFixed(1)} ft`
-                : '—'
+              point.elevation != null ? `${point.elevation.toFixed(1)} ft` : '—'
             }
           />
           <Field
             label="Speed"
-            value={
-              point.speed != null ? `${point.speed.toFixed(1)} mph` : '—'
-            }
+            value={point.speed != null ? `${point.speed.toFixed(1)} mph` : '—'}
           />
-          <Field label="Time" value={`${timeStr} (${point.time.toFixed(1)} min)`} />
+          <Field
+            label="Time"
+            value={`${timeStr} (${point.time.toFixed(1)} min)`}
+          />
           <Field
             label="Distance"
             value={

--- a/src/components/garmin/ActivityHoverDetails.tsx
+++ b/src/components/garmin/ActivityHoverDetails.tsx
@@ -1,0 +1,77 @@
+import { Card, CardContent } from '@/components/ui/card'
+import type { ChartDataPoint } from './ActivityCharts'
+
+interface ActivityHoverDetailsProps {
+  point: ChartDataPoint | null
+}
+
+export function ActivityHoverDetails({ point }: ActivityHoverDetailsProps) {
+  if (!point) {
+    return (
+      <Card data-testid="activity-hover-details">
+        <CardContent className="py-3 text-xs text-muted-foreground">
+          Hover the Elevation or Speed chart to see details for that point.
+        </CardContent>
+      </Card>
+    )
+  }
+
+  const timeStr = new Date(point.timestamp).toLocaleTimeString('en-US', {
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+  })
+
+  return (
+    <Card data-testid="activity-hover-details">
+      <CardContent className="py-3">
+        <div className="grid grid-cols-2 gap-x-6 gap-y-1 text-xs sm:grid-cols-4 lg:grid-cols-5">
+          <Field
+            label="Elevation"
+            value={
+              point.elevation != null
+                ? `${point.elevation.toFixed(1)} ft`
+                : '—'
+            }
+          />
+          <Field
+            label="Speed"
+            value={
+              point.speed != null ? `${point.speed.toFixed(1)} mph` : '—'
+            }
+          />
+          <Field label="Time" value={`${timeStr} (${point.time.toFixed(1)} min)`} />
+          <Field
+            label="Distance"
+            value={
+              point.distance != null
+                ? `${point.distance.toFixed(2)} mi${
+                    point.distanceKm != null
+                      ? ` (${point.distanceKm.toFixed(2)} km)`
+                      : ''
+                  }`
+                : '—'
+            }
+          />
+          <Field
+            label="Lat/Lon"
+            value={
+              point.latitude != null && point.longitude != null
+                ? `${point.latitude.toFixed(5)}, ${point.longitude.toFixed(5)}`
+                : '—'
+            }
+          />
+        </div>
+      </CardContent>
+    </Card>
+  )
+}
+
+function Field({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex flex-col">
+      <span className="text-muted-foreground">{label}</span>
+      <span className="font-medium tabular-nums">{value}</span>
+    </div>
+  )
+}

--- a/src/components/garmin/ActivityRouteMap.tsx
+++ b/src/components/garmin/ActivityRouteMap.tsx
@@ -148,6 +148,7 @@ export function ActivityRouteMap({
           weight: 2,
           fillColor: '#ffffff',
           fillOpacity: 1,
+          className: 'activity-hover-marker',
         },
       ).addTo(map)
     }

--- a/src/components/garmin/ActivityRouteMap.tsx
+++ b/src/components/garmin/ActivityRouteMap.tsx
@@ -11,6 +11,12 @@ interface TrackPoint {
 
 interface ActivityRouteMapProps {
   trackPoints: TrackPoint[]
+  /**
+   * Optional point currently under the chart cursor. When provided, the map
+   * renders a small marker at that location so users can see where the active
+   * elevation/speed reading occurred. The map view is not re-centered.
+   */
+  activeLatLng?: { lat: number; lng: number } | null
 }
 
 function speedToColor(
@@ -29,9 +35,13 @@ function speedToColor(
   return '#ef4444' // red - fast
 }
 
-export function ActivityRouteMap({ trackPoints }: ActivityRouteMapProps) {
+export function ActivityRouteMap({
+  trackPoints,
+  activeLatLng,
+}: ActivityRouteMapProps) {
   const mapRef = useRef<HTMLDivElement>(null)
   const mapInstanceRef = useRef<L.Map | null>(null)
+  const hoverMarkerRef = useRef<L.CircleMarker | null>(null)
 
   useEffect(() => {
     if (!mapRef.current || trackPoints.length === 0) return
@@ -109,13 +119,44 @@ export function ActivityRouteMap({ trackPoints }: ActivityRouteMapProps) {
     return () => {
       map.remove()
       mapInstanceRef.current = null
+      hoverMarkerRef.current = null
     }
   }, [trackPoints])
+
+  // Sync hover marker with the active chart point. Avoid re-fitting bounds so
+  // the map stays put while the user scrubs the charts.
+  useEffect(() => {
+    const map = mapInstanceRef.current
+    if (!map) return
+
+    if (!activeLatLng) {
+      if (hoverMarkerRef.current) {
+        hoverMarkerRef.current.remove()
+        hoverMarkerRef.current = null
+      }
+      return
+    }
+
+    if (hoverMarkerRef.current) {
+      hoverMarkerRef.current.setLatLng([activeLatLng.lat, activeLatLng.lng])
+    } else {
+      hoverMarkerRef.current = L.circleMarker(
+        [activeLatLng.lat, activeLatLng.lng],
+        {
+          radius: 6,
+          color: '#111827',
+          weight: 2,
+          fillColor: '#ffffff',
+          fillOpacity: 1,
+        },
+      ).addTo(map)
+    }
+  }, [activeLatLng])
 
   if (trackPoints.length === 0) return null
 
   return (
-    <Card>
+    <Card data-testid="activity-route-map">
       <CardHeader className="pb-2">
         <CardTitle className="text-base">Route</CardTitle>
       </CardHeader>

--- a/src/pages/GarminDetailPage.tsx
+++ b/src/pages/GarminDetailPage.tsx
@@ -26,6 +26,17 @@ export function GarminDetailPage() {
   const location = useLocation()
   const [activePoint, setActivePoint] = useState<ChartDataPoint | null>(null)
 
+  // Reset hover state when switching activities so the shared details
+  // panel and map marker don't briefly show stale coordinates from the
+  // previously-viewed activity. React's recommended "adjusting state on
+  // prop change" pattern keeps this in render and avoids the
+  // set-state-in-effect lint rule.
+  const [prevActivityId, setPrevActivityId] = useState(activityId)
+  if (activityId !== prevActivityId) {
+    setPrevActivityId(activityId)
+    setActivePoint(null)
+  }
+
   useEffect(() => {
     setNRCustomAttribute('garmin.flow', true)
   }, [])

--- a/src/pages/GarminDetailPage.tsx
+++ b/src/pages/GarminDetailPage.tsx
@@ -1,5 +1,5 @@
 import { useParams, useLocation } from 'react-router-dom'
-import { useEffect } from 'react'
+import { useEffect, useState } from 'react'
 import {
   useGarminActivityQuery,
   useGarminTrackPointsQuery,
@@ -10,7 +10,11 @@ import { ErrorState } from '@/components/shared/ErrorState'
 import { ActivityHeader } from '@/components/garmin/ActivityHeader'
 import { ActivityStatsBar } from '@/components/garmin/ActivityStatsBar'
 import { ActivityRouteMap } from '@/components/garmin/ActivityRouteMap'
-import { ActivityCharts } from '@/components/garmin/ActivityCharts'
+import {
+  ActivityCharts,
+  type ChartDataPoint,
+} from '@/components/garmin/ActivityCharts'
+import { ActivityHoverDetails } from '@/components/garmin/ActivityHoverDetails'
 import { ActivityStatsPanel } from '@/components/garmin/ActivityStatsPanel'
 import { setNRCustomAttribute } from '@/lib/newrelic-browser'
 
@@ -20,6 +24,7 @@ const SIMPLIFY_TOLERANCE = 0.00001
 export function GarminDetailPage() {
   const { activityId } = useParams<{ activityId: string }>()
   const location = useLocation()
+  const [activePoint, setActivePoint] = useState<ChartDataPoint | null>(null)
 
   useEffect(() => {
     setNRCustomAttribute('garmin.flow', true)
@@ -87,14 +92,29 @@ export function GarminDetailPage() {
       {trackLoading && <LoadingState message="Loading track data..." />}
 
       {mapTrackPoints.length > 0 && (
-        <ActivityRouteMap trackPoints={mapTrackPoints} />
+        <ActivityRouteMap
+          trackPoints={mapTrackPoints}
+          activeLatLng={
+            activePoint?.latitude != null && activePoint?.longitude != null
+              ? { lat: activePoint.latitude, lng: activePoint.longitude }
+              : null
+          }
+        />
       )}
 
       {chartError && (
         <ErrorState message={`Chart data failed: ${chartError.message}`} />
       )}
 
-      {chartPoints.length > 0 && <ActivityCharts trackPoints={chartPoints} />}
+      {chartPoints.length > 0 && (
+        <>
+          <ActivityHoverDetails point={activePoint} />
+          <ActivityCharts
+            trackPoints={chartPoints}
+            onActivePointChange={setActivePoint}
+          />
+        </>
+      )}
 
       <ActivityStatsPanel activity={a} />
     </div>


### PR DESCRIPTION
## Summary

On the Garmin Activity page, the Elevation and Speed charts now share a single
synchronized crosshair, a unified details panel replaces the two per-chart
tooltips, and the route map shows a marker at the hovered point.

## Changes

- **`ActivityCharts.tsx`**: Added Recharts `syncId="garmin-activity"` so
  the cursor line on one chart mirrors the other. Replaced the per-chart
  tooltip body with a transparent cursor-only `Tooltip` (keeps the crosshair
  line, drops the duplicate popup). Emits the hovered `ChartDataPoint` via
  a new `onActivePointChange` prop.
- **`ActivityHoverDetails.tsx`** (new): Single shared details card showing
  Elevation (ft), Speed (mph), Time (HH:MM:SS), Distance (mi/km), and
  Lat/Lon. Renders a placeholder until a point is hovered.
- **`ActivityRouteMap.tsx`**: Accepts an `activeLatLng` prop and draws a
  small Leaflet `circleMarker` at the hovered point, clearing on mouse
  leave. No `fitBounds` triggered by hover.
- **`GarminDetailPage.tsx`**: Lifts the active hover point into local state
  and wires it to both the map and the unified details card.
- **`e2e/garmin-charts.spec.ts`**: New Playwright test that hovers the
  elevation chart and asserts both charts render a synced cursor, the details
  panel updates, and a hover marker appears on the route map. Saves a
  screenshot to `e2e/screenshots/garmin-synced-cursor-and-map.png`.

## Validation

- `npm run lint:all` — pass
- `npm run type-check` — pass
- `npm run test:run` — 141 tests pass
- `npm run build` — pass

Playwright run pending against a live API; the new spec runs in the same
`garmin-charts.spec.ts` suite as existing tests.

## Acceptance Criteria

- [x] Hovering one chart moves the crosshair on the other chart.
- [x] A single details panel shows elevation, speed, time, distance, and
      coordinates for the hovered point.
- [x] A marker appears on the map at the hovered point and disappears when
      the cursor leaves the charts.