### PR TITLE
feat: multi-point saved markers on Garmin activity detail (Step 1)

### DIFF
--- a/src/components/garmin/ActivityChartData.ts
+++ b/src/components/garmin/ActivityChartData.ts
@@ -20,6 +20,16 @@ export interface ChartDataPoint {
   timestamp: string
 }
 
+/**
+ * A {@link ChartDataPoint} the user has explicitly saved. `id` is the point
+ * timestamp (stable per track point, used for de-duplication/toggle) and
+ * `color` is the palette color assigned when the point was saved.
+ */
+export interface SavedPoint extends ChartDataPoint {
+  id: string
+  color: string
+}
+
 export interface ActivityChartDataResult {
   chartData: ChartDataPoint[]
   hasReliableDistance: boolean

--- a/src/components/garmin/ActivityCharts.tsx
+++ b/src/components/garmin/ActivityCharts.tsx
@@ -16,11 +16,17 @@ import {
   buildActivityChartData,
   type ActivityChartTrackPoint,
   type ChartDataPoint,
+  type SavedPoint,
 } from './ActivityChartData'
 
 interface ActivityChartsProps {
   trackPoints: ActivityChartTrackPoint[]
   activePoint?: ChartDataPoint | null
+  /**
+   * Points the user has saved. Each renders a persistent crosshair in its own
+   * color on both charts so multiple selections stay visible at once.
+   */
+  savedPoints?: SavedPoint[]
   /**
    * Notifies the parent which chart point is currently under the cursor so the
    * page can render a shared details panel and a map hover marker. The two
@@ -29,10 +35,10 @@ interface ActivityChartsProps {
    */
   onActivePointChange?: (point: ChartDataPoint | null) => void
   /**
-   * Locks the current chart point so it remains visible on the route map after
-   * the cursor leaves the chart.
+   * Adds the current chart point to the saved set (or removes it if already
+   * saved). Triggered by double-clicking a chart.
    */
-  onPointLock?: (point: ChartDataPoint) => void
+  onPointToggle?: (point: ChartDataPoint) => void
 }
 
 type XAxisMode = 'distance' | 'time'
@@ -73,8 +79,9 @@ function pointFromTooltipState(
 export function ActivityCharts({
   trackPoints,
   activePoint,
+  savedPoints = [],
   onActivePointChange,
-  onPointLock,
+  onPointToggle,
 }: ActivityChartsProps) {
   const [xMode, setXMode] = useState<XAxisMode>('distance')
 
@@ -166,7 +173,7 @@ export function ActivityCharts({
                   activeTooltipIndex?: number | string | null
                 }) => {
                   const point = pointFromTooltipState(state, chartData)
-                  if (point) onPointLock?.(point)
+                  if (point) onPointToggle?.(point)
                 }}
                 onMouseLeave={() => onActivePointChange?.(null)}
               >
@@ -216,6 +223,37 @@ export function ActivityCharts({
                       ifOverflow="extendDomain"
                     />
                   )}
+                {savedPoints.map((sp) => {
+                  const x = sp[xKey]
+                  if (x == null || !Number.isFinite(x)) return null
+                  return (
+                    <ReferenceLine
+                      key={`saved-line-${sp.id}`}
+                      x={x}
+                      stroke={sp.color}
+                      strokeOpacity={0.8}
+                      strokeDasharray="4 2"
+                      ifOverflow="extendDomain"
+                    />
+                  )
+                })}
+                {savedPoints.map((sp) => {
+                  const x = sp[xKey]
+                  const y = activeMetricValue(sp, chart.dataKey)
+                  if (x == null || !Number.isFinite(x) || y == null) return null
+                  return (
+                    <ReferenceDot
+                      key={`saved-dot-${sp.id}`}
+                      x={x}
+                      y={y}
+                      r={4}
+                      stroke={sp.color}
+                      strokeWidth={2}
+                      fill={sp.color}
+                      ifOverflow="extendDomain"
+                    />
+                  )
+                })}
                 <Area
                   type="monotone"
                   dataKey={chart.dataKey}

--- a/src/components/garmin/ActivityHoverDetails.tsx
+++ b/src/components/garmin/ActivityHoverDetails.tsx
@@ -1,10 +1,15 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { Card, CardContent } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
 import { reverseGeocode } from '@/services/geocoder'
 import type { ChartDataPoint } from './ActivityChartData'
 
 interface ActivityHoverDetailsProps {
   point: ChartDataPoint | null
+  /** Whether the displayed point is already in the saved set. */
+  isSaved?: boolean
+  /** Adds the displayed point to the saved set (or removes it if saved). */
+  onToggleSave?: () => void
 }
 
 type AddressState =
@@ -44,7 +49,11 @@ function coordKey(point: ChartDataPoint | null): CoordKey | null {
   return { key: `${lat},${lon}`, lat, lon }
 }
 
-export function ActivityHoverDetails({ point }: ActivityHoverDetailsProps) {
+export function ActivityHoverDetails({
+  point,
+  isSaved = false,
+  onToggleSave,
+}: ActivityHoverDetailsProps) {
   const target = useMemo(() => coordKey(point), [point])
   const [pendingState, setPendingState] = useState<{
     key: string
@@ -114,6 +123,18 @@ export function ActivityHoverDetails({ point }: ActivityHoverDetailsProps) {
   return (
     <Card data-testid="activity-hover-details">
       <CardContent className="py-3">
+        {onToggleSave && (
+          <div className="mb-2 flex justify-end">
+            <Button
+              size="sm"
+              variant={isSaved ? 'secondary' : 'outline'}
+              onClick={onToggleSave}
+              data-testid="activity-hover-toggle-save"
+            >
+              {isSaved ? 'Remove point' : 'Add point'}
+            </Button>
+          </div>
+        )}
         <div className="grid grid-cols-2 gap-x-6 gap-y-1 text-xs sm:grid-cols-4 lg:grid-cols-5">
           <Field
             label="Elevation"

--- a/src/components/garmin/ActivityRouteMap.tsx
+++ b/src/components/garmin/ActivityRouteMap.tsx
@@ -18,10 +18,13 @@ interface ActivityRouteMapProps {
    */
   activeLatLng?: { lat: number; lng: number } | null
   /**
-   * Optional point explicitly locked from a chart double-click. It remains on
-   * the map independently of the transient hover marker.
+   * Points the user has saved (via chart double-click, map click, or the
+   * details panel). Each renders a persistent color-coded marker. Clicking a
+   * saved marker removes it via {@link onSavedPointRemove}.
    */
-  lockedLatLng?: { lat: number; lng: number } | null
+  savedPoints?: Array<{ id: string; lat: number; lng: number; color: string }>
+  /** Removes a saved point when its marker is clicked. */
+  onSavedPointRemove?: (id: string) => void
   /**
    * Emits the raw map click coordinate. The page resolves it to the nearest
    * chart point so the map and charts stay synchronized on full-resolution
@@ -49,16 +52,27 @@ function speedToColor(
 export function ActivityRouteMap({
   trackPoints,
   activeLatLng,
-  lockedLatLng,
+  savedPoints = [],
+  onSavedPointRemove,
   onMapPointSelect,
 }: ActivityRouteMapProps) {
   const mapRef = useRef<HTMLDivElement>(null)
   const mapInstanceRef = useRef<L.Map | null>(null)
   const hoverMarkerRef = useRef<L.CircleMarker | null>(null)
-  const lockedMarkerRef = useRef<L.CircleMarker | null>(null)
+  const savedMarkersRef = useRef<Map<string, L.CircleMarker>>(new Map())
+  // Keep the latest remove handler in a ref so marker click listeners (bound
+  // once per marker) always call the current callback without re-binding.
+  const onSavedPointRemoveRef = useRef(onSavedPointRemove)
+  useEffect(() => {
+    onSavedPointRemoveRef.current = onSavedPointRemove
+  }, [onSavedPointRemove])
 
   useEffect(() => {
     if (!mapRef.current || trackPoints.length === 0) return
+
+    // The saved-markers map is a stable ref object; capture it so the cleanup
+    // closure doesn't read a possibly-changed ref value at teardown time.
+    const savedMarkers = savedMarkersRef.current
 
     // Clean up previous instance
     if (mapInstanceRef.current) {
@@ -143,7 +157,7 @@ export function ActivityRouteMap({
       map.remove()
       mapInstanceRef.current = null
       hoverMarkerRef.current = null
-      lockedMarkerRef.current = null
+      savedMarkers.clear()
     }
   }, [trackPoints, onMapPointSelect])
 
@@ -178,41 +192,53 @@ export function ActivityRouteMap({
     }
   }, [activeLatLng])
 
-  // Keep the locked chart-selection marker on the map until the user locks a
-  // different chart point or switches activities.
+  // Keep the saved-point markers in sync with the saved set. Each marker is
+  // color-coded and clickable to remove its point; the map stays put so saving
+  // points never re-centers the view.
   useEffect(() => {
     const map = mapInstanceRef.current
     if (!map) return
 
-    if (!lockedLatLng) {
-      if (lockedMarkerRef.current) {
-        lockedMarkerRef.current.remove()
-        lockedMarkerRef.current = null
+    const markers = savedMarkersRef.current
+    const nextIds = new Set(savedPoints.map((p) => p.id))
+
+    // Drop markers whose points are no longer saved.
+    for (const [id, marker] of markers) {
+      if (!nextIds.has(id)) {
+        marker.remove()
+        markers.delete(id)
       }
-      return
     }
 
-    if (lockedMarkerRef.current) {
-      lockedMarkerRef.current.setLatLng([lockedLatLng.lat, lockedLatLng.lng])
-    } else {
-      lockedMarkerRef.current = L.circleMarker(
-        [lockedLatLng.lat, lockedLatLng.lng],
-        {
+    // Add or update markers for the current saved points.
+    for (const p of savedPoints) {
+      const existing = markers.get(p.id)
+      if (existing) {
+        existing.setLatLng([p.lat, p.lng])
+        existing.setStyle({ color: p.color, fillColor: p.color })
+      } else {
+        const marker = L.circleMarker([p.lat, p.lng], {
           radius: 8,
-          color: '#f97316',
+          color: p.color,
           weight: 3,
-          fillColor: '#ffffff',
-          fillOpacity: 1,
-          className: 'activity-locked-marker',
-        },
-      )
-        .bindTooltip('Locked chart point', {
-          direction: 'top',
-          offset: [0, -8],
+          fillColor: p.color,
+          fillOpacity: 0.9,
+          className: 'activity-saved-marker',
         })
-        .addTo(map)
+          .bindTooltip('Saved point — click to remove', {
+            direction: 'top',
+            offset: [0, -8],
+          })
+          .addTo(map)
+        marker.on('click', (event: L.LeafletMouseEvent) => {
+          // Stop the map 'click' handler from saving a new point on top.
+          L.DomEvent.stopPropagation(event)
+          onSavedPointRemoveRef.current?.(p.id)
+        })
+        markers.set(p.id, marker)
+      }
     }
-  }, [lockedLatLng])
+  }, [savedPoints])
 
   if (trackPoints.length === 0) return null
 

--- a/src/components/garmin/SavedPointsList.tsx
+++ b/src/components/garmin/SavedPointsList.tsx
@@ -1,0 +1,83 @@
+import { X } from 'lucide-react'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import type { SavedPoint } from './ActivityChartData'
+
+interface SavedPointsListProps {
+  points: SavedPoint[]
+  onRemove: (id: string) => void
+  onClear: () => void
+}
+
+/**
+ * Lists the points the user has saved on the Garmin activity detail page. Each
+ * row shows the saved point's color swatch and key metrics with a remove
+ * control, plus a "Clear all" action. Renders nothing when no points are saved.
+ */
+export function SavedPointsList({
+  points,
+  onRemove,
+  onClear,
+}: SavedPointsListProps) {
+  if (points.length === 0) return null
+
+  return (
+    <Card data-testid="saved-points-list">
+      <CardHeader className="flex flex-row items-center justify-between pb-2">
+        <CardTitle className="text-base">
+          Saved Points ({points.length})
+        </CardTitle>
+        <Button
+          size="sm"
+          variant="outline"
+          onClick={onClear}
+          data-testid="saved-points-clear"
+        >
+          Clear all
+        </Button>
+      </CardHeader>
+      <CardContent className="space-y-1">
+        {points.map((p, i) => (
+          <div
+            key={p.id}
+            className="flex items-center gap-3 text-xs"
+            data-testid="saved-point-row"
+          >
+            <span
+              className="inline-block h-3 w-3 shrink-0 rounded-full"
+              style={{ backgroundColor: p.color }}
+              aria-hidden="true"
+            />
+            <span className="font-medium">#{i + 1}</span>
+            <span className="tabular-nums">
+              {p.distance != null
+                ? `${p.distance.toFixed(2)} mi`
+                : `${p.time.toFixed(1)} min`}
+            </span>
+            <span className="tabular-nums text-muted-foreground">
+              {p.elevation != null ? `${p.elevation.toFixed(0)} ft` : '—'}
+            </span>
+            <span className="tabular-nums text-muted-foreground">
+              {p.speed != null ? `${p.speed.toFixed(1)} mph` : '—'}
+            </span>
+            <span className="hidden tabular-nums text-muted-foreground sm:inline">
+              {p.latitude != null && p.longitude != null
+                ? `${p.latitude.toFixed(5)}, ${p.longitude.toFixed(5)}`
+                : '—'}
+            </span>
+            <Button
+              size="icon"
+              variant="ghost"
+              className="ml-auto h-6 w-6"
+              onClick={() => onRemove(p.id)}
+              data-testid="saved-point-remove"
+              aria-label={`Remove saved point ${i + 1}`}
+            >
+              <X className="h-3 w-3" />
+            </Button>
+          </div>
+        ))}
+      </CardContent>
+    </Card>
+  )
+}

--- a/src/components/garmin/savedPointColors.ts
+++ b/src/components/garmin/savedPointColors.ts
@@ -1,0 +1,30 @@
+/**
+ * Categorical palette for saved Garmin chart/map points. Deliberately distinct
+ * from the route speed legend (blue/green/yellow/red) and the chart series
+ * colors (gray elevation, blue speed) so saved markers stay visually separable.
+ */
+export const SAVED_POINT_PALETTE = [
+  '#a855f7', // purple
+  '#14b8a6', // teal
+  '#ec4899', // pink
+  '#f59e0b', // amber
+  '#8b5cf6', // violet
+  '#06b6d4', // cyan
+  '#d946ef', // fuchsia
+  '#f43f5e', // rose
+] as const
+
+/**
+ * Pick the next color for a new saved point: the first palette color not
+ * already in use, or — once every color is taken — recycle deterministically by
+ * count so colors keep cycling through the palette.
+ */
+export function nextSavedPointColor(
+  existing: ReadonlyArray<{ color: string }>,
+): string {
+  const used = new Set(existing.map((p) => p.color))
+  const unused = SAVED_POINT_PALETTE.find((color) => !used.has(color))
+  return (
+    unused ?? SAVED_POINT_PALETTE[existing.length % SAVED_POINT_PALETTE.length]
+  )
+}

--- a/src/pages/GarminDetailPage.test.tsx
+++ b/src/pages/GarminDetailPage.test.tsx
@@ -36,32 +36,50 @@ vi.mock('@/components/garmin/ActivityStatsBar', () => ({
 vi.mock('@/components/garmin/ActivityRouteMap', () => ({
   ActivityRouteMap: ({
     activeLatLng,
-    lockedLatLng,
+    savedPoints,
+    onSavedPointRemove,
     onMapPointSelect,
   }: {
     activeLatLng?: { lat: number; lng: number } | null
-    lockedLatLng?: { lat: number; lng: number } | null
+    savedPoints?: Array<{ id: string; lat: number; lng: number; color: string }>
+    onSavedPointRemove?: (id: string) => void
     onMapPointSelect?: (latLng: { lat: number; lng: number }) => void
   }) => (
-    <button
-      data-testid="activity-route-map"
-      type="button"
-      onClick={() => onMapPointSelect?.({ lat: 40.702, lng: -74.002 })}
-    >
-      route-map
-      {activeLatLng ? ` active:${activeLatLng.lat},${activeLatLng.lng}` : ''}
-      {lockedLatLng ? ` locked:${lockedLatLng.lat},${lockedLatLng.lng}` : ''}
-    </button>
+    <div>
+      <button
+        data-testid="activity-route-map"
+        type="button"
+        onClick={() => onMapPointSelect?.({ lat: 40.702, lng: -74.002 })}
+      >
+        route-map
+        {activeLatLng ? ` active:${activeLatLng.lat},${activeLatLng.lng}` : ''}
+        {savedPoints && savedPoints.length > 0
+          ? ` saved:${savedPoints.map((p) => `${p.lat},${p.lng}`).join('|')}`
+          : ''}
+      </button>
+      {(savedPoints ?? []).map((p) => (
+        <button
+          key={p.id}
+          type="button"
+          data-testid={`map-saved-marker-${p.id}`}
+          onClick={() => onSavedPointRemove?.(p.id)}
+        >
+          marker:{p.color}
+        </button>
+      ))}
+    </div>
   ),
 }))
 
 vi.mock('@/components/garmin/ActivityCharts', () => ({
   ActivityCharts: ({
     activePoint,
-    onPointLock,
+    savedPoints,
+    onPointToggle,
   }: {
     activePoint?: { timestamp: string; latitude?: number; longitude?: number }
-    onPointLock?: (point: {
+    savedPoints?: Array<{ id: string; color: string }>
+    onPointToggle?: (point: {
       timestamp: string
       time: number
       distance?: number | null
@@ -73,7 +91,7 @@ vi.mock('@/components/garmin/ActivityCharts', () => ({
       data-testid="activity-charts"
       type="button"
       onDoubleClick={() =>
-        onPointLock?.({
+        onPointToggle?.({
           timestamp: '2026-03-14T09:10:00Z',
           time: 10,
           distance: 1,
@@ -83,6 +101,9 @@ vi.mock('@/components/garmin/ActivityCharts', () => ({
       }
     >
       {activePoint ? activePoint.timestamp : 'charts'}
+      {savedPoints && savedPoints.length > 0
+        ? ` charts-saved:${savedPoints.length}`
+        : ''}
     </button>
   ),
 }))
@@ -295,9 +316,15 @@ describe('GarminDetailPage', () => {
     expect(screen.getByTestId('activity-route-map')).toHaveTextContent(
       'active:40.702,-74.002',
     )
+    // The clicked point is saved and gets a persistent map marker + list row.
+    expect(screen.getByTestId('activity-route-map')).toHaveTextContent(
+      'saved:40.702,-74.002',
+    )
+    expect(screen.getByTestId('saved-points-list')).toBeInTheDocument()
+    expect(screen.getAllByTestId('saved-point-row')).toHaveLength(1)
   })
 
-  it('locks a chart point on the route map when the chart is double-clicked', async () => {
+  it('saves a chart point on the route map when the chart is double-clicked', async () => {
     const user = userEvent.setup()
     garminDetailHooks.useGarminActivityQuery.mockReturnValue({
       loading: false,
@@ -345,12 +372,74 @@ describe('GarminDetailPage', () => {
 
     await user.dblClick(screen.getByTestId('activity-charts'))
 
+    // Double-click saves the point: it appears as a map marker and a list row.
     expect(screen.getByTestId('activity-route-map')).toHaveTextContent(
-      'locked:40.704,-74.004',
+      'saved:40.704,-74.004',
     )
-    expect(screen.getByTestId('activity-hover-details')).toHaveTextContent(
-      '40.70400, -74.00400',
-    )
+    expect(screen.getByTestId('saved-points-list')).toBeInTheDocument()
+    expect(screen.getAllByTestId('saved-point-row')).toHaveLength(1)
+
+    // Double-clicking the same point again toggles it off.
+    await user.dblClick(screen.getByTestId('activity-charts'))
+    expect(screen.queryByTestId('saved-points-list')).not.toBeInTheDocument()
+  })
+
+  it('removes a saved point via the list remove control and clear all', async () => {
+    const user = userEvent.setup()
+    garminDetailHooks.useGarminActivityQuery.mockReturnValue({
+      loading: false,
+      error: undefined,
+      refetch: vi.fn(),
+      data: {
+        garminActivity: {
+          sport: 'running',
+          sub_sport: 'road',
+          start_time: '2026-03-14T09:00:00Z',
+          device_manufacturer: 'Garmin',
+          distance_km: 5,
+          duration_seconds: 1800,
+          avg_speed_kmh: 10,
+          total_ascent_m: 40,
+        },
+      },
+    })
+    garminDetailHooks.useGarminTrackPointsQuery.mockReturnValue({
+      loading: false,
+      data: {
+        garminTrackPoints: {
+          items: [{ latitude: 40.704, longitude: -74.004 }],
+        },
+      },
+    })
+    garminDetailHooks.useGarminChartDataQuery.mockReturnValue({
+      loading: false,
+      error: undefined,
+      data: {
+        garminChartData: [
+          {
+            timestamp: '2026-03-14T09:10:00Z',
+            latitude: 40.704,
+            longitude: -74.004,
+            altitude: 20,
+            speed_kmh: 10,
+            distance_from_start_km: 1,
+          },
+        ],
+      },
+    })
+
+    renderPage()
+
+    await user.dblClick(screen.getByTestId('activity-charts'))
+    expect(screen.getAllByTestId('saved-point-row')).toHaveLength(1)
+
+    await user.click(screen.getByTestId('saved-point-remove'))
+    expect(screen.queryByTestId('saved-points-list')).not.toBeInTheDocument()
+
+    // Save again, then clear all.
+    await user.dblClick(screen.getByTestId('activity-charts'))
+    await user.click(screen.getByTestId('saved-points-clear'))
+    expect(screen.queryByTestId('saved-points-list')).not.toBeInTheDocument()
   })
 
   it('resolves map clicks against full-resolution points, not the downsampled chart series', async () => {

--- a/src/pages/GarminDetailPage.tsx
+++ b/src/pages/GarminDetailPage.tsx
@@ -18,9 +18,12 @@ import {
   toChartDataPoint,
   type ActivityChartTrackPoint,
   type ChartDataPoint,
+  type SavedPoint,
 } from '@/components/garmin/ActivityChartData'
+import { nextSavedPointColor } from '@/components/garmin/savedPointColors'
 import { ActivityCharts } from '@/components/garmin/ActivityCharts'
 import { ActivityHoverDetails } from '@/components/garmin/ActivityHoverDetails'
+import { SavedPointsList } from '@/components/garmin/SavedPointsList'
 import { ActivityStatsPanel } from '@/components/garmin/ActivityStatsPanel'
 import { Button } from '@/components/ui/button'
 import { setNRCustomAttribute } from '@/lib/newrelic-browser'
@@ -88,7 +91,7 @@ export function GarminDetailPage() {
   const { activityId } = useParams<{ activityId: string }>()
   const location = useLocation()
   const [activePoint, setActivePoint] = useState<ChartDataPoint | null>(null)
-  const [lockedPoint, setLockedPoint] = useState<ChartDataPoint | null>(null)
+  const [savedPoints, setSavedPoints] = useState<SavedPoint[]>([])
 
   // Reset hover state when switching activities so the shared details
   // panel and map marker don't briefly show stale coordinates from the
@@ -99,8 +102,26 @@ export function GarminDetailPage() {
   if (activityId !== prevActivityId) {
     setPrevActivityId(activityId)
     setActivePoint(null)
-    setLockedPoint(null)
+    setSavedPoints([])
   }
+
+  // Add the given point to the saved set, or remove it if already saved
+  // (toggle by timestamp). New points get the next palette color.
+  const addOrTogglePoint = useCallback((point: ChartDataPoint) => {
+    setSavedPoints((prev) => {
+      const id = point.timestamp
+      if (prev.some((p) => p.id === id)) {
+        return prev.filter((p) => p.id !== id)
+      }
+      return [...prev, { ...point, id, color: nextSavedPointColor(prev) }]
+    })
+  }, [])
+
+  const removeSavedPoint = useCallback((id: string) => {
+    setSavedPoints((prev) => prev.filter((p) => p.id !== id))
+  }, [])
+
+  const clearSavedPoints = useCallback(() => setSavedPoints([]), [])
 
   useEffect(() => {
     setNRCustomAttribute('garmin.flow', true)
@@ -321,17 +342,21 @@ export function GarminDetailPage() {
         return
       }
       const nearest = findNearestTrackPoint(rawChartPoints, lat, lng)
-      setActivePoint(
-        nearest
-          ? toChartDataPoint(
-              nearest,
-              chartContext.startTime,
-              chartContext.hasReliableDistance,
-            )
-          : null,
+      if (!nearest) {
+        setActivePoint(null)
+        return
+      }
+      const point = toChartDataPoint(
+        nearest,
+        chartContext.startTime,
+        chartContext.hasReliableDistance,
       )
+      // Show the clicked point in the details panel and toggle it in the
+      // saved set so it gets a persistent color-coded marker.
+      setActivePoint(point)
+      addOrTogglePoint(point)
     },
-    [rawChartPoints, chartContext],
+    [rawChartPoints, chartContext, addOrTogglePoint],
   )
 
   if (loading) return <LoadingState message="Loading activity..." />
@@ -344,7 +369,24 @@ export function GarminDetailPage() {
   const mapTrackPoints = mapTrackData?.garminTrackPoints?.items ?? []
   const chartPoints = chartData?.garminChartData ?? []
   const trackLoading = mapTrackLoading || chartLoading
-  const displayPoint = activePoint ?? lockedPoint
+  const displayPoint = activePoint
+  const displayPointSaved =
+    displayPoint != null &&
+    savedPoints.some((p) => p.id === displayPoint.timestamp)
+  const savedMapPoints = savedPoints
+    .filter(
+      (p) =>
+        p.latitude != null &&
+        p.longitude != null &&
+        Number.isFinite(p.latitude) &&
+        Number.isFinite(p.longitude),
+    )
+    .map((p) => ({
+      id: p.id,
+      lat: p.latitude as number,
+      lng: p.longitude as number,
+      color: p.color,
+    }))
 
   return (
     <div className="space-y-6">
@@ -410,11 +452,8 @@ export function GarminDetailPage() {
               ? { lat: activePoint.latitude, lng: activePoint.longitude }
               : null
           }
-          lockedLatLng={
-            lockedPoint?.latitude != null && lockedPoint?.longitude != null
-              ? { lat: lockedPoint.latitude, lng: lockedPoint.longitude }
-              : null
-          }
+          savedPoints={savedMapPoints}
+          onSavedPointRemove={removeSavedPoint}
           onMapPointSelect={
             rawChartPoints.length > 0 ? handleMapPointSelect : undefined
           }
@@ -427,12 +466,24 @@ export function GarminDetailPage() {
 
       {chartPoints.length > 0 && (
         <>
-          <ActivityHoverDetails point={displayPoint} />
+          <ActivityHoverDetails
+            point={displayPoint}
+            isSaved={displayPointSaved}
+            onToggleSave={
+              displayPoint ? () => addOrTogglePoint(displayPoint) : undefined
+            }
+          />
           <ActivityCharts
             trackPoints={chartPoints}
             activePoint={displayPoint}
+            savedPoints={savedPoints}
             onActivePointChange={setActivePoint}
-            onPointLock={setLockedPoint}
+            onPointToggle={addOrTogglePoint}
+          />
+          <SavedPointsList
+            points={savedPoints}
+            onRemove={removeSavedPoint}
+            onClear={clearSavedPoints}
           />
         </>
       )}


### PR DESCRIPTION
## Summary

Step 1 of the multi-point saved markers feature for the Garmin activity detail page. Replaces the single hidden double-click "lock" (one orange marker) with a collection of **color-coded saved points** rendered on the route map and both charts, with add/remove/clear controls.

Refs #158

## Changes

**New files**
- `src/components/garmin/savedPointColors.ts` — categorical palette (distinct from the route speed legend) + `nextSavedPointColor()` (first unused color, then recycles by count).
- `src/components/garmin/SavedPointsList.tsx` — list of saved points with color swatch, metrics, per-row remove (×), and "Clear all". Renders nothing when empty.

**Edited**
- `src/components/garmin/ActivityChartData.ts` — added `SavedPoint` type (`id` = timestamp, `color`).
- `src/components/garmin/ActivityCharts.tsx` — `onPointLock` → `onPointToggle`; renders a colored dashed `ReferenceLine` + `ReferenceDot` per saved point on both charts. Hover crosshair unchanged.
- `src/components/garmin/ActivityRouteMap.tsx` — replaced the single locked marker with a `Map`-backed set of color-coded `CircleMarker`s; clicking one removes it (`stopPropagation` so it doesn't add a new point). Callback held in a ref to avoid stale closures.
- `src/components/garmin/ActivityHoverDetails.tsx` — optional "Add point"/"Remove point" toggle button (no lock icon).
- `src/pages/GarminDetailPage.tsx` — in-memory `savedPoints` state with add/toggle, remove, and clear-all; reset on activity switch; map click toggles the nearest point and previews it.
- `src/pages/GarminDetailPage.test.tsx` — mocks + tests updated for saved-point behavior.

## Behavior

- Add a point via chart double-click, map click (nearest), or the details "Add point" button.
- Points are differentiated by **color** on map + both charts; toggle off by re-selecting.
- Remove via list ×, "Clear all", or clicking the saved map marker.
- Persistence is **in-memory only** for Step 1 (localStorage/DB deferred).

## Validation

- `npm run test:run` — 177 passed
- `npm run type-check` — clean
- `npm run lint:all` — clean
- `npm run build` — succeeds