### PR TITLE
fix(e2e): scroll elevation chart into view before hover

### DIFF
--- a/e2e/garmin-charts.spec.ts
+++ b/e2e/garmin-charts.spec.ts
@@ -93,6 +93,11 @@ test.describe('Garmin Activity Charts', () => {
     await expect(routeMap).toBeVisible({ timeout: 20_000 })
     await expect(details).toBeVisible()
 
+    // Charts sit below the initial viewport fold; scroll the elevation card
+    // into view so its bounding box maps onto on-screen coordinates that
+    // page.mouse.move can actually hit.
+    await elevationCard.scrollIntoViewIfNeeded()
+
     // Hover the middle of the Elevation chart's SVG.
     const elevationSvg = elevationCard.locator('.recharts-responsive-container')
     const box = await elevationSvg.boundingBox()


### PR DESCRIPTION
## Summary

The `hovering one chart syncs the cursor and map marker` Playwright test in `e2e/garmin-charts.spec.ts` was flaky/failing because it computed the elevation chart's bounding box without first scrolling the chart into view. The chart card sits below the 1280×720 viewport fold on initial paint, so `page.mouse.move(box.x + w/2, box.y + h/2)` landed off-screen, no `recharts-tooltip-cursor` rendered, and the assertion timed out.

## Fix

Add `await elevationCard.scrollIntoViewIfNeeded()` before reading the bounding box.

## Validation

Discovered during post-deploy validation of otel-data-ui v1.0.447 (k8s-gitops PR #438). Ran the full e2e suite against the live cluster (`https://data-ui.lab.informationcart.com`):

```
Running 6 tests using 1 worker
  ✓  1 page loads and activity header is visible (1.6s)
  ✓  2 renders Elevation chart card (2.4s)
  ✓  3 renders Speed chart card (2.2s)
  ✓  4 distance/time toggle buttons are visible (2.2s)
  ✓  5 switching to Time x-axis re-renders charts (2.3s)
  ✓  6 hovering one chart syncs the cursor and map marker (3.0s)
  6 passed (15.1s)
```

`npm run lint:all` and `npm run type-check` clean.

## Risk

Test-only change. No application code modified.