### PR TITLE
[codex] Lock Garmin chart point on route map

### DIFF
--- a/src/components/garmin/ActivityCharts.tsx
+++ b/src/components/garmin/ActivityCharts.tsx
@@ -28,6 +28,11 @@ interface ActivityChartsProps {
    * crosshair at the same x-position and emit the same active index.
    */
   onActivePointChange?: (point: ChartDataPoint | null) => void
+  /**
+   * Locks the current chart point so it remains visible on the route map after
+   * the cursor leaves the chart.
+   */
+  onPointLock?: (point: ChartDataPoint) => void
 }
 
 type XAxisMode = 'distance' | 'time'
@@ -49,10 +54,27 @@ function activeMetricValue(
   return typeof value === 'number' && Number.isFinite(value) ? value : null
 }
 
+function pointFromTooltipState(
+  state: { activeTooltipIndex?: number | string | null } | undefined,
+  chartData: ChartDataPoint[],
+): ChartDataPoint | null {
+  const raw = state?.activeTooltipIndex
+  // Recharts 3 may emit the index as a string; normalize it.
+  const i =
+    typeof raw === 'number'
+      ? raw
+      : typeof raw === 'string' && raw !== ''
+        ? Number(raw)
+        : NaN
+
+  return Number.isInteger(i) && chartData[i] ? chartData[i] : null
+}
+
 export function ActivityCharts({
   trackPoints,
   activePoint,
   onActivePointChange,
+  onPointLock,
 }: ActivityChartsProps) {
   const [xMode, setXMode] = useState<XAxisMode>('distance')
 
@@ -137,17 +159,14 @@ export function ActivityCharts({
                 onMouseMove={(state: {
                   activeTooltipIndex?: number | string | null
                 }) => {
-                  const raw = state?.activeTooltipIndex
-                  // Recharts 3 may emit the index as a string; normalize it.
-                  const i =
-                    typeof raw === 'number'
-                      ? raw
-                      : typeof raw === 'string' && raw !== ''
-                        ? Number(raw)
-                        : NaN
-                  if (Number.isInteger(i) && chartData[i]) {
-                    onActivePointChange?.(chartData[i])
-                  }
+                  const point = pointFromTooltipState(state, chartData)
+                  if (point) onActivePointChange?.(point)
+                }}
+                onDoubleClick={(state: {
+                  activeTooltipIndex?: number | string | null
+                }) => {
+                  const point = pointFromTooltipState(state, chartData)
+                  if (point) onPointLock?.(point)
                 }}
                 onMouseLeave={() => onActivePointChange?.(null)}
               >

--- a/src/components/garmin/ActivityRouteMap.tsx
+++ b/src/components/garmin/ActivityRouteMap.tsx
@@ -18,6 +18,11 @@ interface ActivityRouteMapProps {
    */
   activeLatLng?: { lat: number; lng: number } | null
   /**
+   * Optional point explicitly locked from a chart double-click. It remains on
+   * the map independently of the transient hover marker.
+   */
+  lockedLatLng?: { lat: number; lng: number } | null
+  /**
    * Emits the raw map click coordinate. The page resolves it to the nearest
    * chart point so the map and charts stay synchronized on full-resolution
    * data, even when the displayed route is simplified.
@@ -44,11 +49,13 @@ function speedToColor(
 export function ActivityRouteMap({
   trackPoints,
   activeLatLng,
+  lockedLatLng,
   onMapPointSelect,
 }: ActivityRouteMapProps) {
   const mapRef = useRef<HTMLDivElement>(null)
   const mapInstanceRef = useRef<L.Map | null>(null)
   const hoverMarkerRef = useRef<L.CircleMarker | null>(null)
+  const lockedMarkerRef = useRef<L.CircleMarker | null>(null)
 
   useEffect(() => {
     if (!mapRef.current || trackPoints.length === 0) return
@@ -136,6 +143,7 @@ export function ActivityRouteMap({
       map.remove()
       mapInstanceRef.current = null
       hoverMarkerRef.current = null
+      lockedMarkerRef.current = null
     }
   }, [trackPoints, onMapPointSelect])
 
@@ -169,6 +177,42 @@ export function ActivityRouteMap({
       ).addTo(map)
     }
   }, [activeLatLng])
+
+  // Keep the locked chart-selection marker on the map until the user locks a
+  // different chart point or switches activities.
+  useEffect(() => {
+    const map = mapInstanceRef.current
+    if (!map) return
+
+    if (!lockedLatLng) {
+      if (lockedMarkerRef.current) {
+        lockedMarkerRef.current.remove()
+        lockedMarkerRef.current = null
+      }
+      return
+    }
+
+    if (lockedMarkerRef.current) {
+      lockedMarkerRef.current.setLatLng([lockedLatLng.lat, lockedLatLng.lng])
+    } else {
+      lockedMarkerRef.current = L.circleMarker(
+        [lockedLatLng.lat, lockedLatLng.lng],
+        {
+          radius: 8,
+          color: '#f97316',
+          weight: 3,
+          fillColor: '#ffffff',
+          fillOpacity: 1,
+          className: 'activity-locked-marker',
+        },
+      )
+        .bindTooltip('Locked chart point', {
+          direction: 'top',
+          offset: [0, -8],
+        })
+        .addTo(map)
+    }
+  }, [lockedLatLng])
 
   if (trackPoints.length === 0) return null
 

--- a/src/pages/GarminDetailPage.test.tsx
+++ b/src/pages/GarminDetailPage.test.tsx
@@ -36,9 +36,11 @@ vi.mock('@/components/garmin/ActivityStatsBar', () => ({
 vi.mock('@/components/garmin/ActivityRouteMap', () => ({
   ActivityRouteMap: ({
     activeLatLng,
+    lockedLatLng,
     onMapPointSelect,
   }: {
     activeLatLng?: { lat: number; lng: number } | null
+    lockedLatLng?: { lat: number; lng: number } | null
     onMapPointSelect?: (latLng: { lat: number; lng: number }) => void
   }) => (
     <button
@@ -47,7 +49,8 @@ vi.mock('@/components/garmin/ActivityRouteMap', () => ({
       onClick={() => onMapPointSelect?.({ lat: 40.702, lng: -74.002 })}
     >
       route-map
-      {activeLatLng ? ` ${activeLatLng.lat},${activeLatLng.lng}` : ''}
+      {activeLatLng ? ` active:${activeLatLng.lat},${activeLatLng.lng}` : ''}
+      {lockedLatLng ? ` locked:${lockedLatLng.lat},${lockedLatLng.lng}` : ''}
     </button>
   ),
 }))
@@ -55,12 +58,32 @@ vi.mock('@/components/garmin/ActivityRouteMap', () => ({
 vi.mock('@/components/garmin/ActivityCharts', () => ({
   ActivityCharts: ({
     activePoint,
+    onPointLock,
   }: {
-    activePoint?: { timestamp: string }
+    activePoint?: { timestamp: string; latitude?: number; longitude?: number }
+    onPointLock?: (point: {
+      timestamp: string
+      time: number
+      distance?: number | null
+      latitude?: number
+      longitude?: number
+    }) => void
   }) => (
-    <div data-testid="activity-charts">
+    <button
+      data-testid="activity-charts"
+      type="button"
+      onDoubleClick={() =>
+        onPointLock?.({
+          timestamp: '2026-03-14T09:10:00Z',
+          time: 10,
+          distance: 1,
+          latitude: 40.704,
+          longitude: -74.004,
+        })
+      }
+    >
       {activePoint ? activePoint.timestamp : 'charts'}
-    </div>
+    </button>
   ),
 }))
 
@@ -270,7 +293,63 @@ describe('GarminDetailPage', () => {
       '40.70200, -74.00200',
     )
     expect(screen.getByTestId('activity-route-map')).toHaveTextContent(
-      '40.702,-74.002',
+      'active:40.702,-74.002',
+    )
+  })
+
+  it('locks a chart point on the route map when the chart is double-clicked', async () => {
+    const user = userEvent.setup()
+    garminDetailHooks.useGarminActivityQuery.mockReturnValue({
+      loading: false,
+      error: undefined,
+      refetch: vi.fn(),
+      data: {
+        garminActivity: {
+          sport: 'running',
+          sub_sport: 'road',
+          start_time: '2026-03-14T09:00:00Z',
+          device_manufacturer: 'Garmin',
+          distance_km: 5,
+          duration_seconds: 1800,
+          avg_speed_kmh: 10,
+          total_ascent_m: 40,
+        },
+      },
+    })
+    garminDetailHooks.useGarminTrackPointsQuery.mockReturnValue({
+      loading: false,
+      data: {
+        garminTrackPoints: {
+          items: [{ latitude: 40.704, longitude: -74.004 }],
+        },
+      },
+    })
+    garminDetailHooks.useGarminChartDataQuery.mockReturnValue({
+      loading: false,
+      error: undefined,
+      data: {
+        garminChartData: [
+          {
+            timestamp: '2026-03-14T09:10:00Z',
+            latitude: 40.704,
+            longitude: -74.004,
+            altitude: 20,
+            speed_kmh: 10,
+            distance_from_start_km: 1,
+          },
+        ],
+      },
+    })
+
+    renderPage()
+
+    await user.dblClick(screen.getByTestId('activity-charts'))
+
+    expect(screen.getByTestId('activity-route-map')).toHaveTextContent(
+      'locked:40.704,-74.004',
+    )
+    expect(screen.getByTestId('activity-hover-details')).toHaveTextContent(
+      '40.70400, -74.00400',
     )
   })
 

--- a/src/pages/GarminDetailPage.tsx
+++ b/src/pages/GarminDetailPage.tsx
@@ -88,6 +88,7 @@ export function GarminDetailPage() {
   const { activityId } = useParams<{ activityId: string }>()
   const location = useLocation()
   const [activePoint, setActivePoint] = useState<ChartDataPoint | null>(null)
+  const [lockedPoint, setLockedPoint] = useState<ChartDataPoint | null>(null)
 
   // Reset hover state when switching activities so the shared details
   // panel and map marker don't briefly show stale coordinates from the
@@ -98,6 +99,7 @@ export function GarminDetailPage() {
   if (activityId !== prevActivityId) {
     setPrevActivityId(activityId)
     setActivePoint(null)
+    setLockedPoint(null)
   }
 
   useEffect(() => {
@@ -342,6 +344,7 @@ export function GarminDetailPage() {
   const mapTrackPoints = mapTrackData?.garminTrackPoints?.items ?? []
   const chartPoints = chartData?.garminChartData ?? []
   const trackLoading = mapTrackLoading || chartLoading
+  const displayPoint = activePoint ?? lockedPoint
 
   return (
     <div className="space-y-6">
@@ -403,8 +406,13 @@ export function GarminDetailPage() {
         <ActivityRouteMap
           trackPoints={mapTrackPoints}
           activeLatLng={
-            activePoint?.latitude != null && activePoint?.longitude != null
+            activePoint?.latitude != null && activePoint.longitude != null
               ? { lat: activePoint.latitude, lng: activePoint.longitude }
+              : null
+          }
+          lockedLatLng={
+            lockedPoint?.latitude != null && lockedPoint.longitude != null
+              ? { lat: lockedPoint.latitude, lng: lockedPoint.longitude }
               : null
           }
           onMapPointSelect={
@@ -419,11 +427,12 @@ export function GarminDetailPage() {
 
       {chartPoints.length > 0 && (
         <>
-          <ActivityHoverDetails point={activePoint} />
+          <ActivityHoverDetails point={displayPoint} />
           <ActivityCharts
             trackPoints={chartPoints}
-            activePoint={activePoint}
+            activePoint={displayPoint}
             onActivePointChange={setActivePoint}
+            onPointLock={setLockedPoint}
           />
         </>
       )}

--- a/src/pages/GarminDetailPage.tsx
+++ b/src/pages/GarminDetailPage.tsx
@@ -406,12 +406,12 @@ export function GarminDetailPage() {
         <ActivityRouteMap
           trackPoints={mapTrackPoints}
           activeLatLng={
-            activePoint?.latitude != null && activePoint.longitude != null
+            activePoint?.latitude != null && activePoint?.longitude != null
               ? { lat: activePoint.latitude, lng: activePoint.longitude }
               : null
           }
           lockedLatLng={
-            lockedPoint?.latitude != null && lockedPoint.longitude != null
+            lockedPoint?.latitude != null && lockedPoint?.longitude != null
               ? { lat: lockedPoint.latitude, lng: lockedPoint.longitude }
               : null
           }


### PR DESCRIPTION
## Summary
- Add double-click locking for Garmin Elevation and Speed chart points
- Render a persistent locked marker on the route map separate from transient hover markers
- Keep point details synchronized with either the hovered point or the locked point
- Add Garmin detail test coverage for chart point locking

## Impact
Users can double-click a point on the Elevation or Speed graph and keep the exact corresponding map location visible while inspecting the route.

Refs #158

## Validation
- npm run type-check
- npm run lint:all
- npm run build
- npm run test:run