### PR TITLE
feat: Add CSV and GeoJSON export to Garmin Activity detail page

### DIFF
--- a/src/__generated__/graphql.ts
+++ b/src/__generated__/graphql.ts
@@ -1,15 +1,14 @@
 /* eslint-disable */
 // @ts-nocheck
+/** Internal type. DO NOT USE DIRECTLY. */
+type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
+/** Internal type. DO NOT USE DIRECTLY. */
+export type Incremental<T> = T | { [P in keyof T]?: P extends ' $fragmentName' | '__typename' ? T[P] : never };
 import { gql } from '@apollo/client';
 import type * as ApolloReactCommon from '@apollo/client/react';
 import * as ApolloReactHooks from '@apollo/client/react';
 export type Maybe<T> = T | null;
 export type InputMaybe<T> = Maybe<T>;
-export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
-export type MakeOptional<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]?: Maybe<T[SubKey]> };
-export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]: Maybe<T[SubKey]> };
-export type MakeEmpty<T extends { [key: string]: unknown }, K extends keyof T> = { [_ in K]?: never };
-export type Incremental<T> = T | { [P in keyof T]?: P extends ' $fragmentName' | '__typename' ? T[P] : never };
 const defaultOptions = {} as const;
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
@@ -154,6 +153,45 @@ export type GarminActivity = {
   uploaded_at?: Maybe<Scalars['String']['output']>;
 };
 
+/** Full reverse-geocoded address attached to a Garmin activity waypoint. */
+export type GarminActivityAddress = {
+  __typename?: 'GarminActivityAddress';
+  /** Parent Garmin activity identifier */
+  activity_id: Scalars['String']['output'];
+  /** Pelias confidence score (0-1) */
+  confidence?: Maybe<Scalars['Float']['output']>;
+  /** Country name */
+  country?: Maybe<Scalars['String']['output']>;
+  /** Full formatted address label from Pelias */
+  display_address?: Maybe<Scalars['String']['output']>;
+  /** UTC timestamp when geocoding was performed */
+  geocoded_at?: Maybe<Scalars['String']['output']>;
+  /** House or building number */
+  housenumber?: Maybe<Scalars['String']['output']>;
+  /** GPS latitude in decimal degrees (WGS 84) */
+  latitude: Scalars['Float']['output'];
+  /** City or town */
+  locality?: Maybe<Scalars['String']['output']>;
+  /** GPS longitude in decimal degrees (WGS 84) */
+  longitude: Scalars['Float']['output'];
+  /** Neighbourhood name */
+  neighbourhood?: Maybe<Scalars['String']['output']>;
+  /** Postal or ZIP code */
+  postalcode?: Maybe<Scalars['String']['output']>;
+  /** State or province */
+  region?: Maybe<Scalars['String']['output']>;
+  /** Geocoding status: success, no_coverage, error, pending */
+  status: Scalars['String']['output'];
+  /** Street name */
+  street?: Maybe<Scalars['String']['output']>;
+  /** UTC timestamp of the track point this address was derived from */
+  timestamp: Scalars['DateTime']['output'];
+  /** garmin_track_points.id this address was geocoded from */
+  track_point_id: Scalars['Int']['output'];
+  /** Role of this waypoint within the activity: start, end, or waypoint */
+  waypoint_kind: Scalars['String']['output'];
+};
+
 /** Paginated list of Garmin activities. */
 export type GarminActivityConnection = {
   __typename?: 'GarminActivityConnection';
@@ -242,6 +280,8 @@ export type GarminTrackPoint = {
   __typename?: 'GarminTrackPoint';
   /** Parent Garmin activity identifier */
   activity_id: Scalars['String']['output'];
+  /** Compact reverse-geocoded address summary, when geocoded */
+  address?: Maybe<GeocodedAddressSummary>;
   /** Elevation above sea level in meters */
   altitude?: Maybe<Scalars['Float']['output']>;
   /** Pedal/step cadence in RPM */
@@ -306,9 +346,55 @@ export type GeocodedAddress = {
   street?: Maybe<Scalars['String']['output']>;
 };
 
+/** Compact reverse-geocoded address summary embedded in track-point payloads. */
+export type GeocodedAddressSummary = {
+  __typename?: 'GeocodedAddressSummary';
+  /** Pelias confidence score (0-1) */
+  confidence?: Maybe<Scalars['Float']['output']>;
+  /** Country name */
+  country?: Maybe<Scalars['String']['output']>;
+  /** Full formatted address label from Pelias */
+  display_address?: Maybe<Scalars['String']['output']>;
+  /** UTC timestamp when geocoding was performed */
+  geocoded_at?: Maybe<Scalars['String']['output']>;
+  /** House or building number */
+  housenumber?: Maybe<Scalars['String']['output']>;
+  /** City or town */
+  locality?: Maybe<Scalars['String']['output']>;
+  /** Neighbourhood name */
+  neighbourhood?: Maybe<Scalars['String']['output']>;
+  /** Postal or ZIP code */
+  postalcode?: Maybe<Scalars['String']['output']>;
+  /** State or province */
+  region?: Maybe<Scalars['String']['output']>;
+  /** Geocoding status: success, no_coverage, error, pending */
+  status: Scalars['String']['output'];
+  /** Street name */
+  street?: Maybe<Scalars['String']['output']>;
+  /** Role of this waypoint within a Garmin activity (start, end, waypoint). Null for OwnTracks records. */
+  waypoint_kind?: Maybe<Scalars['String']['output']>;
+};
+
+/** Coverage statistics for a single geocoding source (owntracks or garmin). */
+export type GeocodingSourceStatus = {
+  __typename?: 'GeocodingSourceStatus';
+  /** Number of records that failed geocoding */
+  errors: Scalars['Int']['output'];
+  /** Number of records outside Pelias coverage area */
+  no_coverage: Scalars['Int']['output'];
+  /** Number of records awaiting geocoding for this source */
+  pending: Scalars['Int']['output'];
+  /** Number of successfully geocoded records for this source */
+  success: Scalars['Int']['output'];
+  /** Total number of geocoded_addresses rows for this source */
+  total: Scalars['Int']['output'];
+};
+
 /** Coverage statistics for geocoded location records. */
 export type GeocodingStatus = {
   __typename?: 'GeocodingStatus';
+  /** Per-source breakdown of geocoding coverage (owntracks, garmin) */
+  by_source: GeocodingStatusBySource;
   /** Percentage of locations with a geocoded address */
   coverage_percent: Scalars['Float']['output'];
   /** Number of locations that failed geocoding */
@@ -323,6 +409,21 @@ export type GeocodingStatus = {
   success: Scalars['Int']['output'];
   /** Total number of OwnTracks location records */
   total_locations: Scalars['Int']['output'];
+};
+
+/** Per-source breakdown of geocoding coverage. */
+export type GeocodingStatusBySource = {
+  __typename?: 'GeocodingStatusBySource';
+  /** Coverage stats for Garmin rows */
+  garmin: GeocodingSourceStatus;
+  /** Number of Garmin activities that have at least one address row */
+  garmin_activities_geocoded: Scalars['Int']['output'];
+  /** Total number of Garmin activities (denominator for activity-level coverage) */
+  garmin_activities_total: Scalars['Int']['output'];
+  /** Percentage of Garmin activities with at least one geocoded address */
+  garmin_coverage_percent: Scalars['Float']['output'];
+  /** Coverage stats for OwnTracks rows */
+  owntracks: GeocodingSourceStatus;
 };
 
 /** Result of triggering a batch geocoding operation. */
@@ -512,6 +613,8 @@ export type Query = {
   garminActivities: GarminActivityConnection;
   /** Retrieve a single Garmin activity by its ID. */
   garminActivity?: Maybe<GarminActivity>;
+  /** Retrieve all reverse-geocoded addresses for a Garmin activity (start, mid-route waypoints, and end). */
+  garminActivityAddresses: Array<GarminActivityAddress>;
   /** Aggregate Garmin activity totals grouped by week, month, or year. */
   garminActivityTotals: Array<GarminActivityTotal>;
   /** Retrieve chart-optimised track points for a Garmin activity. */
@@ -577,6 +680,11 @@ export type QueryGarminActivitiesArgs = {
 
 
 export type QueryGarminActivityArgs = {
+  activity_id: Scalars['String']['input'];
+};
+
+
+export type QueryGarminActivityAddressesArgs = {
   activity_id: Scalars['String']['input'];
 };
 
@@ -757,204 +865,218 @@ export type WithinReferenceResult = {
   total_points: Scalars['Int']['output'];
 };
 
+/** Sort direction for query results. */
+export type SortOrder =
+  /** Ascending order (oldest first, A-Z) */
+  | 'asc'
+  /** Descending order (newest first, Z-A) */
+  | 'desc';
+
 export type GarminActivitiesQueryVariables = Exact<{
-  sport?: InputMaybe<Scalars['String']['input']>;
-  date_from?: InputMaybe<Scalars['String']['input']>;
-  date_to?: InputMaybe<Scalars['String']['input']>;
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  offset?: InputMaybe<Scalars['Int']['input']>;
-  sort?: InputMaybe<Scalars['String']['input']>;
-  order?: InputMaybe<SortOrder>;
+  sport?: string | null | undefined;
+  date_from?: string | null | undefined;
+  date_to?: string | null | undefined;
+  limit?: number | null | undefined;
+  offset?: number | null | undefined;
+  sort?: string | null | undefined;
+  order?: SortOrder | null | undefined;
 }>;
 
 
-export type GarminActivitiesQuery = { __typename?: 'Query', garminActivities: { __typename?: 'GarminActivityConnection', total: number, limit: number, offset: number, items: Array<{ __typename?: 'GarminActivity', activity_id: string, sport: string, sub_sport?: string | null, start_time?: string | null, end_time?: string | null, distance_km?: number | null, duration_seconds?: number | null, avg_heart_rate?: number | null, max_heart_rate?: number | null, avg_cadence?: number | null, max_cadence?: number | null, calories?: number | null, avg_speed_kmh?: number | null, max_speed_kmh?: number | null, total_ascent_m?: number | null, total_descent_m?: number | null, total_distance?: number | null, avg_pace?: number | null, device_manufacturer?: string | null, created_at?: string | null, uploaded_at?: string | null, track_point_count?: number | null }> } };
+export type GarminActivitiesQuery = { garminActivities: { total: number, limit: number, offset: number, items: Array<{ activity_id: string, sport: string, sub_sport: string | null, start_time: string | null, end_time: string | null, distance_km: number | null, duration_seconds: number | null, avg_heart_rate: number | null, max_heart_rate: number | null, avg_cadence: number | null, max_cadence: number | null, calories: number | null, avg_speed_kmh: number | null, max_speed_kmh: number | null, total_ascent_m: number | null, total_descent_m: number | null, total_distance: number | null, avg_pace: number | null, device_manufacturer: string | null, created_at: string | null, uploaded_at: string | null, track_point_count: number | null }> } };
 
 export type GarminActivityQueryVariables = Exact<{
-  activity_id: Scalars['String']['input'];
+  activity_id: string;
 }>;
 
 
-export type GarminActivityQuery = { __typename?: 'Query', garminActivity?: { __typename?: 'GarminActivity', activity_id: string, sport: string, sub_sport?: string | null, start_time?: string | null, end_time?: string | null, distance_km?: number | null, duration_seconds?: number | null, avg_heart_rate?: number | null, max_heart_rate?: number | null, avg_cadence?: number | null, max_cadence?: number | null, calories?: number | null, avg_speed_kmh?: number | null, max_speed_kmh?: number | null, total_ascent_m?: number | null, total_descent_m?: number | null, total_distance?: number | null, avg_pace?: number | null, device_manufacturer?: string | null, avg_temperature_c?: number | null, min_temperature_c?: number | null, max_temperature_c?: number | null, total_elapsed_time?: number | null, total_timer_time?: number | null, created_at?: string | null, uploaded_at?: string | null, track_point_count?: number | null } | null };
+export type GarminActivityQuery = { garminActivity: { activity_id: string, sport: string, sub_sport: string | null, start_time: string | null, end_time: string | null, distance_km: number | null, duration_seconds: number | null, avg_heart_rate: number | null, max_heart_rate: number | null, avg_cadence: number | null, max_cadence: number | null, calories: number | null, avg_speed_kmh: number | null, max_speed_kmh: number | null, total_ascent_m: number | null, total_descent_m: number | null, total_distance: number | null, avg_pace: number | null, device_manufacturer: string | null, avg_temperature_c: number | null, min_temperature_c: number | null, max_temperature_c: number | null, total_elapsed_time: number | null, total_timer_time: number | null, created_at: string | null, uploaded_at: string | null, track_point_count: number | null } | null };
 
 export type GarminTrackPointsQueryVariables = Exact<{
-  activity_id: Scalars['String']['input'];
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  offset?: InputMaybe<Scalars['Int']['input']>;
-  sort?: InputMaybe<Scalars['String']['input']>;
-  order?: InputMaybe<SortOrder>;
-  simplify?: InputMaybe<Scalars['Float']['input']>;
+  activity_id: string;
+  limit?: number | null | undefined;
+  offset?: number | null | undefined;
+  sort?: string | null | undefined;
+  order?: SortOrder | null | undefined;
+  simplify?: number | null | undefined;
 }>;
 
 
-export type GarminTrackPointsQuery = { __typename?: 'Query', garminTrackPoints: { __typename?: 'GarminTrackPointConnection', total: number, limit: number, offset: number, items: Array<{ __typename?: 'GarminTrackPoint', id: number, activity_id: string, latitude: number, longitude: number, timestamp: string, altitude?: number | null, distance_from_start_km?: number | null, speed_kmh?: number | null, heart_rate?: number | null, cadence?: number | null, temperature_c?: number | null, created_at?: string | null }> } };
+export type GarminTrackPointsQuery = { garminTrackPoints: { total: number, limit: number, offset: number, items: Array<{ id: number, activity_id: string, latitude: number, longitude: number, timestamp: string, altitude: number | null, distance_from_start_km: number | null, speed_kmh: number | null, heart_rate: number | null, cadence: number | null, temperature_c: number | null, created_at: string | null }> } };
 
 export type GarminDateRangeQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type GarminDateRangeQuery = { __typename?: 'Query', garminDateRange: { __typename?: 'GarminDateRange', min_date: string, max_date: string } };
+export type GarminDateRangeQuery = { garminDateRange: { min_date: string, max_date: string } };
 
 export type GarminSportsQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type GarminSportsQuery = { __typename?: 'Query', garminSports: Array<{ __typename?: 'SportInfo', sport: string, activity_count: number }> };
+export type GarminSportsQuery = { garminSports: Array<{ sport: string, activity_count: number }> };
 
 export type GarminActivityTotalsQueryVariables = Exact<{
-  period: Scalars['String']['input'];
-  date_from?: InputMaybe<Scalars['String']['input']>;
-  date_to?: InputMaybe<Scalars['String']['input']>;
-  sport?: InputMaybe<Scalars['String']['input']>;
+  period: string;
+  date_from?: string | null | undefined;
+  date_to?: string | null | undefined;
+  sport?: string | null | undefined;
 }>;
 
 
-export type GarminActivityTotalsQuery = { __typename?: 'Query', garminActivityTotals: Array<{ __typename?: 'GarminActivityTotal', period_start: string, activity_count: number, total_distance_km?: number | null, total_duration_seconds?: number | null, total_ascent_m?: number | null, total_calories?: number | null }> };
+export type GarminActivityTotalsQuery = { garminActivityTotals: Array<{ period_start: string, activity_count: number, total_distance_km: number | null, total_duration_seconds: number | null, total_ascent_m: number | null, total_calories: number | null }> };
 
 export type GarminChartDataQueryVariables = Exact<{
-  activity_id: Scalars['String']['input'];
+  activity_id: string;
 }>;
 
 
-export type GarminChartDataQuery = { __typename?: 'Query', garminChartData: Array<{ __typename?: 'GarminChartPoint', timestamp: string, altitude?: number | null, distance_from_start_km?: number | null, speed_kmh?: number | null, heart_rate?: number | null, cadence?: number | null, temperature_c?: number | null, latitude: number, longitude: number }> };
+export type GarminChartDataQuery = { garminChartData: Array<{ timestamp: string, altitude: number | null, distance_from_start_km: number | null, speed_kmh: number | null, heart_rate: number | null, cadence: number | null, temperature_c: number | null, latitude: number, longitude: number }> };
 
 export type TriggerGarminSyncMutationVariables = Exact<{
-  window_hours?: InputMaybe<Scalars['Int']['input']>;
-  lookback?: InputMaybe<Scalars['Int']['input']>;
+  window_hours?: number | null | undefined;
+  lookback?: number | null | undefined;
 }>;
 
 
-export type TriggerGarminSyncMutation = { __typename?: 'Mutation', triggerGarminSync: { __typename?: 'GarminSyncTriggerResult', status: string, message: string, accepted: boolean, triggered_at?: string | null, started_at?: string | null, window_hours?: number | null, window_start?: string | null, lookback?: number | null } };
+export type TriggerGarminSyncMutation = { triggerGarminSync: { status: string, message: string, accepted: boolean, triggered_at: string | null, started_at: string | null, window_hours: number | null, window_start: string | null, lookback: number | null } };
+
+export type GarminExportPointsQueryVariables = Exact<{
+  activity_id: string;
+}>;
+
+
+export type GarminExportPointsQuery = { garminTrackPoints: { total: number, items: Array<{ id: number, activity_id: string, timestamp: string, latitude: number, longitude: number, altitude: number | null, distance_from_start_km: number | null, speed_kmh: number | null, heart_rate: number | null, cadence: number | null, temperature_c: number | null, address: { display_address: string | null, street: string | null, housenumber: string | null, neighbourhood: string | null, locality: string | null, region: string | null, country: string | null, postalcode: string | null, confidence: number | null, waypoint_kind: string | null, status: string, geocoded_at: string | null } | null }> } };
 
 export type GeocodingStatusQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type GeocodingStatusQuery = { __typename?: 'Query', geocodingStatus: { __typename?: 'GeocodingStatus', total_locations: number, geocoded: number, success: number, pending: number, no_coverage: number, errors: number, coverage_percent: number } };
+export type GeocodingStatusQuery = { geocodingStatus: { total_locations: number, geocoded: number, success: number, pending: number, no_coverage: number, errors: number, coverage_percent: number } };
 
 export type TriggerGeocodingMutationVariables = Exact<{
-  batch_size?: InputMaybe<Scalars['Int']['input']>;
-  retry_failed?: InputMaybe<Scalars['Boolean']['input']>;
+  batch_size?: number | null | undefined;
+  retry_failed?: boolean | null | undefined;
 }>;
 
 
-export type TriggerGeocodingMutation = { __typename?: 'Mutation', triggerGeocoding: { __typename?: 'GeocodingTriggerResult', processed: number, remaining: number, skipped_dedup: number } };
+export type TriggerGeocodingMutation = { triggerGeocoding: { processed: number, remaining: number, skipped_dedup: number } };
 
 export type HealthQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type HealthQuery = { __typename?: 'Query', health: { __typename?: 'HealthStatus', status: string, version: string } };
+export type HealthQuery = { health: { status: string, version: string } };
 
 export type ReadyQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type ReadyQuery = { __typename?: 'Query', ready: { __typename?: 'ReadyStatus', status: string, database?: string | null, version?: string | null } };
+export type ReadyQuery = { ready: { status: string, database: string | null, version: string | null } };
 
 export type LocationsQueryVariables = Exact<{
-  device_id?: InputMaybe<Scalars['String']['input']>;
-  date_from?: InputMaybe<Scalars['String']['input']>;
-  date_to?: InputMaybe<Scalars['String']['input']>;
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  offset?: InputMaybe<Scalars['Int']['input']>;
-  sort?: InputMaybe<Scalars['String']['input']>;
-  order?: InputMaybe<SortOrder>;
+  device_id?: string | null | undefined;
+  date_from?: string | null | undefined;
+  date_to?: string | null | undefined;
+  limit?: number | null | undefined;
+  offset?: number | null | undefined;
+  sort?: string | null | undefined;
+  order?: SortOrder | null | undefined;
 }>;
 
 
-export type LocationsQuery = { __typename?: 'Query', locations: { __typename?: 'LocationConnection', total: number, limit: number, offset: number, items: Array<{ __typename?: 'Location', id: number, device_id: string, tid?: string | null, latitude: number, longitude: number, accuracy?: number | null, altitude?: number | null, velocity?: number | null, battery?: number | null, battery_status?: number | null, connection_type?: string | null, trigger?: string | null, timestamp: string, created_at?: string | null, display_address?: string | null }> } };
+export type LocationsQuery = { locations: { total: number, limit: number, offset: number, items: Array<{ id: number, device_id: string, tid: string | null, latitude: number, longitude: number, accuracy: number | null, altitude: number | null, velocity: number | null, battery: number | null, battery_status: number | null, connection_type: string | null, trigger: string | null, timestamp: string, created_at: string | null, display_address: string | null }> } };
 
 export type LocationDetailQueryVariables = Exact<{
-  id: Scalars['Int']['input'];
+  id: number;
 }>;
 
 
-export type LocationDetailQuery = { __typename?: 'Query', location?: { __typename?: 'LocationDetail', id: number, device_id: string, tid?: string | null, latitude: number, longitude: number, accuracy?: number | null, altitude?: number | null, velocity?: number | null, battery?: number | null, battery_status?: number | null, connection_type?: string | null, trigger?: string | null, timestamp: string, created_at?: string | null, raw_payload?: Record<string, unknown> | null, address?: { __typename?: 'GeocodedAddress', display_address?: string | null, street?: string | null, housenumber?: string | null, neighbourhood?: string | null, locality?: string | null, region?: string | null, country?: string | null, postalcode?: string | null, confidence?: number | null, status: string, geocoded_at?: string | null } | null } | null };
+export type LocationDetailQuery = { location: { id: number, device_id: string, tid: string | null, latitude: number, longitude: number, accuracy: number | null, altitude: number | null, velocity: number | null, battery: number | null, battery_status: number | null, connection_type: string | null, trigger: string | null, timestamp: string, created_at: string | null, raw_payload: Record<string, unknown> | null, address: { display_address: string | null, street: string | null, housenumber: string | null, neighbourhood: string | null, locality: string | null, region: string | null, country: string | null, postalcode: string | null, confidence: number | null, status: string, geocoded_at: string | null } | null } | null };
 
 export type DevicesQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type DevicesQuery = { __typename?: 'Query', devices: Array<{ __typename?: 'DeviceInfo', device_id: string }> };
+export type DevicesQuery = { devices: Array<{ device_id: string }> };
 
 export type LocationCountQueryVariables = Exact<{
-  date?: InputMaybe<Scalars['String']['input']>;
-  device_id?: InputMaybe<Scalars['String']['input']>;
+  date?: string | null | undefined;
+  device_id?: string | null | undefined;
 }>;
 
 
-export type LocationCountQuery = { __typename?: 'Query', locationCount: { __typename?: 'LocationCount', count: number, date?: string | null, device_id?: string | null } };
+export type LocationCountQuery = { locationCount: { count: number, date: string | null, device_id: string | null } };
 
 export type LocationDateRangeQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type LocationDateRangeQuery = { __typename?: 'Query', locationDateRange: { __typename?: 'LocationDateRange', min_date: string, max_date: string } };
+export type LocationDateRangeQuery = { locationDateRange: { min_date: string, max_date: string } };
 
 export type ReferenceLocationsQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type ReferenceLocationsQuery = { __typename?: 'Query', referenceLocations: Array<{ __typename?: 'ReferenceLocation', id: number, name: string, latitude: number, longitude: number, radius_meters: number, description?: string | null, created_at?: string | null, updated_at?: string | null }> };
+export type ReferenceLocationsQuery = { referenceLocations: Array<{ id: number, name: string, latitude: number, longitude: number, radius_meters: number, description: string | null, created_at: string | null, updated_at: string | null }> };
 
 export type ReferenceLocationQueryVariables = Exact<{
-  id: Scalars['Int']['input'];
+  id: number;
 }>;
 
 
-export type ReferenceLocationQuery = { __typename?: 'Query', referenceLocation?: { __typename?: 'ReferenceLocation', id: number, name: string, latitude: number, longitude: number, radius_meters: number, description?: string | null, created_at?: string | null, updated_at?: string | null } | null };
+export type ReferenceLocationQuery = { referenceLocation: { id: number, name: string, latitude: number, longitude: number, radius_meters: number, description: string | null, created_at: string | null, updated_at: string | null } | null };
 
 export type NearbyPointsQueryVariables = Exact<{
-  lat: Scalars['Float']['input'];
-  lon: Scalars['Float']['input'];
-  radius_meters?: InputMaybe<Scalars['Float']['input']>;
-  source?: InputMaybe<Scalars['String']['input']>;
-  limit?: InputMaybe<Scalars['Int']['input']>;
+  lat: number;
+  lon: number;
+  radius_meters?: number | null | undefined;
+  source?: string | null | undefined;
+  limit?: number | null | undefined;
 }>;
 
 
-export type NearbyPointsQuery = { __typename?: 'Query', nearbyPoints: Array<{ __typename?: 'NearbyPoint', source: string, id: number, latitude: number, longitude: number, distance_meters: number, timestamp: string }> };
+export type NearbyPointsQuery = { nearbyPoints: Array<{ source: string, id: number, latitude: number, longitude: number, distance_meters: number, timestamp: string }> };
 
 export type CalculateDistanceQueryVariables = Exact<{
-  from_lat: Scalars['Float']['input'];
-  from_lon: Scalars['Float']['input'];
-  to_lat: Scalars['Float']['input'];
-  to_lon: Scalars['Float']['input'];
+  from_lat: number;
+  from_lon: number;
+  to_lat: number;
+  to_lon: number;
 }>;
 
 
-export type CalculateDistanceQuery = { __typename?: 'Query', calculateDistance: { __typename?: 'DistanceResult', distance_meters: number, from_lat: number, from_lon: number, to_lat: number, to_lon: number } };
+export type CalculateDistanceQuery = { calculateDistance: { distance_meters: number, from_lat: number, from_lon: number, to_lat: number, to_lon: number } };
 
 export type WithinReferenceQueryVariables = Exact<{
-  name: Scalars['String']['input'];
-  source?: InputMaybe<Scalars['String']['input']>;
-  limit?: InputMaybe<Scalars['Int']['input']>;
+  name: string;
+  source?: string | null | undefined;
+  limit?: number | null | undefined;
 }>;
 
 
-export type WithinReferenceQuery = { __typename?: 'Query', withinReference: { __typename?: 'WithinReferenceResult', reference_name: string, radius_meters: number, total_points: number, points: Array<{ __typename?: 'NearbyPoint', source: string, id: number, latitude: number, longitude: number, distance_meters: number, timestamp: string }> } };
+export type WithinReferenceQuery = { withinReference: { reference_name: string, radius_meters: number, total_points: number, points: Array<{ source: string, id: number, latitude: number, longitude: number, distance_meters: number, timestamp: string }> } };
 
 export type UnifiedGpsQueryVariables = Exact<{
-  source?: InputMaybe<Scalars['String']['input']>;
-  date_from?: InputMaybe<Scalars['String']['input']>;
-  date_to?: InputMaybe<Scalars['String']['input']>;
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  offset?: InputMaybe<Scalars['Int']['input']>;
-  order?: InputMaybe<SortOrder>;
-  exclude_stationary?: InputMaybe<Scalars['Boolean']['input']>;
-  deduplicate?: InputMaybe<Scalars['Boolean']['input']>;
+  source?: string | null | undefined;
+  date_from?: string | null | undefined;
+  date_to?: string | null | undefined;
+  limit?: number | null | undefined;
+  offset?: number | null | undefined;
+  order?: SortOrder | null | undefined;
+  exclude_stationary?: boolean | null | undefined;
+  deduplicate?: boolean | null | undefined;
 }>;
 
 
-export type UnifiedGpsQuery = { __typename?: 'Query', unifiedGps: { __typename?: 'UnifiedGpsConnection', total: number, limit: number, offset: number, items: Array<{ __typename?: 'UnifiedGpsPoint', source: string, identifier: string, latitude: number, longitude: number, timestamp: string, accuracy?: number | null, battery?: number | null, speed_kmh?: number | null, heart_rate?: number | null, created_at?: string | null }> } };
+export type UnifiedGpsQuery = { unifiedGps: { total: number, limit: number, offset: number, items: Array<{ source: string, identifier: string, latitude: number, longitude: number, timestamp: string, accuracy: number | null, battery: number | null, speed_kmh: number | null, heart_rate: number | null, created_at: string | null }> } };
 
 export type DailySummaryQueryVariables = Exact<{
-  date_from?: InputMaybe<Scalars['String']['input']>;
-  date_to?: InputMaybe<Scalars['String']['input']>;
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  offset?: InputMaybe<Scalars['Int']['input']>;
+  date_from?: string | null | undefined;
+  date_to?: string | null | undefined;
+  limit?: number | null | undefined;
+  offset?: number | null | undefined;
 }>;
 
 
-export type DailySummaryQuery = { __typename?: 'Query', dailySummary: { __typename?: 'DailySummaryConnection', total: number, limit: number, offset: number, items: Array<{ __typename?: 'DailyActivitySummary', activity_date?: string | null, owntracks_device?: string | null, owntracks_points?: number | null, min_battery?: number | null, max_battery?: number | null, avg_accuracy?: number | null, garmin_sport?: string | null, garmin_activities?: number | null, total_distance_km?: number | null, total_duration_seconds?: number | null, avg_heart_rate?: number | null, total_calories?: number | null }> } };
+export type DailySummaryQuery = { dailySummary: { total: number, limit: number, offset: number, items: Array<{ activity_date: string | null, owntracks_device: string | null, owntracks_points: number | null, min_battery: number | null, max_battery: number | null, avg_accuracy: number | null, garmin_sport: string | null, garmin_activities: number | null, total_distance_km: number | null, total_duration_seconds: number | null, avg_heart_rate: number | null, total_calories: number | null }> } };
 
 export type DailySummaryDateRangeQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type DailySummaryDateRangeQuery = { __typename?: 'Query', dailySummaryDateRange: { __typename?: 'DailySummaryDateRange', min_date: string, max_date: string } };
+export type DailySummaryDateRangeQuery = { dailySummaryDateRange: { min_date: string, max_date: string } };
 
 
 export const GarminActivitiesDocument = gql`
@@ -1414,6 +1536,76 @@ export function useTriggerGarminSyncMutation(baseOptions?: ApolloReactHooks.Muta
 export type TriggerGarminSyncMutationHookResult = ReturnType<typeof useTriggerGarminSyncMutation>;
 export type TriggerGarminSyncMutationResult = ApolloReactCommon.MutationResult<TriggerGarminSyncMutation>;
 export type TriggerGarminSyncMutationOptions = ApolloReactCommon.BaseMutationOptions<TriggerGarminSyncMutation, TriggerGarminSyncMutationVariables>;
+export const GarminExportPointsDocument = gql`
+    query GarminExportPoints($activity_id: String!) {
+  garminTrackPoints(activity_id: $activity_id, limit: 25000) {
+    items {
+      id
+      activity_id
+      timestamp
+      latitude
+      longitude
+      altitude
+      distance_from_start_km
+      speed_kmh
+      heart_rate
+      cadence
+      temperature_c
+      address {
+        display_address
+        street
+        housenumber
+        neighbourhood
+        locality
+        region
+        country
+        postalcode
+        confidence
+        waypoint_kind
+        status
+        geocoded_at
+      }
+    }
+    total
+  }
+}
+    `;
+
+/**
+ * __useGarminExportPointsQuery__
+ *
+ * To run a query within a React component, call `useGarminExportPointsQuery` and pass it any options that fit your needs.
+ * When your component renders, `useGarminExportPointsQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useGarminExportPointsQuery({
+ *   variables: {
+ *      activity_id: // value for 'activity_id'
+ *   },
+ * });
+ */
+export function useGarminExportPointsQuery(baseOptions: ApolloReactHooks.QueryHookOptions<GarminExportPointsQuery, GarminExportPointsQueryVariables> & ({ variables: GarminExportPointsQueryVariables; skip?: boolean; } | { skip: boolean; }) ) {
+        const options = {...defaultOptions, ...baseOptions}
+        return ApolloReactHooks.useQuery<GarminExportPointsQuery, GarminExportPointsQueryVariables>(GarminExportPointsDocument, options);
+      }
+export function useGarminExportPointsLazyQuery(baseOptions?: ApolloReactHooks.LazyQueryHookOptions<GarminExportPointsQuery, GarminExportPointsQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return ApolloReactHooks.useLazyQuery<GarminExportPointsQuery, GarminExportPointsQueryVariables>(GarminExportPointsDocument, options);
+        }
+// @ts-ignore
+export function useGarminExportPointsSuspenseQuery(baseOptions?: ApolloReactHooks.SuspenseQueryHookOptions<GarminExportPointsQuery, GarminExportPointsQueryVariables>): ApolloReactHooks.UseSuspenseQueryResult<GarminExportPointsQuery, GarminExportPointsQueryVariables>;
+export function useGarminExportPointsSuspenseQuery(baseOptions?: ApolloReactHooks.SkipToken | ApolloReactHooks.SuspenseQueryHookOptions<GarminExportPointsQuery, GarminExportPointsQueryVariables>): ApolloReactHooks.UseSuspenseQueryResult<GarminExportPointsQuery | undefined, GarminExportPointsQueryVariables>;
+export function useGarminExportPointsSuspenseQuery(baseOptions?: ApolloReactHooks.SkipToken | ApolloReactHooks.SuspenseQueryHookOptions<GarminExportPointsQuery, GarminExportPointsQueryVariables>) {
+          const options = baseOptions === ApolloReactHooks.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
+          return ApolloReactHooks.useSuspenseQuery<GarminExportPointsQuery, GarminExportPointsQueryVariables>(GarminExportPointsDocument, options);
+        }
+export type GarminExportPointsQueryHookResult = ReturnType<typeof useGarminExportPointsQuery>;
+export type GarminExportPointsLazyQueryHookResult = ReturnType<typeof useGarminExportPointsLazyQuery>;
+export type GarminExportPointsSuspenseQueryHookResult = ReturnType<typeof useGarminExportPointsSuspenseQuery>;
+export type GarminExportPointsQueryResult = ApolloReactCommon.QueryResult<GarminExportPointsQuery, GarminExportPointsQueryVariables>;
 export const GeocodingStatusDocument = gql`
     query GeocodingStatus {
   geocodingStatus {

--- a/src/__generated__/graphql.ts
+++ b/src/__generated__/graphql.ts
@@ -798,12 +798,7 @@ export type ReferenceLocation = {
   updated_at?: Maybe<Scalars['String']['output']>;
 };
 
-/** Sort direction for query results. */
-export type SortOrder =
-  /** Ascending order (oldest first, A-Z) */
-  | 'asc'
-  /** Descending order (newest first, Z-A) */
-  | 'desc';
+
 
 /** Sport type with its activity count. */
 export type SportInfo = {
@@ -941,6 +936,8 @@ export type TriggerGarminSyncMutation = { triggerGarminSync: { status: string, m
 
 export type GarminExportPointsQueryVariables = Exact<{
   activity_id: string;
+  limit?: number | null | undefined;
+  offset?: number | null | undefined;
 }>;
 
 
@@ -1537,8 +1534,8 @@ export type TriggerGarminSyncMutationHookResult = ReturnType<typeof useTriggerGa
 export type TriggerGarminSyncMutationResult = ApolloReactCommon.MutationResult<TriggerGarminSyncMutation>;
 export type TriggerGarminSyncMutationOptions = ApolloReactCommon.BaseMutationOptions<TriggerGarminSyncMutation, TriggerGarminSyncMutationVariables>;
 export const GarminExportPointsDocument = gql`
-    query GarminExportPoints($activity_id: String!) {
-  garminTrackPoints(activity_id: $activity_id, limit: 25000) {
+    query GarminExportPoints($activity_id: String!, $limit: Int, $offset: Int) {
+  garminTrackPoints(activity_id: $activity_id, limit: $limit, offset: $offset) {
     items {
       id
       activity_id
@@ -1584,6 +1581,8 @@ export const GarminExportPointsDocument = gql`
  * const { data, loading, error } = useGarminExportPointsQuery({
  *   variables: {
  *      activity_id: // value for 'activity_id'
+ *      limit: // value for 'limit'
+ *      offset: // value for 'offset'
  *   },
  * });
  */

--- a/src/graphql/garmin.ts
+++ b/src/graphql/garmin.ts
@@ -195,8 +195,8 @@ export const TRIGGER_GARMIN_SYNC_MUTATION = gql`
 `
 
 export const GARMIN_EXPORT_POINTS_QUERY = gql`
-  query GarminExportPoints($activity_id: String!) {
-    garminTrackPoints(activity_id: $activity_id, limit: 25000) {
+  query GarminExportPoints($activity_id: String!, $limit: Int, $offset: Int) {
+    garminTrackPoints(activity_id: $activity_id, limit: $limit, offset: $offset) {
       items {
         id
         activity_id

--- a/src/graphql/garmin.ts
+++ b/src/graphql/garmin.ts
@@ -193,3 +193,38 @@ export const TRIGGER_GARMIN_SYNC_MUTATION = gql`
     }
   }
 `
+
+export const GARMIN_EXPORT_POINTS_QUERY = gql`
+  query GarminExportPoints($activity_id: String!) {
+    garminTrackPoints(activity_id: $activity_id, limit: 25000) {
+      items {
+        id
+        activity_id
+        timestamp
+        latitude
+        longitude
+        altitude
+        distance_from_start_km
+        speed_kmh
+        heart_rate
+        cadence
+        temperature_c
+        address {
+          display_address
+          street
+          housenumber
+          neighbourhood
+          locality
+          region
+          country
+          postalcode
+          confidence
+          waypoint_kind
+          status
+          geocoded_at
+        }
+      }
+      total
+    }
+  }
+`

--- a/src/graphql/garmin.ts
+++ b/src/graphql/garmin.ts
@@ -196,7 +196,11 @@ export const TRIGGER_GARMIN_SYNC_MUTATION = gql`
 
 export const GARMIN_EXPORT_POINTS_QUERY = gql`
   query GarminExportPoints($activity_id: String!, $limit: Int, $offset: Int) {
-    garminTrackPoints(activity_id: $activity_id, limit: $limit, offset: $offset) {
+    garminTrackPoints(
+      activity_id: $activity_id
+      limit: $limit
+      offset: $offset
+    ) {
       items {
         id
         activity_id

--- a/src/lib/export.ts
+++ b/src/lib/export.ts
@@ -1,0 +1,40 @@
+/**
+ * Shared export utilities for CSV and file download helpers.
+ * Used by pages that offer on-demand data export (CSV, GeoJSON, etc.).
+ */
+
+/**
+ * Wraps a value in CSV-safe quotes when it contains commas, quotes, or
+ * newline characters. Returns an empty string for null / undefined values.
+ */
+export function escapeCsvValue(value: unknown): string {
+  if (value == null) return ''
+  const str = String(value)
+  if (/[,"\n\r]/.test(str)) {
+    return `"${str.replace(/"/g, '""')}"`
+  }
+  return str
+}
+
+/**
+ * Triggers a browser file download for the given string content.
+ *
+ * @param content  - String content to write to the file.
+ * @param mime     - MIME type (e.g. 'text/csv', 'application/geo+json').
+ * @param filename - Suggested download filename.
+ */
+export function triggerDownload(
+  content: string,
+  mime: string,
+  filename: string,
+): void {
+  const blob = new Blob([content], { type: mime })
+  const url = URL.createObjectURL(blob)
+  const a = document.createElement('a')
+  a.href = url
+  a.download = filename
+  document.body.appendChild(a)
+  a.click()
+  document.body.removeChild(a)
+  URL.revokeObjectURL(url)
+}

--- a/src/pages/DailySummaryDetailPage.tsx
+++ b/src/pages/DailySummaryDetailPage.tsx
@@ -39,6 +39,7 @@ import {
   TableRow,
 } from '@/components/ui/table'
 import { toLocalDate } from '@/lib/date-range'
+import { escapeCsvValue, triggerDownload } from '@/lib/export'
 
 const PAGE_SIZE = 100
 const EXPORT_LIMIT = 10000
@@ -71,27 +72,6 @@ function parseColorBy(value: string | null): ColorBy {
 
 function parseBoolParam(value: string | null): boolean {
   return value === '1' || value === 'true'
-}
-
-function escapeCsvValue(value: unknown): string {
-  if (value == null) return ''
-  const str = String(value)
-  if (/[,"\n\r]/.test(str)) {
-    return `"${str.replace(/"/g, '""')}"`
-  }
-  return str
-}
-
-function triggerDownload(content: string, mime: string, filename: string) {
-  const blob = new Blob([content], { type: mime })
-  const url = URL.createObjectURL(blob)
-  const a = document.createElement('a')
-  a.href = url
-  a.download = filename
-  document.body.appendChild(a)
-  a.click()
-  document.body.removeChild(a)
-  URL.revokeObjectURL(url)
 }
 
 export function DailySummaryDetailPage() {

--- a/src/pages/GarminDetailPage.test.tsx
+++ b/src/pages/GarminDetailPage.test.tsx
@@ -8,6 +8,7 @@ const garminDetailHooks = vi.hoisted(() => ({
   useGarminActivityQuery: vi.fn(),
   useGarminTrackPointsQuery: vi.fn(),
   useGarminChartDataQuery: vi.fn(),
+  useGarminExportPointsLazyQuery: vi.fn(),
 }))
 
 vi.mock('@/__generated__/graphql', () => garminDetailHooks)
@@ -45,6 +46,13 @@ describe('GarminDetailPage', () => {
     garminDetailHooks.useGarminActivityQuery.mockReset()
     garminDetailHooks.useGarminTrackPointsQuery.mockReset()
     garminDetailHooks.useGarminChartDataQuery.mockReset()
+    garminDetailHooks.useGarminExportPointsLazyQuery.mockReset()
+
+    // Default no-op export hook so tests that don't exercise export don't crash.
+    garminDetailHooks.useGarminExportPointsLazyQuery.mockReturnValue([
+      vi.fn(),
+      { loading: false },
+    ])
   })
 
   function renderPage(
@@ -185,5 +193,146 @@ describe('GarminDetailPage', () => {
     renderPage()
 
     expect(screen.getByText('Activity not found')).toBeInTheDocument()
+  })
+
+  // ---------------------------------------------------------------------------
+  // Export helpers
+  // ---------------------------------------------------------------------------
+
+  function mockLoadedActivity() {
+    garminDetailHooks.useGarminActivityQuery.mockReturnValue({
+      loading: false,
+      error: undefined,
+      refetch: vi.fn(),
+      data: {
+        garminActivity: {
+          sport: 'cycling',
+          sub_sport: 'road',
+          start_time: '2026-03-14T09:00:00Z',
+          device_manufacturer: 'Garmin',
+          distance_km: 50.6,
+          duration_seconds: 6932,
+          avg_speed_kmh: 26.3,
+          total_ascent_m: 385,
+        },
+      },
+    })
+    garminDetailHooks.useGarminTrackPointsQuery.mockReturnValue({
+      loading: false,
+      data: { garminTrackPoints: { items: [] } },
+    })
+    garminDetailHooks.useGarminChartDataQuery.mockReturnValue({
+      loading: false,
+      error: undefined,
+      data: { garminChartData: [] },
+    })
+  }
+
+  function mockExportPoints() {
+    return [
+      {
+        id: 1,
+        activity_id: '42',
+        timestamp: '2026-03-14T09:00:00Z',
+        latitude: 40.715,
+        longitude: -74.017,
+        altitude: 12.4,
+        distance_from_start_km: 0.0,
+        speed_kmh: 24.5,
+        heart_rate: 135,
+        cadence: 80,
+        temperature_c: 18,
+        address: {
+          display_address: 'Pier 13, Hoboken, NJ',
+          street: 'Sinatra Drive',
+          housenumber: '1301',
+          neighbourhood: 'Waterfront',
+          locality: 'Hoboken',
+          region: 'New Jersey',
+          country: 'United States',
+          postalcode: '07030',
+          confidence: 0.92,
+          waypoint_kind: 'start',
+          status: 'success',
+          geocoded_at: '2026-02-12T08:10:55Z',
+        },
+      },
+    ]
+  }
+
+  it('clicking Export CSV calls the lazy query and triggers a CSV download', async () => {
+    const user = userEvent.setup()
+    mockLoadedActivity()
+
+    const fetchExport = vi.fn().mockResolvedValue({
+      data: {
+        garminTrackPoints: { total: 1, items: mockExportPoints() },
+      },
+    })
+    garminDetailHooks.useGarminExportPointsLazyQuery.mockReturnValue([
+      fetchExport,
+      { loading: false },
+    ])
+
+    const createObjectURL = vi.fn(() => 'blob:test')
+    const revokeObjectURL = vi.fn()
+    const clickSpy = vi.fn()
+    vi.stubGlobal('URL', { createObjectURL, revokeObjectURL })
+    vi
+      .spyOn(HTMLAnchorElement.prototype, 'click')
+      .mockImplementation(clickSpy)
+
+    renderPage()
+
+    await user.click(screen.getByRole('button', { name: /Export CSV/i }))
+
+    expect(fetchExport).toHaveBeenCalledWith(
+      expect.objectContaining({
+        variables: expect.objectContaining({ activity_id: '42' }),
+      }),
+    )
+    expect(createObjectURL).toHaveBeenCalledTimes(1)
+    expect(clickSpy).toHaveBeenCalledTimes(1)
+
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+  })
+
+  it('clicking Export GeoJSON calls the lazy query and triggers a GeoJSON download', async () => {
+    const user = userEvent.setup()
+    mockLoadedActivity()
+
+    const fetchExport = vi.fn().mockResolvedValue({
+      data: {
+        garminTrackPoints: { total: 1, items: mockExportPoints() },
+      },
+    })
+    garminDetailHooks.useGarminExportPointsLazyQuery.mockReturnValue([
+      fetchExport,
+      { loading: false },
+    ])
+
+    const createObjectURL = vi.fn(() => 'blob:test')
+    const revokeObjectURL = vi.fn()
+    const clickSpy = vi.fn()
+    vi.stubGlobal('URL', { createObjectURL, revokeObjectURL })
+    vi
+      .spyOn(HTMLAnchorElement.prototype, 'click')
+      .mockImplementation(clickSpy)
+
+    renderPage()
+
+    await user.click(screen.getByRole('button', { name: /Export GeoJSON/i }))
+
+    expect(fetchExport).toHaveBeenCalledWith(
+      expect.objectContaining({
+        variables: expect.objectContaining({ activity_id: '42' }),
+      }),
+    )
+    expect(createObjectURL).toHaveBeenCalledTimes(1)
+    expect(clickSpy).toHaveBeenCalledTimes(1)
+
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
   })
 })

--- a/src/pages/GarminDetailPage.test.tsx
+++ b/src/pages/GarminDetailPage.test.tsx
@@ -278,9 +278,7 @@ describe('GarminDetailPage', () => {
     const revokeObjectURL = vi.fn()
     const clickSpy = vi.fn()
     vi.stubGlobal('URL', { createObjectURL, revokeObjectURL })
-    vi
-      .spyOn(HTMLAnchorElement.prototype, 'click')
-      .mockImplementation(clickSpy)
+    vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(clickSpy)
 
     renderPage()
 
@@ -316,9 +314,7 @@ describe('GarminDetailPage', () => {
     const revokeObjectURL = vi.fn()
     const clickSpy = vi.fn()
     vi.stubGlobal('URL', { createObjectURL, revokeObjectURL })
-    vi
-      .spyOn(HTMLAnchorElement.prototype, 'click')
-      .mockImplementation(clickSpy)
+    vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(clickSpy)
 
     renderPage()
 

--- a/src/pages/GarminDetailPage.tsx
+++ b/src/pages/GarminDetailPage.tsx
@@ -20,30 +20,12 @@ import { ActivityHoverDetails } from '@/components/garmin/ActivityHoverDetails'
 import { ActivityStatsPanel } from '@/components/garmin/ActivityStatsPanel'
 import { Button } from '@/components/ui/button'
 import { setNRCustomAttribute } from '@/lib/newrelic-browser'
+import { escapeCsvValue, triggerDownload } from '@/lib/export'
 
 /** Douglas-Peucker tolerance in degrees (~1.1 m) for PostGIS ST_Simplify */
 const SIMPLIFY_TOLERANCE = 0.00001
-
-function escapeCsvValue(value: unknown): string {
-  if (value == null) return ''
-  const str = String(value)
-  if (/[,"\n\r]/.test(str)) {
-    return `"${str.replace(/"/g, '""')}"`
-  }
-  return str
-}
-
-function triggerDownload(content: string, mime: string, filename: string) {
-  const blob = new Blob([content], { type: mime })
-  const url = URL.createObjectURL(blob)
-  const a = document.createElement('a')
-  a.href = url
-  a.download = filename
-  document.body.appendChild(a)
-  a.click()
-  document.body.removeChild(a)
-  URL.revokeObjectURL(url)
-}
+/** Maximum track points fetched per page when exporting. */
+const EXPORT_PAGE_SIZE = 10000
 
 export function GarminDetailPage() {
   const { activityId } = useParams<{ activityId: string }>()
@@ -74,10 +56,28 @@ export function GarminDetailPage() {
 
   async function handleExport(format: 'csv' | 'geojson') {
     if (!activityId) return
-    const result = await fetchExportPoints({
-      variables: { activity_id: activityId },
-    })
-    const points = result.data?.garminTrackPoints?.items ?? []
+
+    // Page through all track points in batches to avoid the 25 k hard limit.
+    type TrackItem = NonNullable<
+      Awaited<ReturnType<typeof fetchExportPoints>>['data']
+    >['garminTrackPoints']['items'][number]
+    const allPoints: TrackItem[] = []
+    let offset = 0
+    let total = Infinity
+
+    while (offset < total) {
+      const result = await fetchExportPoints({
+        variables: { activity_id: activityId, limit: EXPORT_PAGE_SIZE, offset },
+      })
+      const page = result.data?.garminTrackPoints
+      if (!page) break
+      total = page.total
+      allPoints.push(...(page.items ?? []))
+      offset += EXPORT_PAGE_SIZE
+      if (allPoints.length >= total) break
+    }
+
+    const points = allPoints
     if (points.length === 0) return
 
     if (format === 'csv') {

--- a/src/pages/GarminDetailPage.tsx
+++ b/src/pages/GarminDetailPage.tsx
@@ -136,7 +136,11 @@ export function GarminDetailPage() {
           .join(','),
       )
       const csv = [headers.join(','), ...rows].join('\n')
-      triggerDownload(csv, 'text/csv', `garmin_activity_${activityId}_points.csv`)
+      triggerDownload(
+        csv,
+        'text/csv',
+        `garmin_activity_${activityId}_points.csv`,
+      )
     } else {
       const geojson = {
         type: 'FeatureCollection' as const,

--- a/src/pages/GarminDetailPage.tsx
+++ b/src/pages/GarminDetailPage.tsx
@@ -1,9 +1,11 @@
 import { useParams, useLocation } from 'react-router-dom'
 import { useEffect, useState } from 'react'
+import { Download, Loader2 } from 'lucide-react'
 import {
   useGarminActivityQuery,
   useGarminTrackPointsQuery,
   useGarminChartDataQuery,
+  useGarminExportPointsLazyQuery,
 } from '@/__generated__/graphql'
 import { LoadingState } from '@/components/shared/LoadingState'
 import { ErrorState } from '@/components/shared/ErrorState'
@@ -16,10 +18,32 @@ import {
 } from '@/components/garmin/ActivityCharts'
 import { ActivityHoverDetails } from '@/components/garmin/ActivityHoverDetails'
 import { ActivityStatsPanel } from '@/components/garmin/ActivityStatsPanel'
+import { Button } from '@/components/ui/button'
 import { setNRCustomAttribute } from '@/lib/newrelic-browser'
 
 /** Douglas-Peucker tolerance in degrees (~1.1 m) for PostGIS ST_Simplify */
 const SIMPLIFY_TOLERANCE = 0.00001
+
+function escapeCsvValue(value: unknown): string {
+  if (value == null) return ''
+  const str = String(value)
+  if (/[,"\n\r]/.test(str)) {
+    return `"${str.replace(/"/g, '""')}"`
+  }
+  return str
+}
+
+function triggerDownload(content: string, mime: string, filename: string) {
+  const blob = new Blob([content], { type: mime })
+  const url = URL.createObjectURL(blob)
+  const a = document.createElement('a')
+  a.href = url
+  a.download = filename
+  document.body.appendChild(a)
+  a.click()
+  document.body.removeChild(a)
+  URL.revokeObjectURL(url)
+}
 
 export function GarminDetailPage() {
   const { activityId } = useParams<{ activityId: string }>()
@@ -44,6 +68,116 @@ export function GarminDetailPage() {
     location.state as { garminListSearch?: string } | null
   )?.garminListSearch
   const backTo = garminListSearch ? `/garmin?${garminListSearch}` : '/garmin'
+
+  const [fetchExportPoints, { loading: exportLoading }] =
+    useGarminExportPointsLazyQuery({ fetchPolicy: 'no-cache' })
+
+  async function handleExport(format: 'csv' | 'geojson') {
+    if (!activityId) return
+    const result = await fetchExportPoints({
+      variables: { activity_id: activityId },
+    })
+    const points = result.data?.garminTrackPoints?.items ?? []
+    if (points.length === 0) return
+
+    if (format === 'csv') {
+      const headers = [
+        'activity_id',
+        'track_point_id',
+        'timestamp',
+        'latitude',
+        'longitude',
+        'altitude',
+        'distance_from_start_km',
+        'speed_kmh',
+        'heart_rate',
+        'cadence',
+        'temperature_c',
+        'geocode_status',
+        'confidence',
+        'waypoint_kind',
+        'display_address',
+        'street',
+        'housenumber',
+        'neighbourhood',
+        'locality',
+        'region',
+        'country',
+        'postalcode',
+        'geocoded_at',
+      ]
+      const rows = points.map((p) =>
+        [
+          p.activity_id,
+          p.id,
+          p.timestamp,
+          p.latitude,
+          p.longitude,
+          p.altitude,
+          p.distance_from_start_km,
+          p.speed_kmh,
+          p.heart_rate,
+          p.cadence,
+          p.temperature_c,
+          p.address?.status ?? '',
+          p.address?.confidence,
+          p.address?.waypoint_kind,
+          p.address?.display_address,
+          p.address?.street,
+          p.address?.housenumber,
+          p.address?.neighbourhood,
+          p.address?.locality,
+          p.address?.region,
+          p.address?.country,
+          p.address?.postalcode,
+          p.address?.geocoded_at,
+        ]
+          .map(escapeCsvValue)
+          .join(','),
+      )
+      const csv = [headers.join(','), ...rows].join('\n')
+      triggerDownload(csv, 'text/csv', `garmin_activity_${activityId}_points.csv`)
+    } else {
+      const geojson = {
+        type: 'FeatureCollection' as const,
+        features: points.map((p) => ({
+          type: 'Feature' as const,
+          geometry: {
+            type: 'Point' as const,
+            coordinates: [p.longitude, p.latitude],
+          },
+          properties: {
+            activity_id: p.activity_id,
+            track_point_id: p.id,
+            timestamp: p.timestamp,
+            altitude: p.altitude,
+            distance_from_start_km: p.distance_from_start_km,
+            speed_kmh: p.speed_kmh,
+            heart_rate: p.heart_rate,
+            cadence: p.cadence,
+            temperature_c: p.temperature_c,
+            geocode_status: p.address?.status ?? null,
+            confidence: p.address?.confidence ?? null,
+            waypoint_kind: p.address?.waypoint_kind ?? null,
+            display_address: p.address?.display_address ?? null,
+            street: p.address?.street ?? null,
+            housenumber: p.address?.housenumber ?? null,
+            neighbourhood: p.address?.neighbourhood ?? null,
+            locality: p.address?.locality ?? null,
+            region: p.address?.region ?? null,
+            country: p.address?.country ?? null,
+            postalcode: p.address?.postalcode ?? null,
+            geocoded_at: p.address?.geocoded_at ?? null,
+          },
+        })),
+      }
+      triggerDownload(
+        JSON.stringify(geojson, null, 2),
+        'application/geo+json',
+        `garmin_activity_${activityId}_points.geojson`,
+      )
+    }
+  }
   const { data, loading, error, refetch } = useGarminActivityQuery({
     variables: { activity_id: activityId ?? '' },
     skip: !activityId,
@@ -99,6 +233,35 @@ export function GarminDetailPage() {
         avgSpeedKmh={a.avg_speed_kmh}
         totalAscentM={a.total_ascent_m}
       />
+
+      <div className="flex gap-2">
+        <Button
+          variant="outline"
+          size="sm"
+          disabled={exportLoading}
+          onClick={() => handleExport('csv')}
+        >
+          {exportLoading ? (
+            <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+          ) : (
+            <Download className="mr-2 h-4 w-4" />
+          )}
+          Export CSV
+        </Button>
+        <Button
+          variant="outline"
+          size="sm"
+          disabled={exportLoading}
+          onClick={() => handleExport('geojson')}
+        >
+          {exportLoading ? (
+            <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+          ) : (
+            <Download className="mr-2 h-4 w-4" />
+          )}
+          Export GeoJSON
+        </Button>
+      </div>
 
       {trackLoading && <LoadingState message="Loading track data..." />}
 


### PR DESCRIPTION
## Summary
Implements CSV and GeoJSON export functionality for all Garmin activity track points with complete address mapping on the Garmin Activity detail page.

## Features
### Export Formats
1. **CSV Export**: All track point and address fields in columnar format
   - Track point fields: activity_id, id, timestamp, latitude, longitude, altitude, distance_from_start_km, speed_kmh, heart_rate, cadence, temperature_c
   - Address fields: geocode_status, confidence, waypoint_kind, display_address, street, housenumber, neighbourhood, locality, region, country, postalcode, geocoded_at
   - Filename: `garmin_activity_{id}_points.csv`

2. **GeoJSON Export**: FeatureCollection with Point features
   - Coordinates: [longitude, latitude]
   - All non-coordinate data as feature properties
   - Filename: `garmin_activity_{id}_points.geojson`

### UI Changes
- Added export buttons below the Activity Stats Bar on the Garmin Activity detail page
- Export buttons show loading spinner while fetching data
- Uses lazy query hook to fetch all points with addresses on-demand (not pre-loaded)
- Implements CSV escaping and GeoJSON formatting utilities

## Implementation
- Added `GARMIN_EXPORT_POINTS_QUERY` GraphQL query in `src/graphql/garmin.ts`
- Added `escapeCsvValue()` and `triggerDownload()` utility functions
- Added `handleExport()` async handler for both CSV and GeoJSON formats
- Regenerated TypeScript types via codegen with `GRAPHQL_SCHEMA_PATH=../otel-data-gateway/src/schema/schema.graphql`

## Testing
- TypeScript validation passes (`npm run type-check`)
- UI tests pass (Vitest)
- Export query validates against schema

## Related Repos
- otel-data-api: Extended address fields in API
- otel-data-gateway: Extended GraphQL schema

## Deployment Order
Requires both otel-data-api and otel-data-gateway deployed first