### PR TITLE
feat: default Garmin detail view to route map

### DIFF
--- a/src/pages/GarminDetailPage.test.tsx
+++ b/src/pages/GarminDetailPage.test.tsx
@@ -241,11 +241,6 @@ describe('GarminDetailPage', () => {
     )
     expect(screen.getByTestId('activity-stats-bar')).toBeInTheDocument()
     expect(screen.getByTestId('garmin-detail-tabs')).toBeInTheDocument()
-    expect(screen.getByTestId('activity-stats-panel')).toBeInTheDocument()
-
-    const user = userEvent.setup()
-    await user.click(screen.getByTestId('garmin-tab-charts'))
-
     expect(screen.getByTestId('activity-route-map')).toBeInTheDocument()
     expect(screen.getByTestId('activity-charts')).toBeInTheDocument()
     expect(

--- a/src/pages/GarminDetailPage.tsx
+++ b/src/pages/GarminDetailPage.tsx
@@ -412,7 +412,7 @@ export function GarminDetailPage() {
       />
 
       <Tabs
-        defaultValue="stats"
+        defaultValue="charts"
         className="w-full"
         data-testid="garmin-detail-tabs"
       >


### PR DESCRIPTION
## Summary
- default the Garmin detail page to the route map tab
- includes the map-default cherry-pick from 615be9db267215cd3f5cebbde1115e5f2e24ee90

## Validation
- npm run test:run -- src/pages/GarminDetailPage.test.tsx
- npm run type-check