### PR TITLE
feat(garmin): show reverse-geocoded address in hover details

### DIFF
--- a/src/components/garmin/ActivityHoverDetails.tsx
+++ b/src/components/garmin/ActivityHoverDetails.tsx
@@ -1,11 +1,99 @@
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { Card, CardContent } from '@/components/ui/card'
+import { reverseGeocode } from '@/services/geocoder'
 import type { ChartDataPoint } from './ActivityCharts'
 
 interface ActivityHoverDetailsProps {
   point: ChartDataPoint | null
 }
 
+type AddressState =
+  | { status: 'idle' }
+  | { status: 'loading' }
+  | { status: 'ok'; label: string }
+  | { status: 'empty' }
+  | { status: 'error' }
+
+// Round to ~11m precision so small jitter between adjacent samples reuses the
+// cache and we do not flood the geocoder while a cursor sweeps a chart.
+function roundCoord(n: number): number {
+  return Math.round(n * 10_000) / 10_000
+}
+
+const DEBOUNCE_MS = 250
+const addressCache = new Map<string, string | null>()
+
+interface CoordKey {
+  key: string
+  lat: number
+  lon: number
+}
+
+function coordKey(point: ChartDataPoint | null): CoordKey | null {
+  if (
+    !point ||
+    point.latitude == null ||
+    point.longitude == null ||
+    !Number.isFinite(point.latitude) ||
+    !Number.isFinite(point.longitude)
+  ) {
+    return null
+  }
+  const lat = roundCoord(point.latitude)
+  const lon = roundCoord(point.longitude)
+  return { key: `${lat},${lon}`, lat, lon }
+}
+
 export function ActivityHoverDetails({ point }: ActivityHoverDetailsProps) {
+  const target = useMemo(() => coordKey(point), [point])
+  const [pendingState, setPendingState] = useState<{
+    key: string
+    state: AddressState
+  } | null>(null)
+  const abortRef = useRef<AbortController | null>(null)
+
+  useEffect(() => {
+    if (!target) return
+    if (addressCache.has(target.key)) return
+
+    abortRef.current?.abort()
+    const controller = new AbortController()
+    abortRef.current = controller
+
+    const timer = window.setTimeout(async () => {
+      try {
+        const res = await reverseGeocode(target.lat, target.lon, 1)
+        if (controller.signal.aborted) return
+        const label = res.features[0]?.properties?.label ?? null
+        addressCache.set(target.key, label)
+        setPendingState({
+          key: target.key,
+          state: label ? { status: 'ok', label } : { status: 'empty' },
+        })
+      } catch {
+        if (controller.signal.aborted) return
+        setPendingState({ key: target.key, state: { status: 'error' } })
+      }
+    }, DEBOUNCE_MS)
+
+    return () => {
+      window.clearTimeout(timer)
+      controller.abort()
+    }
+  }, [target])
+
+  const address: AddressState = (() => {
+    if (!target) return { status: 'idle' }
+    if (addressCache.has(target.key)) {
+      const cached = addressCache.get(target.key)
+      return cached ? { status: 'ok', label: cached } : { status: 'empty' }
+    }
+    if (pendingState && pendingState.key === target.key) {
+      return pendingState.state
+    }
+    return { status: 'loading' }
+  })()
+
   if (!point) {
     return (
       <Card data-testid="activity-hover-details">
@@ -61,9 +149,37 @@ export function ActivityHoverDetails({ point }: ActivityHoverDetailsProps) {
             }
           />
         </div>
+        <div
+          className="mt-2 border-t pt-2 text-xs"
+          data-testid="activity-hover-address"
+        >
+          <span className="text-muted-foreground">Address</span>{' '}
+          <span
+            className="font-medium"
+            data-testid="activity-hover-address-value"
+          >
+            {renderAddress(address)}
+          </span>
+        </div>
       </CardContent>
     </Card>
   )
+}
+
+function renderAddress(state: AddressState): string {
+  switch (state.status) {
+    case 'loading':
+      return 'Resolving…'
+    case 'ok':
+      return state.label
+    case 'empty':
+      return 'No address found'
+    case 'error':
+      return 'Unavailable'
+    case 'idle':
+    default:
+      return '—'
+  }
 }
 
 function Field({ label, value }: { label: string; value: string }) {


### PR DESCRIPTION
## Summary

Add a reverse-geocoded address line to the Garmin activity hover details panel so users can see *where* a point is, not just its lat/lon.

## Changes

- Wired `ActivityHoverDetails` to the existing Pelias-compatible `reverseGeocode` service.
- Added an "Address" row below the Lat/Lon field.
- Debounced lookups (250 ms) and deduplicated by lat/lon rounded to ~11 m precision so sweeping the cursor along a chart does not flood the geocoder.
- In-memory `Map` cache keyed by rounded coord; cache hits render synchronously.
- `AbortController` cancels stale requests when the hovered point changes.
- Surfaces loading / empty / error states with dedicated text ("Resolving…", "No address found", "Unavailable").

## Validation

- `npm run lint` — clean
- `npm run type-check` — clean
- `npm run test:run` — 141/141 passing
- `npm run build` — succeeded

## Test IDs

- `activity-hover-address` wraps the new row.
- `activity-hover-address-value` wraps the address text for e2e assertions.

Follow-up: extend the Playwright hover-sync test to assert the address renders.