### PR TITLE
feat: segment analysis between saved Garmin points

### DIFF
--- a/src/components/garmin/ActivityCharts.tsx
+++ b/src/components/garmin/ActivityCharts.tsx
@@ -7,6 +7,7 @@ import {
   CartesianGrid,
   ReferenceDot,
   ReferenceLine,
+  ReferenceArea,
   Tooltip,
   ResponsiveContainer,
 } from 'recharts'
@@ -102,6 +103,22 @@ export function ActivityCharts({
   const hasElevation = chartData.some((d) => d.elevation != null)
   const hasSpeed = chartData.some((d) => d.speed != null)
 
+  // Shaded regions between consecutive saved points (ordered along the x-axis).
+  const savedPointsByX = savedPoints
+    .filter((sp) => sp[xKey] != null && Number.isFinite(sp[xKey]))
+    .map((sp) => ({ id: sp.id, color: sp.color, x: sp[xKey] as number }))
+    .sort((a, b) => a.x - b.x)
+  const savedSegments = savedPointsByX.slice(0, -1).map((sp, i) => {
+    const next = savedPointsByX[i + 1]
+    return {
+      fromId: sp.id,
+      toId: next.id,
+      color: next.color,
+      x1: sp.x,
+      x2: next.x,
+    }
+  })
+
   const charts: ChartConfig[] = [
     {
       title: 'Elevation',
@@ -178,6 +195,16 @@ export function ActivityCharts({
                 onMouseLeave={() => onActivePointChange?.(null)}
               >
                 <CartesianGrid strokeDasharray="3 3" className="stroke-muted" />
+                {savedSegments.map((seg) => (
+                  <ReferenceArea
+                    key={`seg-${seg.fromId}-${seg.toId}`}
+                    x1={seg.x1}
+                    x2={seg.x2}
+                    fill={seg.color}
+                    fillOpacity={0.08}
+                    ifOverflow="extendDomain"
+                  />
+                ))}
                 <XAxis
                   dataKey={xKey}
                   type="number"

--- a/src/components/garmin/SegmentAnalysis.test.tsx
+++ b/src/components/garmin/SegmentAnalysis.test.tsx
@@ -1,0 +1,73 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import type { SavedPoint } from './ActivityChartData'
+import { SegmentAnalysis } from './SegmentAnalysis'
+
+function savedPoint(overrides: Partial<SavedPoint> = {}): SavedPoint {
+  return {
+    id: overrides.id ?? 'p',
+    color: '#ff0000',
+    timestamp: '2026-05-31T12:00:00Z',
+    time: 0,
+    distance: null,
+    distanceKm: null,
+    elevation: null,
+    speed: null,
+    latitude: null,
+    longitude: null,
+    ...overrides,
+  }
+}
+
+describe('SegmentAnalysis', () => {
+  it('renders nothing with fewer than two points', () => {
+    const { container } = render(<SegmentAnalysis points={[]} />)
+    expect(container).toBeEmptyDOMElement()
+
+    const { container: single } = render(
+      <SegmentAnalysis points={[savedPoint()]} />,
+    )
+    expect(single).toBeEmptyDOMElement()
+  })
+
+  it('renders one row per consecutive segment', () => {
+    const points = [
+      savedPoint({ id: 'a', time: 0, distanceKm: 0 }),
+      savedPoint({ id: 'b', time: 6, distanceKm: 1.609344 }),
+      savedPoint({ id: 'c', time: 12, distanceKm: 3.218688 }),
+    ]
+
+    render(<SegmentAnalysis points={points} />)
+
+    expect(screen.getByTestId('segment-analysis')).toBeInTheDocument()
+    expect(screen.getByText('Segment Analysis (2)')).toBeInTheDocument()
+    expect(screen.getAllByTestId('segment-row')).toHaveLength(2)
+    expect(screen.getByText('#1→2')).toBeInTheDocument()
+    expect(screen.getByText('#2→3')).toBeInTheDocument()
+  })
+
+  it('shows computed metrics for a segment', () => {
+    const points = [
+      savedPoint({ id: 'a', time: 0, distanceKm: 0, elevation: 100 }),
+      savedPoint({ id: 'b', time: 6, distanceKm: 1.609344, elevation: 200 }),
+    ]
+
+    render(<SegmentAnalysis points={points} />)
+
+    expect(screen.getByText('1.00 mi')).toBeInTheDocument()
+    expect(screen.getByText('10.0 mph')).toBeInTheDocument()
+    expect(screen.getByText('6:00 /mi')).toBeInTheDocument()
+    expect(screen.getByText('+100 ft')).toBeInTheDocument()
+  })
+
+  it('flags a straight-line distance with a direct suffix', () => {
+    const points = [
+      savedPoint({ id: 'a', time: 0, latitude: 40.0, longitude: -74.0 }),
+      savedPoint({ id: 'b', time: 10, latitude: 40.0, longitude: -73.9 }),
+    ]
+
+    render(<SegmentAnalysis points={points} />)
+
+    expect(screen.getByText(/\(direct\)/)).toBeInTheDocument()
+  })
+})

--- a/src/components/garmin/SegmentAnalysis.tsx
+++ b/src/components/garmin/SegmentAnalysis.tsx
@@ -1,0 +1,107 @@
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { formatDuration } from '@/lib/units'
+import type { SavedPoint } from './ActivityChartData'
+import {
+  buildSavedSegments,
+  formatPaceMinPerMi,
+  type SavedSegment,
+} from './segmentAnalysis'
+
+interface SegmentAnalysisProps {
+  points: SavedPoint[]
+}
+
+function formatDistance(segment: SavedSegment): string {
+  if (segment.distanceMi == null) return '—'
+  const suffix = segment.distanceIsStraightLine ? ' (direct)' : ''
+  return `${segment.distanceMi.toFixed(2)} mi${suffix}`
+}
+
+function formatSpeed(value: number | null): string {
+  return value != null ? `${value.toFixed(1)} mph` : '—'
+}
+
+function formatElevation(value: number | null): string {
+  if (value == null) return '—'
+  const sign = value > 0 ? '+' : ''
+  return `${sign}${value.toFixed(0)} ft`
+}
+
+function formatGrade(value: number | null): string {
+  if (value == null) return '—'
+  const sign = value > 0 ? '+' : ''
+  return `${sign}${value.toFixed(1)}%`
+}
+
+/**
+ * Shows distance and performance metrics for the stretch of activity between
+ * each pair of consecutive saved points. Renders nothing until at least two
+ * points are saved (i.e. there is a segment to analyze).
+ */
+export function SegmentAnalysis({ points }: SegmentAnalysisProps) {
+  const segments = buildSavedSegments(points)
+  if (segments.length === 0) return null
+
+  return (
+    <Card data-testid="segment-analysis">
+      <CardHeader className="pb-2">
+        <CardTitle className="text-base">
+          Segment Analysis ({segments.length})
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="overflow-x-auto">
+        <table className="w-full text-xs">
+          <thead>
+            <tr className="text-left text-muted-foreground">
+              <th className="py-1 pr-3 font-medium">Segment</th>
+              <th className="py-1 pr-3 font-medium">Distance</th>
+              <th className="py-1 pr-3 font-medium">Duration</th>
+              <th className="py-1 pr-3 font-medium">Avg Speed</th>
+              <th className="py-1 pr-3 font-medium">Pace</th>
+              <th className="py-1 pr-3 font-medium">Elev Δ</th>
+              <th className="py-1 font-medium">Grade</th>
+            </tr>
+          </thead>
+          <tbody>
+            {segments.map((s) => (
+              <tr
+                key={s.id}
+                className="border-t border-border"
+                data-testid="segment-row"
+              >
+                <td className="py-1 pr-3">
+                  <span className="flex items-center gap-2">
+                    <span
+                      className="inline-block h-3 w-3 shrink-0 rounded-full"
+                      style={{ backgroundColor: s.color }}
+                      aria-hidden="true"
+                    />
+                    <span className="font-medium">
+                      #{s.index}→{s.index + 1}
+                    </span>
+                  </span>
+                </td>
+                <td className="py-1 pr-3 tabular-nums">{formatDistance(s)}</td>
+                <td className="py-1 pr-3 tabular-nums">
+                  {formatDuration(s.durationSeconds)}
+                </td>
+                <td className="py-1 pr-3 tabular-nums">
+                  {formatSpeed(s.avgSpeedMph)}
+                </td>
+                <td className="py-1 pr-3 tabular-nums">
+                  {formatPaceMinPerMi(s.paceMinPerMi)}
+                </td>
+                <td className="py-1 pr-3 tabular-nums">
+                  {formatElevation(s.elevationChangeFt)}
+                </td>
+                <td className="py-1 tabular-nums">
+                  {formatGrade(s.gradePercent)}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </CardContent>
+    </Card>
+  )
+}

--- a/src/components/garmin/segmentAnalysis.test.ts
+++ b/src/components/garmin/segmentAnalysis.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it } from 'vitest'
+import type { SavedPoint } from './ActivityChartData'
+import { buildSavedSegments, formatPaceMinPerMi } from './segmentAnalysis'
+
+function savedPoint(overrides: Partial<SavedPoint> = {}): SavedPoint {
+  return {
+    id: overrides.id ?? overrides.timestamp ?? 'p',
+    color: '#ff0000',
+    timestamp: '2026-05-31T12:00:00Z',
+    time: 0,
+    distance: null,
+    distanceKm: null,
+    elevation: null,
+    speed: null,
+    latitude: null,
+    longitude: null,
+    ...overrides,
+  }
+}
+
+describe('buildSavedSegments', () => {
+  it('returns an empty array for fewer than two points', () => {
+    expect(buildSavedSegments([])).toEqual([])
+    expect(buildSavedSegments([savedPoint()])).toEqual([])
+  })
+
+  it('orders points by elapsed time regardless of insertion order', () => {
+    const a = savedPoint({ id: 'a', time: 0 })
+    const b = savedPoint({ id: 'b', time: 10 })
+    const c = savedPoint({ id: 'c', time: 20 })
+
+    const segments = buildSavedSegments([c, a, b])
+
+    expect(segments).toHaveLength(2)
+    expect(segments[0].from.id).toBe('a')
+    expect(segments[0].to.id).toBe('b')
+    expect(segments[1].from.id).toBe('b')
+    expect(segments[1].to.id).toBe('c')
+    expect(segments[0].index).toBe(1)
+    expect(segments[1].index).toBe(2)
+  })
+
+  it('computes distance from the cumulative distanceKm delta', () => {
+    const from = savedPoint({ id: 'a', time: 0, distanceKm: 1 })
+    const to = savedPoint({ id: 'b', time: 6, distanceKm: 2.609344 })
+
+    const [seg] = buildSavedSegments([from, to])
+
+    expect(seg.distanceIsStraightLine).toBe(false)
+    expect(seg.distanceMi).toBeCloseTo(1, 4)
+    // 6 minutes => 360 seconds
+    expect(seg.durationSeconds).toBeCloseTo(360, 5)
+    // 1 mile in 6 minutes => 10 mph
+    expect(seg.avgSpeedMph).toBeCloseTo(10, 4)
+    expect(seg.paceMinPerMi).toBeCloseTo(6, 4)
+  })
+
+  it('falls back to the straight-line distance when distanceKm is missing', () => {
+    const from = savedPoint({
+      id: 'a',
+      time: 0,
+      latitude: 40.0,
+      longitude: -74.0,
+    })
+    const to = savedPoint({
+      id: 'b',
+      time: 10,
+      latitude: 40.0,
+      longitude: -73.9,
+    })
+
+    const [seg] = buildSavedSegments([from, to])
+
+    expect(seg.distanceIsStraightLine).toBe(true)
+    expect(seg.distanceMi).not.toBeNull()
+    expect(seg.distanceMi).toBeGreaterThan(0)
+    expect(seg.straightLineMi).toBeCloseTo(seg.distanceMi ?? 0, 6)
+  })
+
+  it('computes net elevation change and grade', () => {
+    const from = savedPoint({
+      id: 'a',
+      time: 0,
+      distanceKm: 0,
+      elevation: 100,
+    })
+    const to = savedPoint({
+      id: 'b',
+      time: 6,
+      distanceKm: 1.609344,
+      elevation: 200,
+    })
+
+    const [seg] = buildSavedSegments([from, to])
+
+    expect(seg.elevationChangeFt).toBeCloseTo(100, 5)
+    expect(seg.distanceMi).toBeCloseTo(1, 4)
+    // 100 ft over 1 mile (5280 ft) => ~1.894%
+    expect(seg.gradePercent).toBeCloseTo((100 / 5280) * 100, 4)
+  })
+
+  it('leaves metrics null when inputs are unavailable', () => {
+    const from = savedPoint({ id: 'a', time: 0 })
+    const to = savedPoint({ id: 'b', time: 0 })
+
+    const [seg] = buildSavedSegments([from, to])
+
+    expect(seg.distanceMi).toBeNull()
+    expect(seg.durationSeconds).toBe(0)
+    expect(seg.avgSpeedMph).toBeNull()
+    expect(seg.paceMinPerMi).toBeNull()
+    expect(seg.elevationChangeFt).toBeNull()
+    expect(seg.gradePercent).toBeNull()
+  })
+
+  it('uses the ending point color for the segment', () => {
+    const from = savedPoint({ id: 'a', time: 0, color: '#111111' })
+    const to = savedPoint({ id: 'b', time: 10, color: '#222222' })
+
+    const [seg] = buildSavedSegments([from, to])
+
+    expect(seg.color).toBe('#222222')
+  })
+})
+
+describe('formatPaceMinPerMi', () => {
+  it('formats minutes and seconds', () => {
+    expect(formatPaceMinPerMi(6)).toBe('6:00 /mi')
+    expect(formatPaceMinPerMi(7.5)).toBe('7:30 /mi')
+  })
+
+  it('carries rounded seconds into the minutes column', () => {
+    expect(formatPaceMinPerMi(8.999)).toBe('9:00 /mi')
+  })
+
+  it('returns an em dash for null or non-finite values', () => {
+    expect(formatPaceMinPerMi(null)).toBe('—')
+    expect(formatPaceMinPerMi(Number.POSITIVE_INFINITY)).toBe('—')
+  })
+})

--- a/src/components/garmin/segmentAnalysis.ts
+++ b/src/components/garmin/segmentAnalysis.ts
@@ -1,0 +1,165 @@
+import { kmToMi } from '@/lib/units'
+import type { SavedPoint } from './ActivityChartData'
+
+const EARTH_RADIUS_KM = 6371
+const FT_PER_MI = 5280
+
+/**
+ * Performance metrics for the stretch of activity between two consecutive
+ * saved points. All distances are in miles, durations in seconds, speeds in
+ * mph and elevation in feet to match the saved-point display units.
+ */
+export interface SavedSegment {
+  /** Stable id derived from the two endpoint ids. */
+  id: string
+  /** 1-based position in the ordered segment list. */
+  index: number
+  from: SavedPoint
+  to: SavedPoint
+  /** Color of the ending point (used for the swatch + chart shading). */
+  color: string
+  /**
+   * Segment distance in miles. Uses the cumulative route distance delta when
+   * available and falls back to the great-circle distance otherwise.
+   */
+  distanceMi: number | null
+  /** True when {@link distanceMi} came from the straight-line fallback. */
+  distanceIsStraightLine: boolean
+  /** Great-circle distance between the endpoints in miles. */
+  straightLineMi: number | null
+  /** Elapsed time between the endpoints in seconds. */
+  durationSeconds: number
+  /** Average speed across the segment in mph. */
+  avgSpeedMph: number | null
+  /** Average pace across the segment in minutes per mile. */
+  paceMinPerMi: number | null
+  /** Net elevation change (to − from) in feet. */
+  elevationChangeFt: number | null
+  /** Average grade across the segment as a percentage. */
+  gradePercent: number | null
+}
+
+function toRadians(degrees: number): number {
+  return (degrees * Math.PI) / 180
+}
+
+function haversineKm(
+  latA: number,
+  lonA: number,
+  latB: number,
+  lonB: number,
+): number {
+  const dLat = toRadians(latB - latA)
+  const dLon = toRadians(lonB - lonA)
+  const a =
+    Math.sin(dLat / 2) ** 2 +
+    Math.cos(toRadians(latA)) *
+      Math.cos(toRadians(latB)) *
+      Math.sin(dLon / 2) ** 2
+  return 2 * EARTH_RADIUS_KM * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a))
+}
+
+function hasFiniteCoords(
+  p: SavedPoint,
+): p is SavedPoint & { latitude: number; longitude: number } {
+  return (
+    p.latitude != null &&
+    p.longitude != null &&
+    Number.isFinite(p.latitude) &&
+    Number.isFinite(p.longitude)
+  )
+}
+
+function straightLineMiles(from: SavedPoint, to: SavedPoint): number | null {
+  if (!hasFiniteCoords(from) || !hasFiniteCoords(to)) return null
+  return kmToMi(
+    haversineKm(from.latitude, from.longitude, to.latitude, to.longitude),
+  )
+}
+
+function routeMiles(from: SavedPoint, to: SavedPoint): number | null {
+  if (
+    from.distanceKm == null ||
+    to.distanceKm == null ||
+    !Number.isFinite(from.distanceKm) ||
+    !Number.isFinite(to.distanceKm)
+  ) {
+    return null
+  }
+  return kmToMi(Math.abs(to.distanceKm - from.distanceKm))
+}
+
+function buildSegment(
+  from: SavedPoint,
+  to: SavedPoint,
+  index: number,
+): SavedSegment {
+  const route = routeMiles(from, to)
+  const straightLineMi = straightLineMiles(from, to)
+  const distanceIsStraightLine = route == null && straightLineMi != null
+  const distanceMi = route ?? straightLineMi
+
+  const durationSeconds = Math.abs(to.time - from.time) * 60
+
+  const avgSpeedMph =
+    distanceMi != null && durationSeconds > 0
+      ? distanceMi / (durationSeconds / 3600)
+      : null
+
+  const paceMinPerMi =
+    avgSpeedMph != null && avgSpeedMph > 0 ? 60 / avgSpeedMph : null
+
+  const elevationChangeFt =
+    from.elevation != null && to.elevation != null
+      ? to.elevation - from.elevation
+      : null
+
+  const gradePercent =
+    elevationChangeFt != null && distanceMi != null && distanceMi > 0
+      ? (elevationChangeFt / (distanceMi * FT_PER_MI)) * 100
+      : null
+
+  return {
+    id: `${from.id}-${to.id}`,
+    index,
+    from,
+    to,
+    color: to.color,
+    distanceMi,
+    distanceIsStraightLine,
+    straightLineMi,
+    durationSeconds,
+    avgSpeedMph,
+    paceMinPerMi,
+    elevationChangeFt,
+    gradePercent,
+  }
+}
+
+/**
+ * Derive the consecutive segments between saved points. Points are ordered
+ * along the activity by their elapsed `time` so segments follow the route
+ * regardless of the order the user saved them. Returns an empty array when
+ * fewer than two points are supplied.
+ */
+export function buildSavedSegments(points: SavedPoint[]): SavedSegment[] {
+  if (points.length < 2) return []
+
+  const ordered = [...points].sort((a, b) => a.time - b.time)
+  const segments: SavedSegment[] = []
+  for (let i = 0; i < ordered.length - 1; i++) {
+    segments.push(buildSegment(ordered[i], ordered[i + 1], i + 1))
+  }
+  return segments
+}
+
+/** Format a pace value (minutes per mile) as `M:SS /mi`. */
+export function formatPaceMinPerMi(paceMinPerMi: number | null): string {
+  if (paceMinPerMi == null || !Number.isFinite(paceMinPerMi)) return '—'
+  const mins = Math.floor(paceMinPerMi)
+  const secs = Math.round((paceMinPerMi - mins) * 60)
+  // Carry rounding (e.g. 59.6s) into the minutes column.
+  const carryMins = secs === 60 ? mins + 1 : mins
+  const displaySecs = secs === 60 ? 0 : secs
+  return `${carryMins}:${displaySecs.toString().padStart(2, '0')} /mi`
+}

--- a/src/components/garmin/segmentAnalysis.ts
+++ b/src/components/garmin/segmentAnalysis.ts
@@ -99,7 +99,7 @@ function buildSegment(
   const distanceIsStraightLine = route == null && straightLineMi != null
   const distanceMi = route ?? straightLineMi
 
-  const durationSeconds = Math.abs(to.time - from.time) * 60
+  const durationSeconds = Math.round(Math.abs(to.time - from.time) * 60)
 
   const avgSpeedMph =
     distanceMi != null && durationSeconds > 0

--- a/src/pages/GarminDetailPage.tsx
+++ b/src/pages/GarminDetailPage.tsx
@@ -24,6 +24,7 @@ import { nextSavedPointColor } from '@/components/garmin/savedPointColors'
 import { ActivityCharts } from '@/components/garmin/ActivityCharts'
 import { ActivityHoverDetails } from '@/components/garmin/ActivityHoverDetails'
 import { SavedPointsList } from '@/components/garmin/SavedPointsList'
+import { SegmentAnalysis } from '@/components/garmin/SegmentAnalysis'
 import { ActivityStatsPanel } from '@/components/garmin/ActivityStatsPanel'
 import { Button } from '@/components/ui/button'
 import { setNRCustomAttribute } from '@/lib/newrelic-browser'
@@ -485,6 +486,7 @@ export function GarminDetailPage() {
             onRemove={removeSavedPoint}
             onClear={clearSavedPoints}
           />
+          <SegmentAnalysis points={savedPoints} />
         </>
       )}
 


### PR DESCRIPTION
## Summary

Adds **Segment Analysis (Step 2)** — performance metrics for the stretch of a
Garmin activity between each pair of consecutive saved points.

Builds on the multi-point saved markers from #168.

## What's new

- New `Segment Analysis` card on the Garmin activity detail page, shown once two
  or more points are saved. For each consecutive segment it computes:
  - **Distance** — from the cumulative `distanceKm` delta, falling back to the
    great-circle (straight-line) distance, labeled `(direct)` when used.
  - **Duration** — elapsed time between the endpoints.
  - **Avg Speed** and **Pace** (`M:SS /mi`).
  - **Elevation Δ** — net elevation change (endpoints only).
  - **Grade** — average grade across the segment.
- Subtle shaded regions on the elevation/speed charts between consecutive saved
  points, colored by the ending point.
- Points are ordered along the route by elapsed time, regardless of the order
  the user saved them.

## Scope notes

Metrics use only data available on the activity endpoints (distance, time,
elevation, speed, coordinates). Net elevation change is used rather than
gain/loss since only the segment endpoints are known — an honest Step-2 scope.

## Validation

- `npm run lint:all` — pass
- `npm run type-check` — pass
- `npm run build` — pass
- `npm run test:run` — 37 files / 191 tests pass (14 new tests for the helper
  and card component)

Refs #169