### PR TITLE
[codex] Sync Garmin chart crosshair from map clicks

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -35,6 +35,7 @@
     "informationcart",
     "k8s",
     "keepalive",
+    "latlng",
     "latlngs",
     "Leaflet",
     "localhost",

--- a/e2e/garmin-charts.spec.ts
+++ b/e2e/garmin-charts.spec.ts
@@ -152,4 +152,43 @@ test.describe('Garmin Activity Charts', () => {
     })
     await expect(hoverMarker).toHaveCount(0, { timeout: 5_000 })
   })
+
+  test('clicking the route map syncs the chart crosshair', async ({ page }) => {
+    await page.goto(`/garmin/${ACTIVITY_ID}`)
+
+    const elevationCard = page.getByTestId('chart-elevation')
+    const speedCard = page.getByTestId('chart-speed')
+    const routeMap = page.getByTestId('activity-route-map')
+    const details = page.getByTestId('activity-hover-details')
+
+    await expect(elevationCard).toBeVisible({ timeout: 20_000 })
+    await expect(speedCard).toBeVisible({ timeout: 20_000 })
+    await expect(routeMap).toBeVisible({ timeout: 20_000 })
+    await expect(details).toContainText('Hover the Elevation')
+
+    await routeMap.scrollIntoViewIfNeeded()
+    const mapBox = await routeMap.boundingBox()
+    if (!mapBox) throw new Error('Route map bounding box unavailable')
+
+    await page.mouse.click(
+      mapBox.x + mapBox.width / 2,
+      mapBox.y + mapBox.height / 2,
+    )
+
+    await expect(details).not.toContainText('Hover the Elevation', {
+      timeout: 5_000,
+    })
+    await expect(details).toContainText(/-?\d+\.\d{5},\s*-?\d+\.\d{5}/)
+
+    await expect(
+      routeMap.locator('.leaflet-overlay-pane svg path.activity-hover-marker'),
+    ).toHaveCount(1, { timeout: 5_000 })
+    await expect(elevationCard.locator('.recharts-reference-line')).toHaveCount(
+      1,
+      { timeout: 5_000 },
+    )
+    await expect(speedCard.locator('.recharts-reference-line')).toHaveCount(1, {
+      timeout: 5_000,
+    })
+  })
 })

--- a/public/config.js
+++ b/public/config.js
@@ -1,0 +1,1 @@
+window.__ENV__ = window.__ENV__ || {};

--- a/src/components/garmin/ActivityChartData.ts
+++ b/src/components/garmin/ActivityChartData.ts
@@ -25,6 +25,13 @@ export interface ActivityChartDataResult {
   hasReliableDistance: boolean
 }
 
+export interface ActivityChartDataContext {
+  /** Epoch ms of the first sampled point, used to compute the time axis. */
+  startTime: number
+  /** Whether distance data is dense enough to drive the distance axis. */
+  hasReliableDistance: boolean
+}
+
 function downsample<T>(data: T[], target: number): T[] {
   if (data.length <= target) return data
   const step = data.length / target
@@ -38,20 +45,22 @@ function downsample<T>(data: T[], target: number): T[] {
   return result
 }
 
-export function buildActivityChartData(
-  trackPoints: ActivityChartTrackPoint[],
-): ActivityChartDataResult {
-  const sampled = downsample(trackPoints, 800)
-  if (sampled.length === 0) {
-    return { chartData: [], hasReliableDistance: false }
-  }
-
-  const startTime = new Date(sampled[0].timestamp).getTime()
-  const hasReliableDistance =
-    sampled.filter((pt) => pt.distance_from_start_km != null).length >=
-    sampled.length * 0.5
-
-  const chartData = sampled.map((pt) => ({
+/**
+ * Convert a single raw track point into the chart/display shape. Kept separate
+ * from {@link buildActivityChartData} so callers (e.g. map-click selection) can
+ * resolve the nearest *full-resolution* point and still render it with the same
+ * unit conversions the downsampled chart series uses.
+ *
+ * `startTime` and `hasReliableDistance` must be derived from the same source
+ * series (see {@link getActivityChartContext}) so the resulting `time`/
+ * `distance` values line up with the rendered charts.
+ */
+export function toChartDataPoint(
+  pt: ActivityChartTrackPoint,
+  startTime: number,
+  hasReliableDistance: boolean,
+): ChartDataPoint {
+  return {
     distance: hasReliableDistance
       ? pt.distance_from_start_km != null
         ? kmToMi(pt.distance_from_start_km)
@@ -64,7 +73,41 @@ export function buildActivityChartData(
     latitude: pt.latitude ?? null,
     longitude: pt.longitude ?? null,
     timestamp: pt.timestamp,
-  }))
+  }
+}
 
-  return { chartData, hasReliableDistance }
+/**
+ * Derive the shared conversion context (start time + distance reliability) from
+ * the same downsampled series the charts render, so map-click selections that
+ * resolve against full-resolution data stay consistent with the displayed
+ * charts.
+ */
+export function getActivityChartContext(
+  trackPoints: ActivityChartTrackPoint[],
+): ActivityChartDataContext | null {
+  const sampled = downsample(trackPoints, 800)
+  if (sampled.length === 0) return null
+
+  const startTime = new Date(sampled[0].timestamp).getTime()
+  const hasReliableDistance =
+    sampled.filter((pt) => pt.distance_from_start_km != null).length >=
+    sampled.length * 0.5
+
+  return { startTime, hasReliableDistance }
+}
+
+export function buildActivityChartData(
+  trackPoints: ActivityChartTrackPoint[],
+): ActivityChartDataResult {
+  const context = getActivityChartContext(trackPoints)
+  if (!context) {
+    return { chartData: [], hasReliableDistance: false }
+  }
+
+  const sampled = downsample(trackPoints, 800)
+  const chartData = sampled.map((pt) =>
+    toChartDataPoint(pt, context.startTime, context.hasReliableDistance),
+  )
+
+  return { chartData, hasReliableDistance: context.hasReliableDistance }
 }

--- a/src/components/garmin/ActivityChartData.ts
+++ b/src/components/garmin/ActivityChartData.ts
@@ -1,0 +1,70 @@
+import { kmToMi, kmhToMph, metersToFeet } from '@/lib/units'
+
+export interface ActivityChartTrackPoint {
+  distance_from_start_km?: number | null
+  timestamp: string
+  altitude?: number | null
+  speed_kmh?: number | null
+  latitude?: number | null
+  longitude?: number | null
+}
+
+export interface ChartDataPoint {
+  distance: number | null
+  distanceKm: number | null
+  time: number
+  elevation: number | null
+  speed: number | null
+  latitude: number | null
+  longitude: number | null
+  timestamp: string
+}
+
+export interface ActivityChartDataResult {
+  chartData: ChartDataPoint[]
+  hasReliableDistance: boolean
+}
+
+function downsample<T>(data: T[], target: number): T[] {
+  if (data.length <= target) return data
+  const step = data.length / target
+  const result: T[] = []
+  for (let i = 0; i < target; i++) {
+    result.push(data[Math.floor(i * step)])
+  }
+  if (result[result.length - 1] !== data[data.length - 1]) {
+    result.push(data[data.length - 1])
+  }
+  return result
+}
+
+export function buildActivityChartData(
+  trackPoints: ActivityChartTrackPoint[],
+): ActivityChartDataResult {
+  const sampled = downsample(trackPoints, 800)
+  if (sampled.length === 0) {
+    return { chartData: [], hasReliableDistance: false }
+  }
+
+  const startTime = new Date(sampled[0].timestamp).getTime()
+  const hasReliableDistance =
+    sampled.filter((pt) => pt.distance_from_start_km != null).length >=
+    sampled.length * 0.5
+
+  const chartData = sampled.map((pt) => ({
+    distance: hasReliableDistance
+      ? pt.distance_from_start_km != null
+        ? kmToMi(pt.distance_from_start_km)
+        : null
+      : null,
+    distanceKm: pt.distance_from_start_km ?? null,
+    time: (new Date(pt.timestamp).getTime() - startTime) / 60000,
+    elevation: pt.altitude != null ? metersToFeet(pt.altitude) : null,
+    speed: pt.speed_kmh != null ? kmhToMph(pt.speed_kmh) : null,
+    latitude: pt.latitude ?? null,
+    longitude: pt.longitude ?? null,
+    timestamp: pt.timestamp,
+  }))
+
+  return { chartData, hasReliableDistance }
+}

--- a/src/components/garmin/ActivityCharts.tsx
+++ b/src/components/garmin/ActivityCharts.tsx
@@ -5,24 +5,22 @@ import {
   XAxis,
   YAxis,
   CartesianGrid,
+  ReferenceDot,
+  ReferenceLine,
   Tooltip,
   ResponsiveContainer,
 } from 'recharts'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
-import { kmToMi, metersToFeet, kmhToMph } from '@/lib/units'
-
-interface TrackPoint {
-  distance_from_start_km?: number | null
-  timestamp: string
-  altitude?: number | null
-  speed_kmh?: number | null
-  latitude?: number | null
-  longitude?: number | null
-}
+import {
+  buildActivityChartData,
+  type ActivityChartTrackPoint,
+  type ChartDataPoint,
+} from './ActivityChartData'
 
 interface ActivityChartsProps {
-  trackPoints: TrackPoint[]
+  trackPoints: ActivityChartTrackPoint[]
+  activePoint?: ChartDataPoint | null
   /**
    * Notifies the parent which chart point is currently under the cursor so the
    * page can render a shared details panel and a map hover marker. The two
@@ -34,20 +32,6 @@ interface ActivityChartsProps {
 
 type XAxisMode = 'distance' | 'time'
 
-function downsample<T>(data: T[], target: number): T[] {
-  if (data.length <= target) return data
-  const step = data.length / target
-  const result: T[] = []
-  for (let i = 0; i < target; i++) {
-    result.push(data[Math.floor(i * step)])
-  }
-  // Always include last point
-  if (result[result.length - 1] !== data[data.length - 1]) {
-    result.push(data[data.length - 1])
-  }
-  return result
-}
-
 interface ChartConfig {
   title: string
   dataKey: string
@@ -56,54 +40,35 @@ interface ChartConfig {
   hasData: boolean
 }
 
-export interface ChartDataPoint {
-  distance: number | null
-  distanceKm: number | null
-  time: number
-  elevation: number | null
-  speed: number | null
-  latitude: number | null
-  longitude: number | null
-  timestamp: string
+function activeMetricValue(
+  point: ChartDataPoint | null | undefined,
+  dataKey: string,
+): number | null {
+  if (dataKey !== 'elevation' && dataKey !== 'speed') return null
+  const value = point?.[dataKey]
+  return typeof value === 'number' && Number.isFinite(value) ? value : null
 }
 
 export function ActivityCharts({
   trackPoints,
+  activePoint,
   onActivePointChange,
 }: ActivityChartsProps) {
   const [xMode, setXMode] = useState<XAxisMode>('distance')
 
   if (trackPoints.length === 0) return null
 
-  // Build chart data with unit conversions
-  const sampled = downsample(trackPoints, 800)
-  const startTime = new Date(sampled[0].timestamp).getTime()
-
-  // Determine whether distance_from_start_km is sufficiently populated to use as the X-axis
-  const hasReliableDistance =
-    sampled.filter((pt) => pt.distance_from_start_km != null).length >=
-    sampled.length * 0.5
-
-  const chartData = sampled.map((pt) => ({
-    distance: hasReliableDistance
-      ? pt.distance_from_start_km != null
-        ? kmToMi(pt.distance_from_start_km)
-        : null
-      : null,
-    distanceKm: pt.distance_from_start_km ?? null,
-    time: (new Date(pt.timestamp).getTime() - startTime) / 60000, // minutes
-    elevation: pt.altitude != null ? metersToFeet(pt.altitude) : null,
-    speed: pt.speed_kmh != null ? kmhToMph(pt.speed_kmh) : null,
-    latitude: pt.latitude ?? null,
-    longitude: pt.longitude ?? null,
-    timestamp: pt.timestamp,
-  }))
+  const { chartData, hasReliableDistance } = buildActivityChartData(trackPoints)
 
   // Fall back to time if distance data is too sparse
   const effectiveXMode =
     xMode === 'distance' && !hasReliableDistance ? 'time' : xMode
   const xKey = effectiveXMode === 'distance' ? 'distance' : 'time'
   const xLabel = effectiveXMode === 'distance' ? 'Distance (mi)' : 'Time (min)'
+  const activeX =
+    activePoint?.[xKey] != null && Number.isFinite(activePoint[xKey])
+      ? activePoint[xKey]
+      : null
 
   const hasElevation = chartData.some((d) => d.elevation != null)
   const hasSpeed = chartData.some((d) => d.speed != null)
@@ -212,6 +177,26 @@ export function ActivityCharts({
                   cursor={{ stroke: 'currentColor', strokeOpacity: 0.4 }}
                   content={() => null}
                 />
+                {activeX != null && (
+                  <ReferenceLine
+                    x={activeX}
+                    stroke="currentColor"
+                    strokeOpacity={0.55}
+                    ifOverflow="extendDomain"
+                  />
+                )}
+                {activeX != null &&
+                  activeMetricValue(activePoint, chart.dataKey) != null && (
+                    <ReferenceDot
+                      x={activeX}
+                      y={activeMetricValue(activePoint, chart.dataKey) ?? 0}
+                      r={4}
+                      stroke="currentColor"
+                      strokeWidth={2}
+                      fill="var(--background)"
+                      ifOverflow="extendDomain"
+                    />
+                  )}
                 <Area
                   type="monotone"
                   dataKey={chart.dataKey}

--- a/src/components/garmin/ActivityHoverDetails.tsx
+++ b/src/components/garmin/ActivityHoverDetails.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { Card, CardContent } from '@/components/ui/card'
 import { reverseGeocode } from '@/services/geocoder'
-import type { ChartDataPoint } from './ActivityCharts'
+import type { ChartDataPoint } from './ActivityChartData'
 
 interface ActivityHoverDetailsProps {
   point: ChartDataPoint | null
@@ -98,7 +98,8 @@ export function ActivityHoverDetails({ point }: ActivityHoverDetailsProps) {
     return (
       <Card data-testid="activity-hover-details">
         <CardContent className="py-3 text-xs text-muted-foreground">
-          Hover the Elevation or Speed chart to see details for that point.
+          Hover the Elevation or Speed chart, or click the map, to see details
+          for that point.
         </CardContent>
       </Card>
     )

--- a/src/components/garmin/ActivityRouteMap.tsx
+++ b/src/components/garmin/ActivityRouteMap.tsx
@@ -17,6 +17,12 @@ interface ActivityRouteMapProps {
    * elevation/speed reading occurred. The map view is not re-centered.
    */
   activeLatLng?: { lat: number; lng: number } | null
+  /**
+   * Emits the raw map click coordinate. The page resolves it to the nearest
+   * chart point so the map and charts stay synchronized on full-resolution
+   * data, even when the displayed route is simplified.
+   */
+  onMapPointSelect?: (latLng: { lat: number; lng: number }) => void
 }
 
 function speedToColor(
@@ -38,6 +44,7 @@ function speedToColor(
 export function ActivityRouteMap({
   trackPoints,
   activeLatLng,
+  onMapPointSelect,
 }: ActivityRouteMapProps) {
   const mapRef = useRef<HTMLDivElement>(null)
   const mapInstanceRef = useRef<L.Map | null>(null)
@@ -112,16 +119,25 @@ export function ActivityRouteMap({
       .bindPopup('Finish')
       .addTo(map)
 
+    const handleMapClick = (event: L.LeafletMouseEvent) => {
+      onMapPointSelect?.({
+        lat: event.latlng.lat,
+        lng: event.latlng.lng,
+      })
+    }
+    map.on('click', handleMapClick)
+
     if (bounds.isValid()) {
       map.fitBounds(bounds, { padding: [30, 30] })
     }
 
     return () => {
+      map.off('click', handleMapClick)
       map.remove()
       mapInstanceRef.current = null
       hoverMarkerRef.current = null
     }
-  }, [trackPoints])
+  }, [trackPoints, onMapPointSelect])
 
   // Sync hover marker with the active chart point. Avoid re-fitting bounds so
   // the map stays put while the user scrubs the charts.

--- a/src/pages/GarminDetailPage.test.tsx
+++ b/src/pages/GarminDetailPage.test.tsx
@@ -17,6 +17,9 @@ const toastMocks = vi.hoisted(() => ({
 
 vi.mock('@/__generated__/graphql', () => garminDetailHooks)
 vi.mock('sonner', () => ({ toast: toastMocks }))
+vi.mock('@/services/geocoder', () => ({
+  reverseGeocode: vi.fn().mockResolvedValue({ features: [] }),
+}))
 
 vi.mock('@/components/garmin/ActivityHeader', () => ({
   ActivityHeader: ({ backTo, sport }: { backTo: string; sport: string }) => (
@@ -31,11 +34,34 @@ vi.mock('@/components/garmin/ActivityStatsBar', () => ({
 }))
 
 vi.mock('@/components/garmin/ActivityRouteMap', () => ({
-  ActivityRouteMap: () => <div data-testid="activity-route-map">route-map</div>,
+  ActivityRouteMap: ({
+    activeLatLng,
+    onMapPointSelect,
+  }: {
+    activeLatLng?: { lat: number; lng: number } | null
+    onMapPointSelect?: (latLng: { lat: number; lng: number }) => void
+  }) => (
+    <button
+      data-testid="activity-route-map"
+      type="button"
+      onClick={() => onMapPointSelect?.({ lat: 40.702, lng: -74.002 })}
+    >
+      route-map
+      {activeLatLng ? ` ${activeLatLng.lat},${activeLatLng.lng}` : ''}
+    </button>
+  ),
 }))
 
 vi.mock('@/components/garmin/ActivityCharts', () => ({
-  ActivityCharts: () => <div data-testid="activity-charts">charts</div>,
+  ActivityCharts: ({
+    activePoint,
+  }: {
+    activePoint?: { timestamp: string }
+  }) => (
+    <div data-testid="activity-charts">
+      {activePoint ? activePoint.timestamp : 'charts'}
+    </div>
+  ),
 }))
 
 vi.mock('@/components/garmin/ActivityStatsPanel', () => ({
@@ -176,6 +202,76 @@ describe('GarminDetailPage', () => {
     expect(
       screen.getByText('Chart data failed: chart fetch failed'),
     ).toBeInTheDocument()
+  })
+
+  it('selects the nearest chart point when the route map is clicked', async () => {
+    const user = userEvent.setup()
+    garminDetailHooks.useGarminActivityQuery.mockReturnValue({
+      loading: false,
+      error: undefined,
+      refetch: vi.fn(),
+      data: {
+        garminActivity: {
+          sport: 'running',
+          sub_sport: 'road',
+          start_time: '2026-03-14T09:00:00Z',
+          device_manufacturer: 'Garmin',
+          distance_km: 5,
+          duration_seconds: 1800,
+          avg_speed_kmh: 10,
+          total_ascent_m: 40,
+        },
+      },
+    })
+    garminDetailHooks.useGarminTrackPointsQuery.mockReturnValue({
+      loading: false,
+      data: {
+        garminTrackPoints: {
+          items: [
+            { latitude: 40.7, longitude: -74.0 },
+            { latitude: 40.702, longitude: -74.002 },
+          ],
+        },
+      },
+    })
+    garminDetailHooks.useGarminChartDataQuery.mockReturnValue({
+      loading: false,
+      error: undefined,
+      data: {
+        garminChartData: [
+          {
+            timestamp: '2026-03-14T09:00:00Z',
+            latitude: 40.7,
+            longitude: -74.0,
+            altitude: 10,
+            speed_kmh: 8,
+            distance_from_start_km: 0,
+          },
+          {
+            timestamp: '2026-03-14T09:05:00Z',
+            latitude: 40.702,
+            longitude: -74.002,
+            altitude: 20,
+            speed_kmh: 10,
+            distance_from_start_km: 1,
+          },
+        ],
+      },
+    })
+
+    renderPage()
+
+    await user.click(screen.getByTestId('activity-route-map'))
+
+    expect(screen.getByTestId('activity-charts')).toHaveTextContent(
+      '2026-03-14T09:05:00Z',
+    )
+    expect(screen.getByTestId('activity-hover-details')).toHaveTextContent(
+      '40.70200, -74.00200',
+    )
+    expect(screen.getByTestId('activity-route-map')).toHaveTextContent(
+      '40.702,-74.002',
+    )
   })
 
   it('shows not found when the activity query returns no activity', () => {

--- a/src/pages/GarminDetailPage.test.tsx
+++ b/src/pages/GarminDetailPage.test.tsx
@@ -274,6 +274,65 @@ describe('GarminDetailPage', () => {
     )
   })
 
+  it('resolves map clicks against full-resolution points, not the downsampled chart series', async () => {
+    const user = userEvent.setup()
+    garminDetailHooks.useGarminActivityQuery.mockReturnValue({
+      loading: false,
+      error: undefined,
+      refetch: vi.fn(),
+      data: {
+        garminActivity: {
+          sport: 'running',
+          sub_sport: 'road',
+          start_time: '2026-03-14T09:00:00Z',
+          device_manufacturer: 'Garmin',
+          distance_km: 5,
+          duration_seconds: 1800,
+          avg_speed_kmh: 10,
+          total_ascent_m: 40,
+        },
+      },
+    })
+    garminDetailHooks.useGarminTrackPointsQuery.mockReturnValue({
+      loading: false,
+      data: {
+        garminTrackPoints: {
+          items: [{ latitude: 40.702, longitude: -74.002 }],
+        },
+      },
+    })
+
+    // 1000 points exceeds the 800-point downsample target. Index 4 is dropped
+    // by downsampling (no integer i satisfies floor(i * 1.25) === 4), so it
+    // only exists in the full-resolution series. Placing the click target there
+    // proves the lookup searches raw data rather than the downsampled charts.
+    const TARGET_INDEX = 4
+    const garminChartData = Array.from({ length: 1000 }, (_, i) => ({
+      timestamp: new Date(Date.UTC(2026, 2, 14, 9, 0, i)).toISOString(),
+      latitude: i === TARGET_INDEX ? 40.702 : 10,
+      longitude: i === TARGET_INDEX ? -74.002 : 10,
+      altitude: 10 + i,
+      speed_kmh: 8,
+      distance_from_start_km: i * 0.01,
+    }))
+    garminDetailHooks.useGarminChartDataQuery.mockReturnValue({
+      loading: false,
+      error: undefined,
+      data: { garminChartData },
+    })
+
+    renderPage()
+
+    await user.click(screen.getByTestId('activity-route-map'))
+
+    expect(screen.getByTestId('activity-charts')).toHaveTextContent(
+      garminChartData[TARGET_INDEX].timestamp,
+    )
+    expect(screen.getByTestId('activity-hover-details')).toHaveTextContent(
+      '40.70200, -74.00200',
+    )
+  })
+
   it('shows not found when the activity query returns no activity', () => {
     garminDetailHooks.useGarminActivityQuery.mockReturnValue({
       loading: false,

--- a/src/pages/GarminDetailPage.tsx
+++ b/src/pages/GarminDetailPage.tsx
@@ -14,7 +14,9 @@ import { ActivityHeader } from '@/components/garmin/ActivityHeader'
 import { ActivityStatsBar } from '@/components/garmin/ActivityStatsBar'
 import { ActivityRouteMap } from '@/components/garmin/ActivityRouteMap'
 import {
-  buildActivityChartData,
+  getActivityChartContext,
+  toChartDataPoint,
+  type ActivityChartTrackPoint,
   type ChartDataPoint,
 } from '@/components/garmin/ActivityChartData'
 import { ActivityCharts } from '@/components/garmin/ActivityCharts'
@@ -35,8 +37,8 @@ function toRadians(degrees: number): number {
 }
 
 function isFiniteCoordinate(
-  point: ChartDataPoint,
-): point is ChartDataPoint & { latitude: number; longitude: number } {
+  point: ActivityChartTrackPoint,
+): point is ActivityChartTrackPoint & { latitude: number; longitude: number } {
   return (
     point.latitude != null &&
     point.longitude != null &&
@@ -61,12 +63,12 @@ function distanceMeters(
   return 2 * EARTH_RADIUS_M * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a))
 }
 
-function findNearestChartPoint(
-  points: ChartDataPoint[],
+function findNearestTrackPoint(
+  points: ActivityChartTrackPoint[],
   lat: number,
   lng: number,
-): ChartDataPoint | null {
-  let nearest: ChartDataPoint | null = null
+): ActivityChartTrackPoint | null {
+  let nearest: ActivityChartTrackPoint | null = null
   let nearestDistance = Infinity
 
   for (const point of points) {
@@ -297,15 +299,37 @@ export function GarminDetailPage() {
     skip: !activityId,
     fetchPolicy: 'no-cache',
   })
-  const chartDataPoints = useMemo(
-    () => buildActivityChartData(chartData?.garminChartData ?? []).chartData,
+  // Resolve map clicks against the *full-resolution* track series (not the
+  // downsampled chart series) so the selected point is the true nearest
+  // location, then convert it into the chart/display shape using the same
+  // context the charts use. This keeps map clicks accurate for activities with
+  // more than 800 points while charts still render a downsampled series.
+  const rawChartPoints = useMemo(
+    () => chartData?.garminChartData ?? [],
     [chartData?.garminChartData],
+  )
+  const chartContext = useMemo(
+    () => getActivityChartContext(rawChartPoints),
+    [rawChartPoints],
   )
   const handleMapPointSelect = useCallback(
     ({ lat, lng }: { lat: number; lng: number }) => {
-      setActivePoint(findNearestChartPoint(chartDataPoints, lat, lng))
+      if (!chartContext) {
+        setActivePoint(null)
+        return
+      }
+      const nearest = findNearestTrackPoint(rawChartPoints, lat, lng)
+      setActivePoint(
+        nearest
+          ? toChartDataPoint(
+              nearest,
+              chartContext.startTime,
+              chartContext.hasReliableDistance,
+            )
+          : null,
+      )
     },
-    [chartDataPoints],
+    [rawChartPoints, chartContext],
   )
 
   if (loading) return <LoadingState message="Loading activity..." />
@@ -384,7 +408,7 @@ export function GarminDetailPage() {
               : null
           }
           onMapPointSelect={
-            chartDataPoints.length > 0 ? handleMapPointSelect : undefined
+            rawChartPoints.length > 0 ? handleMapPointSelect : undefined
           }
         />
       )}

--- a/src/pages/GarminDetailPage.tsx
+++ b/src/pages/GarminDetailPage.tsx
@@ -1,5 +1,5 @@
 import { useParams, useLocation } from 'react-router-dom'
-import { useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Download, Loader2 } from 'lucide-react'
 import { toast } from 'sonner'
 import {
@@ -14,9 +14,10 @@ import { ActivityHeader } from '@/components/garmin/ActivityHeader'
 import { ActivityStatsBar } from '@/components/garmin/ActivityStatsBar'
 import { ActivityRouteMap } from '@/components/garmin/ActivityRouteMap'
 import {
-  ActivityCharts,
+  buildActivityChartData,
   type ChartDataPoint,
-} from '@/components/garmin/ActivityCharts'
+} from '@/components/garmin/ActivityChartData'
+import { ActivityCharts } from '@/components/garmin/ActivityCharts'
 import { ActivityHoverDetails } from '@/components/garmin/ActivityHoverDetails'
 import { ActivityStatsPanel } from '@/components/garmin/ActivityStatsPanel'
 import { Button } from '@/components/ui/button'
@@ -27,6 +28,59 @@ import { escapeCsvValue, triggerDownload } from '@/lib/export'
 const SIMPLIFY_TOLERANCE = 0.00001
 /** Maximum track points fetched per page when exporting. */
 const EXPORT_PAGE_SIZE = 10000
+const EARTH_RADIUS_M = 6_371_000
+
+function toRadians(degrees: number): number {
+  return (degrees * Math.PI) / 180
+}
+
+function isFiniteCoordinate(
+  point: ChartDataPoint,
+): point is ChartDataPoint & { latitude: number; longitude: number } {
+  return (
+    point.latitude != null &&
+    point.longitude != null &&
+    Number.isFinite(point.latitude) &&
+    Number.isFinite(point.longitude)
+  )
+}
+
+function distanceMeters(
+  latA: number,
+  lonA: number,
+  latB: number,
+  lonB: number,
+): number {
+  const dLat = toRadians(latB - latA)
+  const dLon = toRadians(lonB - lonA)
+  const a =
+    Math.sin(dLat / 2) ** 2 +
+    Math.cos(toRadians(latA)) *
+      Math.cos(toRadians(latB)) *
+      Math.sin(dLon / 2) ** 2
+  return 2 * EARTH_RADIUS_M * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a))
+}
+
+function findNearestChartPoint(
+  points: ChartDataPoint[],
+  lat: number,
+  lng: number,
+): ChartDataPoint | null {
+  let nearest: ChartDataPoint | null = null
+  let nearestDistance = Infinity
+
+  for (const point of points) {
+    if (!isFiniteCoordinate(point)) continue
+
+    const distance = distanceMeters(lat, lng, point.latitude, point.longitude)
+    if (distance < nearestDistance) {
+      nearest = point
+      nearestDistance = distance
+    }
+  }
+
+  return nearest
+}
 
 export function GarminDetailPage() {
   const { activityId } = useParams<{ activityId: string }>()
@@ -243,6 +297,16 @@ export function GarminDetailPage() {
     skip: !activityId,
     fetchPolicy: 'no-cache',
   })
+  const chartDataPoints = useMemo(
+    () => buildActivityChartData(chartData?.garminChartData ?? []).chartData,
+    [chartData?.garminChartData],
+  )
+  const handleMapPointSelect = useCallback(
+    ({ lat, lng }: { lat: number; lng: number }) => {
+      setActivePoint(findNearestChartPoint(chartDataPoints, lat, lng))
+    },
+    [chartDataPoints],
+  )
 
   if (loading) return <LoadingState message="Loading activity..." />
   if (error)
@@ -319,6 +383,9 @@ export function GarminDetailPage() {
               ? { lat: activePoint.latitude, lng: activePoint.longitude }
               : null
           }
+          onMapPointSelect={
+            chartDataPoints.length > 0 ? handleMapPointSelect : undefined
+          }
         />
       )}
 
@@ -331,6 +398,7 @@ export function GarminDetailPage() {
           <ActivityHoverDetails point={activePoint} />
           <ActivityCharts
             trackPoints={chartPoints}
+            activePoint={activePoint}
             onActivePointChange={setActivePoint}
           />
         </>


### PR DESCRIPTION
## Summary

Refs #158

Add route-map click handling on Garmin activity detail pages so map selections sync the shared details panel, map marker, and Elevation/Speed chart crosshair. Map clicks now resolve against the full-resolution Garmin track/chart data before converting the selected point into the shared chart display shape, which keeps nearest-point selection accurate even when the rendered chart series is downsampled. This also extracts shared Garmin chart-data conversion helpers, adds regression coverage for a point dropped by downsampling, and includes a dev-safe `public/config.js` so local Vite does not serve HTML for `/config.js`.

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New page / component
- [x] UI enhancement (non-breaking)
- [ ] GraphQL query / mutation change
- [ ] CI/CD pipeline change
- [ ] Documentation update

## Checklist

- [ ] Read `README.md` and relevant docs
- [x] No secrets or credentials committed
- [ ] Environment variables use `VITE_` prefix
- [x] Ran `npm run lint:all` locally (hooks passing)
- [ ] Ran `npm run test` (tests passing)
- [x] Ran `npm run type-check` (no type errors)

## Deployment

- [ ] Does this need [k8s-gitops](https://github.com/stuartshay/k8s-gitops)
      manifest changes?

## Testing

```bash
npm run type-check
npm run lint:all
npm run test:run -- src/pages/GarminDetailPage.test.tsx
npm run build
BASE_URL=http://192.168.1.190:5173 npx playwright test e2e/garmin-charts.spec.ts --project=chromium --reporter=line
BASE_URL=http://192.168.1.190:5173 npx playwright test e2e/garmin-*.spec.ts --project=chromium --reporter=line
```

## Post-Merge Validation

⚠️ **Do NOT use `Closes #` or `Fixes #` in this PR.** Issues must remain open
until acceptance criteria are validated.

After this PR merges:

### For changes that affect deployed UI (components, pages, GraphQL, config)

- [ ] Docker image built and pushed (CI)
- [ ] k8s-gitops deployment PR created and merged
- [ ] Argo CD synced to cluster
- [ ] Acceptance criteria validated against deployed behavior

### For all PRs

- [ ] Final validation comment posted on the linked issue
- [ ] Issue closed manually after all criteria confirmed
- [ ] If any criterion cannot be validated, reason documented on the issue

## Notes

- Map-click nearest-neighbor lookup now uses raw `garminChartData` instead of the downsampled chart series, so activities with more than 800 points snap to the true nearest location.
- The selected raw point is converted through shared chart-context helpers so displayed time/distance values stay aligned with the rendered charts.
- Added a regression test covering a click target at an index omitted by downsampling.
- A full local Playwright run was also attempted against `http://192.168.1.190:5173`: 59 passed, 2 failed, 2 skipped. The two failures were pre-existing/unrelated Playwright strict-mode locator ambiguity in dashboard/map date-picker specs.