### PR TITLE
feat: add tabbed Garmin detail view with HR-aware stats sections

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -9,6 +9,7 @@
     "autofocus",
     "autosync",
     "bff",
+    "brpm",
     "buildx",
     "codegen",
     "Cognito",

--- a/src/components/garmin/ActivityStatsPanel.test.tsx
+++ b/src/components/garmin/ActivityStatsPanel.test.tsx
@@ -35,4 +35,21 @@ describe('ActivityStatsPanel', () => {
     expect(screen.getByText('68 °F')).toBeInTheDocument()
     expect(screen.getByText('720 kcal')).toBeInTheDocument()
   })
+
+  it('hides HR-dependent sections when hr data is unavailable', () => {
+    render(
+      <ActivityStatsPanel
+        activity={{
+          distance_km: 10,
+          duration_seconds: 3661,
+          hr_available: false,
+        }}
+      />,
+    )
+
+    expect(screen.queryByText('Heart Rate')).not.toBeInTheDocument()
+    expect(screen.queryByText('Training Effect')).not.toBeInTheDocument()
+    expect(screen.queryByText('Respiration')).not.toBeInTheDocument()
+    expect(screen.queryByText('Intensity Minutes')).not.toBeInTheDocument()
+  })
 })

--- a/src/components/garmin/ActivityStatsPanel.tsx
+++ b/src/components/garmin/ActivityStatsPanel.tsx
@@ -19,6 +19,20 @@ interface ActivityStatsPanelProps {
     max_speed_kmh?: number | null
     avg_heart_rate?: number | null
     max_heart_rate?: number | null
+    hr_available?: boolean | null
+    min_heart_rate?: number | null
+    aerobic_training_effect?: number | null
+    anaerobic_training_effect?: number | null
+    exercise_load?: number | null
+    avg_respiration_rate?: number | null
+    min_respiration_rate?: number | null
+    max_respiration_rate?: number | null
+    sweat_loss_ml?: number | null
+    moderate_intensity_minutes?: number | null
+    vigorous_intensity_minutes?: number | null
+    total_intensity_minutes?: number | null
+    paved_distance_km?: number | null
+    unpaved_distance_km?: number | null
     avg_cadence?: number | null
     max_cadence?: number | null
     total_ascent_m?: number | null
@@ -51,6 +65,9 @@ function fmt(
 }
 
 export function ActivityStatsPanel({ activity: a }: ActivityStatsPanelProps) {
+  const hrAvailable =
+    a.hr_available ?? (a.avg_heart_rate != null || a.max_heart_rate != null)
+
   const sections: StatSection[] = [
     {
       title: 'Distance',
@@ -123,19 +140,30 @@ export function ActivityStatsPanel({ activity: a }: ActivityStatsPanelProps) {
         { label: 'Max Speed', value: fmt(a.max_speed_kmh, 1, 'km/h') },
       ],
     },
-    {
-      title: 'Heart Rate',
-      rows: [
-        {
-          label: 'Avg Heart Rate',
-          value: a.avg_heart_rate != null ? `${a.avg_heart_rate} bpm` : '—',
-        },
-        {
-          label: 'Max Heart Rate',
-          value: a.max_heart_rate != null ? `${a.max_heart_rate} bpm` : '—',
-        },
-      ],
-    },
+    ...(hrAvailable
+      ? [
+          {
+            title: 'Heart Rate',
+            rows: [
+              {
+                label: 'Avg Heart Rate',
+                value:
+                  a.avg_heart_rate != null ? `${a.avg_heart_rate} bpm` : '—',
+              },
+              {
+                label: 'Max Heart Rate',
+                value:
+                  a.max_heart_rate != null ? `${a.max_heart_rate} bpm` : '—',
+              },
+              {
+                label: 'Min Heart Rate',
+                value:
+                  a.min_heart_rate != null ? `${a.min_heart_rate} bpm` : '—',
+              },
+            ],
+          } satisfies StatSection,
+        ]
+      : []),
     {
       title: 'Cadence',
       rows: [
@@ -187,21 +215,109 @@ export function ActivityStatsPanel({ activity: a }: ActivityStatsPanelProps) {
           label: 'Total Calories',
           value: a.calories != null ? `${a.calories} kcal` : '—',
         },
+        {
+          label: 'Est. Sweat Loss',
+          value: a.sweat_loss_ml != null ? `${a.sweat_loss_ml} ml` : '—',
+        },
       ],
     },
+    ...(hrAvailable
+      ? [
+          {
+            title: 'Training Effect',
+            rows: [
+              {
+                label: 'Aerobic TE',
+                value:
+                  a.aerobic_training_effect != null
+                    ? a.aerobic_training_effect.toFixed(1)
+                    : '—',
+              },
+              {
+                label: 'Anaerobic TE',
+                value:
+                  a.anaerobic_training_effect != null
+                    ? a.anaerobic_training_effect.toFixed(1)
+                    : '—',
+              },
+              {
+                label: 'Exercise Load',
+                value:
+                  a.exercise_load != null ? `${a.exercise_load}` : '—',
+              },
+            ],
+          } satisfies StatSection,
+          {
+            title: 'Respiration',
+            rows: [
+              {
+                label: 'Avg Respiration',
+                value:
+                  a.avg_respiration_rate != null
+                    ? `${a.avg_respiration_rate} brpm`
+                    : '—',
+              },
+              {
+                label: 'Min Respiration',
+                value:
+                  a.min_respiration_rate != null
+                    ? `${a.min_respiration_rate} brpm`
+                    : '—',
+              },
+              {
+                label: 'Max Respiration',
+                value:
+                  a.max_respiration_rate != null
+                    ? `${a.max_respiration_rate} brpm`
+                    : '—',
+              },
+            ],
+          } satisfies StatSection,
+          {
+            title: 'Intensity Minutes',
+            rows: [
+              {
+                label: 'Moderate',
+                value:
+                  a.moderate_intensity_minutes != null
+                    ? `${a.moderate_intensity_minutes} min`
+                    : '—',
+              },
+              {
+                label: 'Vigorous',
+                value:
+                  a.vigorous_intensity_minutes != null
+                    ? `${a.vigorous_intensity_minutes} min`
+                    : '—',
+              },
+              {
+                label: 'Total',
+                value:
+                  a.total_intensity_minutes != null
+                    ? `${a.total_intensity_minutes} min`
+                    : '—',
+              },
+            ],
+          } satisfies StatSection,
+        ]
+      : []),
     {
-      title: 'Training Effect',
+      title: 'Road Surface',
       rows: [
-        { label: 'Aerobic TE', value: '—' },
-        { label: 'Anaerobic TE', value: '—' },
-      ],
-    },
-    {
-      title: 'Additional',
-      rows: [
-        { label: 'VO2 Max', value: '—' },
-        { label: 'Exercise Load', value: '—' },
-        { label: 'Sweat Loss', value: '—' },
+        {
+          label: 'Paved',
+          value:
+            a.paved_distance_km != null
+              ? `${kmToMi(a.paved_distance_km).toFixed(2)} mi`
+              : '—',
+        },
+        {
+          label: 'Unpaved',
+          value:
+            a.unpaved_distance_km != null
+              ? `${kmToMi(a.unpaved_distance_km).toFixed(2)} mi`
+              : '—',
+        },
       ],
     },
   ]

--- a/src/components/garmin/ActivityStatsPanel.tsx
+++ b/src/components/garmin/ActivityStatsPanel.tsx
@@ -242,8 +242,7 @@ export function ActivityStatsPanel({ activity: a }: ActivityStatsPanelProps) {
               },
               {
                 label: 'Exercise Load',
-                value:
-                  a.exercise_load != null ? `${a.exercise_load}` : '—',
+                value: a.exercise_load != null ? `${a.exercise_load}` : '—',
               },
             ],
           } satisfies StatSection,

--- a/src/pages/GarminDetailPage.test.tsx
+++ b/src/pages/GarminDetailPage.test.tsx
@@ -197,7 +197,7 @@ describe('GarminDetailPage', () => {
     expect(refetch).toHaveBeenCalledTimes(1)
   })
 
-  it('renders the activity detail sections and preserves the back link state', () => {
+  it('renders the activity detail sections and preserves the back link state', async () => {
     garminDetailHooks.useGarminActivityQuery.mockReturnValue({
       loading: false,
       error: undefined,
@@ -240,9 +240,14 @@ describe('GarminDetailPage', () => {
       'running:/garmin?page=2&sport=running',
     )
     expect(screen.getByTestId('activity-stats-bar')).toBeInTheDocument()
+    expect(screen.getByTestId('garmin-detail-tabs')).toBeInTheDocument()
+    expect(screen.getByTestId('activity-stats-panel')).toBeInTheDocument()
+
+    const user = userEvent.setup()
+    await user.click(screen.getByTestId('garmin-tab-charts'))
+
     expect(screen.getByTestId('activity-route-map')).toBeInTheDocument()
     expect(screen.getByTestId('activity-charts')).toBeInTheDocument()
-    expect(screen.getByTestId('activity-stats-panel')).toBeInTheDocument()
     expect(
       screen.getByText('Chart data failed: chart fetch failed'),
     ).toBeInTheDocument()
@@ -304,6 +309,7 @@ describe('GarminDetailPage', () => {
     })
 
     renderPage()
+    await user.click(screen.getByTestId('garmin-tab-charts'))
 
     await user.click(screen.getByTestId('activity-route-map'))
 
@@ -369,6 +375,7 @@ describe('GarminDetailPage', () => {
     })
 
     renderPage()
+    await user.click(screen.getByTestId('garmin-tab-charts'))
 
     await user.dblClick(screen.getByTestId('activity-charts'))
 
@@ -429,6 +436,7 @@ describe('GarminDetailPage', () => {
     })
 
     renderPage()
+    await user.click(screen.getByTestId('garmin-tab-charts'))
 
     await user.dblClick(screen.getByTestId('activity-charts'))
     expect(screen.getAllByTestId('saved-point-row')).toHaveLength(1)
@@ -490,6 +498,7 @@ describe('GarminDetailPage', () => {
     })
 
     renderPage()
+    await user.click(screen.getByTestId('garmin-tab-charts'))
 
     await user.click(screen.getByTestId('activity-route-map'))
 
@@ -611,6 +620,7 @@ describe('GarminDetailPage', () => {
     vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(clickSpy)
 
     renderPage()
+    await user.click(screen.getByTestId('garmin-tab-charts'))
 
     await user.click(screen.getByRole('button', { name: /Export CSV/i }))
 
@@ -647,6 +657,7 @@ describe('GarminDetailPage', () => {
     vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(clickSpy)
 
     renderPage()
+    await user.click(screen.getByTestId('garmin-tab-charts'))
 
     await user.click(screen.getByRole('button', { name: /Export GeoJSON/i }))
 
@@ -687,6 +698,7 @@ describe('GarminDetailPage', () => {
     vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(clickSpy)
 
     renderPage()
+    await user.click(screen.getByTestId('garmin-tab-charts'))
 
     await user.click(screen.getByRole('button', { name: /Export GeoJSON/i }))
 
@@ -716,6 +728,7 @@ describe('GarminDetailPage', () => {
     ])
 
     renderPage()
+    await user.click(screen.getByTestId('garmin-tab-charts'))
 
     await user.click(screen.getByRole('button', { name: /Export GeoJSON/i }))
 
@@ -726,7 +739,8 @@ describe('GarminDetailPage', () => {
     })
   })
 
-  it('ignores a second export click before React applies disabled state', () => {
+  it('ignores a second export click before React applies disabled state', async () => {
+    const user = userEvent.setup()
     mockLoadedActivity()
 
     const fetchExport = vi.fn().mockReturnValue(new Promise(() => {}))
@@ -736,6 +750,7 @@ describe('GarminDetailPage', () => {
     ])
 
     renderPage()
+    await user.click(screen.getByTestId('garmin-tab-charts'))
 
     fireEvent.click(screen.getByTestId('export-csv-button'))
     fireEvent.click(screen.getByTestId('export-geojson-button'))
@@ -770,6 +785,7 @@ describe('GarminDetailPage', () => {
     vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => {})
 
     renderPage()
+    await user.click(screen.getByTestId('garmin-tab-charts'))
 
     const csvButton = screen.getByTestId('export-csv-button')
     const geojsonButton = screen.getByTestId('export-geojson-button')

--- a/src/pages/GarminDetailPage.tsx
+++ b/src/pages/GarminDetailPage.tsx
@@ -27,6 +27,12 @@ import { SavedPointsList } from '@/components/garmin/SavedPointsList'
 import { SegmentAnalysis } from '@/components/garmin/SegmentAnalysis'
 import { ActivityStatsPanel } from '@/components/garmin/ActivityStatsPanel'
 import { Button } from '@/components/ui/button'
+import {
+  Tabs,
+  TabsContent,
+  TabsList,
+  TabsTrigger,
+} from '@/components/ui/tabs'
 import { setNRCustomAttribute } from '@/lib/newrelic-browser'
 import { escapeCsvValue, triggerDownload } from '@/lib/export'
 
@@ -369,6 +375,10 @@ export function GarminDetailPage() {
 
   const mapTrackPoints = mapTrackData?.garminTrackPoints?.items ?? []
   const chartPoints = chartData?.garminChartData ?? []
+  const hasHrData =
+    a.avg_heart_rate != null ||
+    a.max_heart_rate != null ||
+    chartPoints.some((point) => point.heart_rate != null)
   const trackLoading = mapTrackLoading || chartLoading
   const displayPoint = activePoint
   const displayPointSaved =
@@ -406,91 +416,106 @@ export function GarminDetailPage() {
         totalAscentM={a.total_ascent_m}
       />
 
-      <div className="flex gap-2">
-        <Button
-          variant="outline"
-          size="sm"
-          data-testid="export-csv-button"
-          disabled={isExporting}
-          onClick={() => handleExport('csv')}
-        >
-          {activeExport === 'csv' ? (
-            <Loader2
-              data-testid="export-csv-spinner"
-              className="mr-2 h-4 w-4 animate-spin"
+      <Tabs defaultValue="stats" className="w-full" data-testid="garmin-detail-tabs">
+        <TabsList variant="line" className="w-full justify-start">
+          <TabsTrigger value="stats" data-testid="garmin-tab-stats">
+            Stats
+          </TabsTrigger>
+          <TabsTrigger value="charts" data-testid="garmin-tab-charts">
+            Charts
+          </TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="stats" className="space-y-4">
+          <ActivityStatsPanel activity={{ ...a, hr_available: hasHrData }} />
+        </TabsContent>
+
+        <TabsContent value="charts" className="space-y-4">
+          <div className="flex gap-2">
+            <Button
+              variant="outline"
+              size="sm"
+              data-testid="export-csv-button"
+              disabled={isExporting}
+              onClick={() => handleExport('csv')}
+            >
+              {activeExport === 'csv' ? (
+                <Loader2
+                  data-testid="export-csv-spinner"
+                  className="mr-2 h-4 w-4 animate-spin"
+                />
+              ) : (
+                <Download className="mr-2 h-4 w-4" />
+              )}
+              Export CSV
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              data-testid="export-geojson-button"
+              disabled={isExporting}
+              onClick={() => handleExport('geojson')}
+            >
+              {activeExport === 'geojson' ? (
+                <Loader2
+                  data-testid="export-geojson-spinner"
+                  className="mr-2 h-4 w-4 animate-spin"
+                />
+              ) : (
+                <Download className="mr-2 h-4 w-4" />
+              )}
+              Export GeoJSON
+            </Button>
+          </div>
+
+          {trackLoading && <LoadingState message="Loading track data..." />}
+
+          {mapTrackPoints.length > 0 && (
+            <ActivityRouteMap
+              trackPoints={mapTrackPoints}
+              activeLatLng={
+                activePoint?.latitude != null && activePoint?.longitude != null
+                  ? { lat: activePoint.latitude, lng: activePoint.longitude }
+                  : null
+              }
+              savedPoints={savedMapPoints}
+              onSavedPointRemove={removeSavedPoint}
+              onMapPointSelect={
+                rawChartPoints.length > 0 ? handleMapPointSelect : undefined
+              }
             />
-          ) : (
-            <Download className="mr-2 h-4 w-4" />
           )}
-          Export CSV
-        </Button>
-        <Button
-          variant="outline"
-          size="sm"
-          data-testid="export-geojson-button"
-          disabled={isExporting}
-          onClick={() => handleExport('geojson')}
-        >
-          {activeExport === 'geojson' ? (
-            <Loader2
-              data-testid="export-geojson-spinner"
-              className="mr-2 h-4 w-4 animate-spin"
-            />
-          ) : (
-            <Download className="mr-2 h-4 w-4" />
+
+          {chartError && (
+            <ErrorState message={`Chart data failed: ${chartError.message}`} />
           )}
-          Export GeoJSON
-        </Button>
-      </div>
 
-      {trackLoading && <LoadingState message="Loading track data..." />}
-
-      {mapTrackPoints.length > 0 && (
-        <ActivityRouteMap
-          trackPoints={mapTrackPoints}
-          activeLatLng={
-            activePoint?.latitude != null && activePoint?.longitude != null
-              ? { lat: activePoint.latitude, lng: activePoint.longitude }
-              : null
-          }
-          savedPoints={savedMapPoints}
-          onSavedPointRemove={removeSavedPoint}
-          onMapPointSelect={
-            rawChartPoints.length > 0 ? handleMapPointSelect : undefined
-          }
-        />
-      )}
-
-      {chartError && (
-        <ErrorState message={`Chart data failed: ${chartError.message}`} />
-      )}
-
-      {chartPoints.length > 0 && (
-        <>
-          <ActivityHoverDetails
-            point={displayPoint}
-            isSaved={displayPointSaved}
-            onToggleSave={
-              displayPoint ? () => addOrTogglePoint(displayPoint) : undefined
-            }
-          />
-          <ActivityCharts
-            trackPoints={chartPoints}
-            activePoint={displayPoint}
-            savedPoints={savedPoints}
-            onActivePointChange={setActivePoint}
-            onPointToggle={addOrTogglePoint}
-          />
-          <SavedPointsList
-            points={savedPoints}
-            onRemove={removeSavedPoint}
-            onClear={clearSavedPoints}
-          />
-          <SegmentAnalysis points={savedPoints} />
-        </>
-      )}
-
-      <ActivityStatsPanel activity={a} />
+          {chartPoints.length > 0 && (
+            <>
+              <ActivityHoverDetails
+                point={displayPoint}
+                isSaved={displayPointSaved}
+                onToggleSave={
+                  displayPoint ? () => addOrTogglePoint(displayPoint) : undefined
+                }
+              />
+              <ActivityCharts
+                trackPoints={chartPoints}
+                activePoint={displayPoint}
+                savedPoints={savedPoints}
+                onActivePointChange={setActivePoint}
+                onPointToggle={addOrTogglePoint}
+              />
+              <SavedPointsList
+                points={savedPoints}
+                onRemove={removeSavedPoint}
+                onClear={clearSavedPoints}
+              />
+              <SegmentAnalysis points={savedPoints} />
+            </>
+          )}
+        </TabsContent>
+      </Tabs>
     </div>
   )
 }

--- a/src/pages/GarminDetailPage.tsx
+++ b/src/pages/GarminDetailPage.tsx
@@ -27,12 +27,7 @@ import { SavedPointsList } from '@/components/garmin/SavedPointsList'
 import { SegmentAnalysis } from '@/components/garmin/SegmentAnalysis'
 import { ActivityStatsPanel } from '@/components/garmin/ActivityStatsPanel'
 import { Button } from '@/components/ui/button'
-import {
-  Tabs,
-  TabsContent,
-  TabsList,
-  TabsTrigger,
-} from '@/components/ui/tabs'
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { setNRCustomAttribute } from '@/lib/newrelic-browser'
 import { escapeCsvValue, triggerDownload } from '@/lib/export'
 
@@ -416,7 +411,11 @@ export function GarminDetailPage() {
         totalAscentM={a.total_ascent_m}
       />
 
-      <Tabs defaultValue="stats" className="w-full" data-testid="garmin-detail-tabs">
+      <Tabs
+        defaultValue="stats"
+        className="w-full"
+        data-testid="garmin-detail-tabs"
+      >
         <TabsList variant="line" className="w-full justify-start">
           <TabsTrigger value="stats" data-testid="garmin-tab-stats">
             Stats
@@ -496,7 +495,9 @@ export function GarminDetailPage() {
                 point={displayPoint}
                 isSaved={displayPointSaved}
                 onToggleSave={
-                  displayPoint ? () => addOrTogglePoint(displayPoint) : undefined
+                  displayPoint
+                    ? () => addOrTogglePoint(displayPoint)
+                    : undefined
                 }
               />
               <ActivityCharts


### PR DESCRIPTION
## Summary
- add Stats/Charts tabbed layout to Garmin detail page
- hide HR-dependent stats sections when HR data is unavailable
- add/update tests for tabbed behavior and HR section visibility

## Validation
- npm run type-check
- npm run test:run -- src/components/garmin/ActivityStatsPanel.test.tsx src/pages/GarminDetailPage.test.tsx
