### PR TITLE
Fix Garmin export button state

### DIFF
--- a/e2e/garmin-export.spec.ts
+++ b/e2e/garmin-export.spec.ts
@@ -192,14 +192,12 @@ test.describe('Garmin Activity Export Buttons', () => {
     const downloadPromise = page.waitForEvent('download')
     await csvButton.click()
 
-    // While CSV is exporting, the GeoJSON button must be `disabled`
-    // and its click must be a no-op (no second download, no extra
-    // spinner). We `click({ force: true })` to verify the underlying
-    // handler honors the guard, not just the disabled HTML attribute.
+    // While CSV is exporting, dispatch a DOM click event directly on
+    // the GeoJSON button. Native disabled buttons will not fire normal
+    // Playwright clicks, so this exercises the handler-level guard
+    // instead of only the disabled HTML attribute.
     await expect(geojsonButton).toBeDisabled({ timeout: 5_000 })
-    await geojsonButton.click({ force: true }).catch(() => {
-      /* clicking a disabled button can throw — that's fine */
-    })
+    await geojsonButton.dispatchEvent('click')
     await expect(page.getByTestId('export-geojson-spinner')).toHaveCount(0)
 
     // The original CSV download still completes successfully.

--- a/e2e/garmin-export.spec.ts
+++ b/e2e/garmin-export.spec.ts
@@ -1,0 +1,212 @@
+import { test, expect, type Page, type Route } from '@playwright/test'
+
+/**
+ * Validates the Garmin Activity Detail export buttons.
+ *
+ * The page renders two export buttons — "Export CSV" and "Export
+ * GeoJSON". Clicking one of them must only "activate" (show the
+ * spinner) for the clicked button; the *other* button should be
+ * disabled to prevent overlapping exports but must NOT render a
+ * spinner of its own.
+ *
+ * Default activity 9965963574 (~2 425 track points) can be overridden
+ * with the PLAYWRIGHT_GARMIN_ACTIVITY_ID environment variable.
+ */
+const ACTIVITY_ID = process.env.PLAYWRIGHT_GARMIN_ACTIVITY_ID ?? '9965963574'
+
+/**
+ * Intercept the GraphQL `GarminExportPoints` query, delay the response,
+ * and return a deterministic export payload. This keeps the in-flight
+ * loading state observable for assertions and avoids relying on a
+ * specific activity having exportable points in the live backend.
+ */
+async function mockExportQuery(page: Page, delayMs: number) {
+  let requestCount = 0
+
+  await page.route('**/*', async (route: Route) => {
+    const request = route.request()
+    if (request.method() !== 'POST') {
+      return route.continue()
+    }
+    const body = request.postData() ?? ''
+    if (body.includes('GarminExportPoints')) {
+      requestCount += 1
+      await new Promise((resolve) => setTimeout(resolve, delayMs))
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          data: {
+            garminTrackPoints: {
+              total: 1,
+              items: [
+                {
+                  id: 1,
+                  activity_id: ACTIVITY_ID,
+                  timestamp: '2026-03-14T09:00:00Z',
+                  latitude: 40.715,
+                  longitude: -74.017,
+                  altitude: 12.4,
+                  distance_from_start_km: 0,
+                  speed_kmh: 24.5,
+                  heart_rate: 135,
+                  cadence: 80,
+                  temperature_c: 18,
+                  address: {
+                    display_address: 'Pier 13, Hoboken, NJ',
+                    street: 'Sinatra Drive',
+                    housenumber: '1301',
+                    neighbourhood: 'Waterfront',
+                    locality: 'Hoboken',
+                    region: 'New Jersey',
+                    country: 'United States',
+                    postalcode: '07030',
+                    confidence: 0.92,
+                    waypoint_kind: 'start',
+                    status: 'success',
+                    geocoded_at: '2026-02-12T08:10:55Z',
+                  },
+                },
+              ],
+            },
+          },
+        }),
+      })
+    }
+    return route.continue()
+  })
+
+  return {
+    getRequestCount: () => requestCount,
+  }
+}
+
+test.describe('Garmin Activity Export Buttons', () => {
+  test.setTimeout(60_000)
+
+  test('both export buttons render in their idle state by default', async ({
+    page,
+  }) => {
+    await page.goto(`/garmin/${ACTIVITY_ID}`)
+
+    const csvButton = page.getByTestId('export-csv-button')
+    const geojsonButton = page.getByTestId('export-geojson-button')
+
+    await expect(csvButton).toBeVisible({ timeout: 20_000 })
+    await expect(geojsonButton).toBeVisible({ timeout: 20_000 })
+
+    // Neither button should be disabled before the user interacts.
+    await expect(csvButton).toBeEnabled()
+    await expect(geojsonButton).toBeEnabled()
+
+    // Neither spinner should be present in the idle state.
+    await expect(page.getByTestId('export-csv-spinner')).toHaveCount(0)
+    await expect(page.getByTestId('export-geojson-spinner')).toHaveCount(0)
+  })
+
+  test('clicking Export CSV only activates the CSV button, GeoJSON stays idle but disabled', async ({
+    page,
+  }) => {
+    await mockExportQuery(page, 1_500)
+    await page.goto(`/garmin/${ACTIVITY_ID}`)
+
+    const csvButton = page.getByTestId('export-csv-button')
+    const geojsonButton = page.getByTestId('export-geojson-button')
+    await expect(csvButton).toBeVisible({ timeout: 20_000 })
+
+    // Kick off the download but don't await it yet — we want to observe
+    // the mid-flight loading state before the response resolves.
+    const downloadPromise = page.waitForEvent('download')
+    await csvButton.click()
+
+    // Only the CSV spinner should be visible while the export is in flight.
+    await expect(page.getByTestId('export-csv-spinner')).toBeVisible({
+      timeout: 5_000,
+    })
+    await expect(page.getByTestId('export-geojson-spinner')).toHaveCount(0)
+
+    // Both buttons must be disabled — preventing the user from clicking
+    // GeoJSON mid-export — but only the CSV one is "activated".
+    await expect(csvButton).toBeDisabled()
+    await expect(geojsonButton).toBeDisabled()
+
+    // Finish: the download fires with the expected filename, and the
+    // page returns to its idle state.
+    const download = await downloadPromise
+    expect(download.suggestedFilename()).toBe(
+      `garmin_activity_${ACTIVITY_ID}_points.csv`,
+    )
+
+    await expect(page.getByTestId('export-csv-spinner')).toHaveCount(0, {
+      timeout: 10_000,
+    })
+    await expect(csvButton).toBeEnabled()
+    await expect(geojsonButton).toBeEnabled()
+  })
+
+  test('clicking Export GeoJSON only activates the GeoJSON button, CSV stays idle but disabled', async ({
+    page,
+  }) => {
+    await mockExportQuery(page, 1_500)
+    await page.goto(`/garmin/${ACTIVITY_ID}`)
+
+    const csvButton = page.getByTestId('export-csv-button')
+    const geojsonButton = page.getByTestId('export-geojson-button')
+    await expect(geojsonButton).toBeVisible({ timeout: 20_000 })
+
+    const downloadPromise = page.waitForEvent('download')
+    await geojsonButton.click()
+
+    // Only the GeoJSON spinner should be visible — this is the
+    // regression we are guarding against.
+    await expect(page.getByTestId('export-geojson-spinner')).toBeVisible({
+      timeout: 5_000,
+    })
+    await expect(page.getByTestId('export-csv-spinner')).toHaveCount(0)
+
+    await expect(csvButton).toBeDisabled()
+    await expect(geojsonButton).toBeDisabled()
+
+    const download = await downloadPromise
+    expect(download.suggestedFilename()).toBe(
+      `garmin_activity_${ACTIVITY_ID}_points.geojson`,
+    )
+
+    await expect(page.getByTestId('export-geojson-spinner')).toHaveCount(0, {
+      timeout: 10_000,
+    })
+    await expect(csvButton).toBeEnabled()
+    await expect(geojsonButton).toBeEnabled()
+  })
+
+  test('a second click on the other button during an in-flight export is ignored', async ({
+    page,
+  }) => {
+    const exportMock = await mockExportQuery(page, 1_500)
+    await page.goto(`/garmin/${ACTIVITY_ID}`)
+
+    const csvButton = page.getByTestId('export-csv-button')
+    const geojsonButton = page.getByTestId('export-geojson-button')
+    await expect(csvButton).toBeVisible({ timeout: 20_000 })
+
+    const downloadPromise = page.waitForEvent('download')
+    await csvButton.click()
+
+    // While CSV is exporting, the GeoJSON button must be `disabled`
+    // and its click must be a no-op (no second download, no extra
+    // spinner). We `click({ force: true })` to verify the underlying
+    // handler honors the guard, not just the disabled HTML attribute.
+    await expect(geojsonButton).toBeDisabled({ timeout: 5_000 })
+    await geojsonButton.click({ force: true }).catch(() => {
+      /* clicking a disabled button can throw — that's fine */
+    })
+    await expect(page.getByTestId('export-geojson-spinner')).toHaveCount(0)
+
+    // The original CSV download still completes successfully.
+    const download = await downloadPromise
+    expect(download.suggestedFilename()).toBe(
+      `garmin_activity_${ACTIVITY_ID}_points.csv`,
+    )
+    expect(exportMock.getRequestCount()).toBe(1)
+  })
+})

--- a/e2e/garmin-export.spec.ts
+++ b/e2e/garmin-export.spec.ts
@@ -13,6 +13,17 @@ import { test, expect, type Page, type Route } from '@playwright/test'
  * with the PLAYWRIGHT_GARMIN_ACTIVITY_ID environment variable.
  */
 const ACTIVITY_ID = process.env.PLAYWRIGHT_GARMIN_ACTIVITY_ID ?? '9965963574'
+const GRAPHQL_ENDPOINT_PATTERN =
+  /^https:\/\/gateway\.lab\.informationcart\.com\/(?:\?.*)?$|^http:\/\/(?:localhost|127\.0\.0\.1):4000\/(?:\?.*)?$/
+
+function isGarminExportOperation(body: string): boolean {
+  try {
+    const payload = JSON.parse(body) as { operationName?: string }
+    return payload.operationName === 'GarminExportPoints'
+  } catch {
+    return body.includes('GarminExportPoints')
+  }
+}
 
 /**
  * Intercept the GraphQL `GarminExportPoints` query, delay the response,
@@ -23,13 +34,13 @@ const ACTIVITY_ID = process.env.PLAYWRIGHT_GARMIN_ACTIVITY_ID ?? '9965963574'
 async function mockExportQuery(page: Page, delayMs: number) {
   let requestCount = 0
 
-  await page.route('**/*', async (route: Route) => {
+  await page.route(GRAPHQL_ENDPOINT_PATTERN, async (route: Route) => {
     const request = route.request()
     if (request.method() !== 'POST') {
       return route.continue()
     }
     const body = request.postData() ?? ''
-    if (body.includes('GarminExportPoints')) {
+    if (isGarminExportOperation(body)) {
       requestCount += 1
       await new Promise((resolve) => setTimeout(resolve, delayMs))
       return route.fulfill({

--- a/src/lib/export.ts
+++ b/src/lib/export.ts
@@ -36,5 +36,11 @@ export function triggerDownload(
   document.body.appendChild(a)
   a.click()
   document.body.removeChild(a)
-  window.setTimeout(() => URL.revokeObjectURL(url), 0)
+  const revokeObjectURL =
+    typeof URL.revokeObjectURL === 'function'
+      ? URL.revokeObjectURL.bind(URL)
+      : undefined
+  if (revokeObjectURL) {
+    window.setTimeout(() => revokeObjectURL(url), 0)
+  }
 }

--- a/src/lib/export.ts
+++ b/src/lib/export.ts
@@ -36,5 +36,5 @@ export function triggerDownload(
   document.body.appendChild(a)
   a.click()
   document.body.removeChild(a)
-  URL.revokeObjectURL(url)
+  window.setTimeout(() => URL.revokeObjectURL(url), 0)
 }

--- a/src/pages/GarminDetailPage.test.tsx
+++ b/src/pages/GarminDetailPage.test.tsx
@@ -1,4 +1,4 @@
-import { screen } from '@testing-library/react'
+import { fireEvent, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { Route, Routes } from 'react-router-dom'
@@ -401,6 +401,28 @@ describe('GarminDetailPage', () => {
         description: 'gateway unavailable',
       })
     })
+  })
+
+  it('ignores a second export click before React applies disabled state', () => {
+    mockLoadedActivity()
+
+    const fetchExport = vi.fn().mockReturnValue(new Promise(() => {}))
+    garminDetailHooks.useGarminExportPointsLazyQuery.mockReturnValue([
+      fetchExport,
+      { loading: false },
+    ])
+
+    renderPage()
+
+    fireEvent.click(screen.getByTestId('export-csv-button'))
+    fireEvent.click(screen.getByTestId('export-geojson-button'))
+
+    expect(fetchExport).toHaveBeenCalledTimes(1)
+    expect(fetchExport).toHaveBeenCalledWith(
+      expect.objectContaining({
+        variables: expect.objectContaining({ activity_id: '42' }),
+      }),
+    )
   })
 
   it('only activates the clicked export button — the other stays idle but disabled', async () => {

--- a/src/pages/GarminDetailPage.test.tsx
+++ b/src/pages/GarminDetailPage.test.tsx
@@ -10,8 +10,13 @@ const garminDetailHooks = vi.hoisted(() => ({
   useGarminChartDataQuery: vi.fn(),
   useGarminExportPointsLazyQuery: vi.fn(),
 }))
+const toastMocks = vi.hoisted(() => ({
+  error: vi.fn(),
+  warning: vi.fn(),
+}))
 
 vi.mock('@/__generated__/graphql', () => garminDetailHooks)
+vi.mock('sonner', () => ({ toast: toastMocks }))
 
 vi.mock('@/components/garmin/ActivityHeader', () => ({
   ActivityHeader: ({ backTo, sport }: { backTo: string; sport: string }) => (
@@ -47,6 +52,8 @@ describe('GarminDetailPage', () => {
     garminDetailHooks.useGarminTrackPointsQuery.mockReset()
     garminDetailHooks.useGarminChartDataQuery.mockReset()
     garminDetailHooks.useGarminExportPointsLazyQuery.mockReset()
+    toastMocks.error.mockReset()
+    toastMocks.warning.mockReset()
 
     // Default no-op export hook so tests that don't exercise export don't crash.
     garminDetailHooks.useGarminExportPointsLazyQuery.mockReturnValue([
@@ -327,6 +334,127 @@ describe('GarminDetailPage', () => {
     )
     expect(createObjectURL).toHaveBeenCalledTimes(1)
     expect(clickSpy).toHaveBeenCalledTimes(1)
+
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+  })
+
+  it('clicking Export GeoJSON downloads an empty FeatureCollection when no points are returned', async () => {
+    const user = userEvent.setup()
+    mockLoadedActivity()
+
+    const fetchExport = vi.fn().mockResolvedValue({
+      data: {
+        garminTrackPoints: { total: 0, items: [] },
+      },
+    })
+    garminDetailHooks.useGarminExportPointsLazyQuery.mockReturnValue([
+      fetchExport,
+      { loading: false },
+    ])
+
+    let exportedBlob: Blob | undefined
+    const createObjectURL = vi.fn((blob: Blob) => {
+      exportedBlob = blob
+      return 'blob:test'
+    })
+    const revokeObjectURL = vi.fn()
+    const clickSpy = vi.fn()
+    vi.stubGlobal('URL', { createObjectURL, revokeObjectURL })
+    vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(clickSpy)
+
+    renderPage()
+
+    await user.click(screen.getByRole('button', { name: /Export GeoJSON/i }))
+
+    expect(createObjectURL).toHaveBeenCalledTimes(1)
+    if (!exportedBlob) throw new Error('Expected export blob to be created')
+    expect(exportedBlob).toBeInstanceOf(Blob)
+    await expect(exportedBlob.text()).resolves.toBe(
+      JSON.stringify({ type: 'FeatureCollection', features: [] }, null, 2),
+    )
+    expect(clickSpy).toHaveBeenCalledTimes(1)
+    expect(toastMocks.warning).toHaveBeenCalledWith(
+      'No track points found for this activity',
+      expect.any(Object),
+    )
+
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+  })
+
+  it('shows an error toast when the export query fails', async () => {
+    const user = userEvent.setup()
+    mockLoadedActivity()
+
+    garminDetailHooks.useGarminExportPointsLazyQuery.mockReturnValue([
+      vi.fn().mockRejectedValue(new Error('gateway unavailable')),
+      { loading: false },
+    ])
+
+    renderPage()
+
+    await user.click(screen.getByRole('button', { name: /Export GeoJSON/i }))
+
+    await vi.waitFor(() => {
+      expect(toastMocks.error).toHaveBeenCalledWith('Export GEOJSON failed', {
+        description: 'gateway unavailable',
+      })
+    })
+  })
+
+  it('only activates the clicked export button — the other stays idle but disabled', async () => {
+    const user = userEvent.setup()
+    mockLoadedActivity()
+
+    // Build a manually-resolved promise so we can observe the in-flight
+    // loading window between click and resolution.
+    let resolveFetch: (value: unknown) => void = () => {}
+    const pending = new Promise((resolve) => {
+      resolveFetch = resolve
+    })
+    const fetchExport = vi.fn().mockReturnValue(pending)
+    garminDetailHooks.useGarminExportPointsLazyQuery.mockReturnValue([
+      fetchExport,
+      { loading: false },
+    ])
+
+    const createObjectURL = vi.fn(() => 'blob:test')
+    const revokeObjectURL = vi.fn()
+    vi.stubGlobal('URL', { createObjectURL, revokeObjectURL })
+    vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => {})
+
+    renderPage()
+
+    const csvButton = screen.getByTestId('export-csv-button')
+    const geojsonButton = screen.getByTestId('export-geojson-button')
+
+    // Before click — both buttons enabled, no spinners.
+    expect(csvButton).not.toBeDisabled()
+    expect(geojsonButton).not.toBeDisabled()
+    expect(screen.queryByTestId('export-csv-spinner')).toBeNull()
+    expect(screen.queryByTestId('export-geojson-spinner')).toBeNull()
+
+    await user.click(csvButton)
+
+    // Mid-flight — CSV button shows a spinner, both are disabled,
+    // and the GeoJSON button must NOT show a spinner.
+    expect(screen.getByTestId('export-csv-spinner')).toBeInTheDocument()
+    expect(screen.queryByTestId('export-geojson-spinner')).toBeNull()
+    expect(csvButton).toBeDisabled()
+    expect(geojsonButton).toBeDisabled()
+
+    // Resolve the in-flight export and wait for state to settle.
+    resolveFetch({
+      data: { garminTrackPoints: { total: 1, items: mockExportPoints() } },
+    })
+
+    await vi.waitFor(() => {
+      expect(screen.queryByTestId('export-csv-spinner')).toBeNull()
+    })
+    expect(screen.queryByTestId('export-geojson-spinner')).toBeNull()
+    expect(csvButton).not.toBeDisabled()
+    expect(geojsonButton).not.toBeDisabled()
 
     vi.unstubAllGlobals()
     vi.restoreAllMocks()

--- a/src/pages/GarminDetailPage.tsx
+++ b/src/pages/GarminDetailPage.tsx
@@ -1,5 +1,5 @@
 import { useParams, useLocation } from 'react-router-dom'
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { Download, Loader2 } from 'lucide-react'
 import { toast } from 'sonner'
 import {
@@ -62,14 +62,16 @@ export function GarminDetailPage() {
   const [activeExport, setActiveExport] = useState<'csv' | 'geojson' | null>(
     null,
   )
+  const exportInFlightRef = useRef(false)
   const isExporting = activeExport !== null
 
   async function handleExport(format: 'csv' | 'geojson') {
     if (!activityId) return
     // Prevent concurrent exports — the other button is disabled, but
     // also guard programmatic re-entry just in case.
-    if (activeExport !== null) return
+    if (exportInFlightRef.current) return
 
+    exportInFlightRef.current = true
     setActiveExport(format)
     try {
       // Page through all track points in batches to avoid the 25 k hard limit.
@@ -210,6 +212,7 @@ export function GarminDetailPage() {
           error instanceof Error ? error.message : 'Unknown export error',
       })
     } finally {
+      exportInFlightRef.current = false
       setActiveExport(null)
     }
   }

--- a/src/pages/GarminDetailPage.tsx
+++ b/src/pages/GarminDetailPage.tsx
@@ -1,6 +1,7 @@
 import { useParams, useLocation } from 'react-router-dom'
 import { useEffect, useState } from 'react'
 import { Download, Loader2 } from 'lucide-react'
+import { toast } from 'sonner'
 import {
   useGarminActivityQuery,
   useGarminTrackPointsQuery,
@@ -51,135 +52,165 @@ export function GarminDetailPage() {
   )?.garminListSearch
   const backTo = garminListSearch ? `/garmin?${garminListSearch}` : '/garmin'
 
-  const [fetchExportPoints, { loading: exportLoading }] =
-    useGarminExportPointsLazyQuery({ fetchPolicy: 'no-cache' })
+  const [fetchExportPoints] = useGarminExportPointsLazyQuery({
+    fetchPolicy: 'no-cache',
+  })
+  // Track *which* export button is actively running so that clicking
+  // "Export CSV" doesn't visually activate the "Export GeoJSON" button
+  // (or vice-versa). Both buttons share a `disabled` lock while an
+  // export is in flight, but only the clicked one shows the spinner.
+  const [activeExport, setActiveExport] = useState<'csv' | 'geojson' | null>(
+    null,
+  )
+  const isExporting = activeExport !== null
 
   async function handleExport(format: 'csv' | 'geojson') {
     if (!activityId) return
+    // Prevent concurrent exports — the other button is disabled, but
+    // also guard programmatic re-entry just in case.
+    if (activeExport !== null) return
 
-    // Page through all track points in batches to avoid the 25 k hard limit.
-    type TrackItem = NonNullable<
-      Awaited<ReturnType<typeof fetchExportPoints>>['data']
-    >['garminTrackPoints']['items'][number]
-    const allPoints: TrackItem[] = []
-    let offset = 0
-    let total = Infinity
+    setActiveExport(format)
+    try {
+      // Page through all track points in batches to avoid the 25 k hard limit.
+      type TrackItem = NonNullable<
+        Awaited<ReturnType<typeof fetchExportPoints>>['data']
+      >['garminTrackPoints']['items'][number]
+      const allPoints: TrackItem[] = []
+      let offset = 0
+      let total = Infinity
 
-    while (offset < total) {
-      const result = await fetchExportPoints({
-        variables: { activity_id: activityId, limit: EXPORT_PAGE_SIZE, offset },
-      })
-      const page = result.data?.garminTrackPoints
-      if (!page) break
-      total = page.total
-      allPoints.push(...(page.items ?? []))
-      offset += EXPORT_PAGE_SIZE
-      if (allPoints.length >= total) break
-    }
-
-    const points = allPoints
-    if (points.length === 0) return
-
-    if (format === 'csv') {
-      const headers = [
-        'activity_id',
-        'track_point_id',
-        'timestamp',
-        'latitude',
-        'longitude',
-        'altitude',
-        'distance_from_start_km',
-        'speed_kmh',
-        'heart_rate',
-        'cadence',
-        'temperature_c',
-        'geocode_status',
-        'confidence',
-        'waypoint_kind',
-        'display_address',
-        'street',
-        'housenumber',
-        'neighbourhood',
-        'locality',
-        'region',
-        'country',
-        'postalcode',
-        'geocoded_at',
-      ]
-      const rows = points.map((p) =>
-        [
-          p.activity_id,
-          p.id,
-          p.timestamp,
-          p.latitude,
-          p.longitude,
-          p.altitude,
-          p.distance_from_start_km,
-          p.speed_kmh,
-          p.heart_rate,
-          p.cadence,
-          p.temperature_c,
-          p.address?.status ?? '',
-          p.address?.confidence,
-          p.address?.waypoint_kind,
-          p.address?.display_address,
-          p.address?.street,
-          p.address?.housenumber,
-          p.address?.neighbourhood,
-          p.address?.locality,
-          p.address?.region,
-          p.address?.country,
-          p.address?.postalcode,
-          p.address?.geocoded_at,
-        ]
-          .map(escapeCsvValue)
-          .join(','),
-      )
-      const csv = [headers.join(','), ...rows].join('\n')
-      triggerDownload(
-        csv,
-        'text/csv',
-        `garmin_activity_${activityId}_points.csv`,
-      )
-    } else {
-      const geojson = {
-        type: 'FeatureCollection' as const,
-        features: points.map((p) => ({
-          type: 'Feature' as const,
-          geometry: {
-            type: 'Point' as const,
-            coordinates: [p.longitude, p.latitude],
+      while (offset < total) {
+        const result = await fetchExportPoints({
+          variables: {
+            activity_id: activityId,
+            limit: EXPORT_PAGE_SIZE,
+            offset,
           },
-          properties: {
-            activity_id: p.activity_id,
-            track_point_id: p.id,
-            timestamp: p.timestamp,
-            altitude: p.altitude,
-            distance_from_start_km: p.distance_from_start_km,
-            speed_kmh: p.speed_kmh,
-            heart_rate: p.heart_rate,
-            cadence: p.cadence,
-            temperature_c: p.temperature_c,
-            geocode_status: p.address?.status ?? null,
-            confidence: p.address?.confidence ?? null,
-            waypoint_kind: p.address?.waypoint_kind ?? null,
-            display_address: p.address?.display_address ?? null,
-            street: p.address?.street ?? null,
-            housenumber: p.address?.housenumber ?? null,
-            neighbourhood: p.address?.neighbourhood ?? null,
-            locality: p.address?.locality ?? null,
-            region: p.address?.region ?? null,
-            country: p.address?.country ?? null,
-            postalcode: p.address?.postalcode ?? null,
-            geocoded_at: p.address?.geocoded_at ?? null,
-          },
-        })),
+        })
+        const page = result.data?.garminTrackPoints
+        if (!page) break
+        total = page.total
+        allPoints.push(...(page.items ?? []))
+        offset += EXPORT_PAGE_SIZE
+        if (allPoints.length >= total) break
       }
-      triggerDownload(
-        JSON.stringify(geojson, null, 2),
-        'application/geo+json',
-        `garmin_activity_${activityId}_points.geojson`,
-      )
+
+      const points = allPoints
+      if (points.length === 0) {
+        toast.warning('No track points found for this activity', {
+          description: 'Exporting an empty file.',
+        })
+      }
+
+      if (format === 'csv') {
+        const headers = [
+          'activity_id',
+          'track_point_id',
+          'timestamp',
+          'latitude',
+          'longitude',
+          'altitude',
+          'distance_from_start_km',
+          'speed_kmh',
+          'heart_rate',
+          'cadence',
+          'temperature_c',
+          'geocode_status',
+          'confidence',
+          'waypoint_kind',
+          'display_address',
+          'street',
+          'housenumber',
+          'neighbourhood',
+          'locality',
+          'region',
+          'country',
+          'postalcode',
+          'geocoded_at',
+        ]
+        const rows = points.map((p) =>
+          [
+            p.activity_id,
+            p.id,
+            p.timestamp,
+            p.latitude,
+            p.longitude,
+            p.altitude,
+            p.distance_from_start_km,
+            p.speed_kmh,
+            p.heart_rate,
+            p.cadence,
+            p.temperature_c,
+            p.address?.status ?? '',
+            p.address?.confidence,
+            p.address?.waypoint_kind,
+            p.address?.display_address,
+            p.address?.street,
+            p.address?.housenumber,
+            p.address?.neighbourhood,
+            p.address?.locality,
+            p.address?.region,
+            p.address?.country,
+            p.address?.postalcode,
+            p.address?.geocoded_at,
+          ]
+            .map(escapeCsvValue)
+            .join(','),
+        )
+        const csv = [headers.join(','), ...rows].join('\n')
+        triggerDownload(
+          csv,
+          'text/csv',
+          `garmin_activity_${activityId}_points.csv`,
+        )
+      } else {
+        const geojson = {
+          type: 'FeatureCollection' as const,
+          features: points.map((p) => ({
+            type: 'Feature' as const,
+            geometry: {
+              type: 'Point' as const,
+              coordinates: [p.longitude, p.latitude],
+            },
+            properties: {
+              activity_id: p.activity_id,
+              track_point_id: p.id,
+              timestamp: p.timestamp,
+              altitude: p.altitude,
+              distance_from_start_km: p.distance_from_start_km,
+              speed_kmh: p.speed_kmh,
+              heart_rate: p.heart_rate,
+              cadence: p.cadence,
+              temperature_c: p.temperature_c,
+              geocode_status: p.address?.status ?? null,
+              confidence: p.address?.confidence ?? null,
+              waypoint_kind: p.address?.waypoint_kind ?? null,
+              display_address: p.address?.display_address ?? null,
+              street: p.address?.street ?? null,
+              housenumber: p.address?.housenumber ?? null,
+              neighbourhood: p.address?.neighbourhood ?? null,
+              locality: p.address?.locality ?? null,
+              region: p.address?.region ?? null,
+              country: p.address?.country ?? null,
+              postalcode: p.address?.postalcode ?? null,
+              geocoded_at: p.address?.geocoded_at ?? null,
+            },
+          })),
+        }
+        triggerDownload(
+          JSON.stringify(geojson, null, 2),
+          'application/geo+json',
+          `garmin_activity_${activityId}_points.geojson`,
+        )
+      }
+    } catch (error) {
+      toast.error(`Export ${format.toUpperCase()} failed`, {
+        description:
+          error instanceof Error ? error.message : 'Unknown export error',
+      })
+    } finally {
+      setActiveExport(null)
     }
   }
   const { data, loading, error, refetch } = useGarminActivityQuery({
@@ -242,11 +273,15 @@ export function GarminDetailPage() {
         <Button
           variant="outline"
           size="sm"
-          disabled={exportLoading}
+          data-testid="export-csv-button"
+          disabled={isExporting}
           onClick={() => handleExport('csv')}
         >
-          {exportLoading ? (
-            <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+          {activeExport === 'csv' ? (
+            <Loader2
+              data-testid="export-csv-spinner"
+              className="mr-2 h-4 w-4 animate-spin"
+            />
           ) : (
             <Download className="mr-2 h-4 w-4" />
           )}
@@ -255,11 +290,15 @@ export function GarminDetailPage() {
         <Button
           variant="outline"
           size="sm"
-          disabled={exportLoading}
+          data-testid="export-geojson-button"
+          disabled={isExporting}
           onClick={() => handleExport('geojson')}
         >
-          {exportLoading ? (
-            <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+          {activeExport === 'geojson' ? (
+            <Loader2
+              data-testid="export-geojson-spinner"
+              className="mr-2 h-4 w-4 animate-spin"
+            />
           ) : (
             <Download className="mr-2 h-4 w-4" />
           )}


### PR DESCRIPTION
## Summary

Fixes Garmin activity export button behavior and improves export feedback in the UI.

## Root Cause

Both export buttons used the same lazy-query loading state, so clicking one export made both buttons look active. Export failures or empty export responses could also appear as no visible result to the user.

## Changes

- Track the active export format (`csv` or `geojson`) separately from the shared disabled state.
- Add an immediate ref lock so rapid same-tick clicks cannot start concurrent exports.
- Show a spinner only on the clicked export button.
- Surface export failures with a toast.
- Export an empty GeoJSON FeatureCollection when no points are returned.
- Delay blob URL revocation while capturing the revoke function before scheduling cleanup.
- Add unit coverage and Playwright coverage for export-button behavior and re-entry handling.

## Review Feedback Addressed

- Added an immediate in-flight lock for concurrent export prevention.
- Captured and guarded `URL.revokeObjectURL` before delayed cleanup.
- Updated the Playwright second-click test to dispatch a DOM click event instead of relying on a disabled button click.

## Validation

- `npm run test:run -- GarminDetailPage.test.tsx`
- `npm run type-check`
- `npm run lint:all`
- `npm run build`
- `BASE_URL=http://127.0.0.1:5173 npx playwright test e2e/garmin-export.spec.ts`
- Real Playwright browser CSV download saved `/tmp/garmin_activity_22976779663_points.csv` with 10,064 data rows.

## Local Note

For local full-stack testing, start the gateway with `OTEL_DATA_API_URL=http://localhost:8080`; otherwise it can still target the deployed API from `.env`.
