### PR TITLE
[codex] Add Garmin-style chart labels

### DIFF
--- a/src/components/garmin/ActivityChartTooltip.ts
+++ b/src/components/garmin/ActivityChartTooltip.ts
@@ -1,0 +1,22 @@
+export type XAxisMode = 'distance' | 'time'
+
+export function formatXAxisValue(
+  value: unknown,
+  mode: XAxisMode,
+): string | undefined {
+  if (value == null || value === '') return undefined
+
+  const numeric = typeof value === 'number' ? value : Number(value)
+  if (!Number.isFinite(numeric)) return undefined
+
+  return mode === 'distance'
+    ? `${numeric.toFixed(1)} mi`
+    : `${numeric.toFixed(0)} min`
+}
+
+export function coerceTooltipMetricValue(value: unknown): number | null {
+  if (value == null || value === '') return null
+
+  const numeric = typeof value === 'number' ? value : Number(value)
+  return Number.isFinite(numeric) ? numeric : null
+}

--- a/src/components/garmin/ActivityCharts.test.tsx
+++ b/src/components/garmin/ActivityCharts.test.tsx
@@ -32,4 +32,37 @@ describe('ActivityCharts', () => {
     expect(screen.getByTestId('chart-heartRate')).toBeInTheDocument()
     expect(screen.getByText('Heart Rate')).toBeInTheDocument()
   })
+
+  it('renders Garmin-style labels and average values for each chart', () => {
+    render(
+      <ActivityCharts
+        trackPoints={[
+          {
+            timestamp: '2026-03-14T09:00:00Z',
+            distance_from_start_km: 0,
+            altitude: 10,
+            speed_kmh: 22,
+            heart_rate: 118,
+            latitude: 40.7,
+            longitude: -74,
+          },
+          {
+            timestamp: '2026-03-14T09:10:00Z',
+            distance_from_start_km: 5,
+            altitude: 30,
+            speed_kmh: 28,
+            heart_rate: 152,
+            latitude: 40.71,
+            longitude: -74.01,
+          },
+        ]}
+      />,
+    )
+
+    expect(screen.getByLabelText('Elevation average 66 ft')).toBeInTheDocument()
+    expect(screen.getByLabelText('Speed average 15.5 mph')).toBeInTheDocument()
+    expect(
+      screen.getByLabelText('Heart Rate average 135 bpm'),
+    ).toBeInTheDocument()
+  })
 })

--- a/src/components/garmin/ActivityCharts.test.tsx
+++ b/src/components/garmin/ActivityCharts.test.tsx
@@ -1,6 +1,10 @@
 import { render, screen } from '@testing-library/react'
 import { describe, expect, it } from 'vitest'
 import { ActivityCharts } from './ActivityCharts'
+import {
+  coerceTooltipMetricValue,
+  formatXAxisValue,
+} from './ActivityChartTooltip'
 
 describe('ActivityCharts', () => {
   it('renders a heart-rate chart when heart-rate data is present', () => {
@@ -64,5 +68,25 @@ describe('ActivityCharts', () => {
     expect(
       screen.getByLabelText('Heart Rate average 135 bpm'),
     ).toBeInTheDocument()
+  })
+
+  it('ignores nullish and empty x-axis tooltip labels', () => {
+    expect(formatXAxisValue(null, 'distance')).toBeUndefined()
+    expect(formatXAxisValue(undefined, 'time')).toBeUndefined()
+    expect(formatXAxisValue('', 'distance')).toBeUndefined()
+  })
+
+  it('formats numeric x-axis tooltip labels', () => {
+    expect(formatXAxisValue(1.234, 'distance')).toBe('1.2 mi')
+    expect(formatXAxisValue('12', 'time')).toBe('12 min')
+    expect(formatXAxisValue('not-a-number', 'distance')).toBeUndefined()
+  })
+
+  it('coerces numeric tooltip payload values', () => {
+    expect(coerceTooltipMetricValue(12.5)).toBe(12.5)
+    expect(coerceTooltipMetricValue('12.5')).toBe(12.5)
+    expect(coerceTooltipMetricValue(null)).toBeNull()
+    expect(coerceTooltipMetricValue('')).toBeNull()
+    expect(coerceTooltipMetricValue('not-a-number')).toBeNull()
   })
 })

--- a/src/components/garmin/ActivityCharts.tsx
+++ b/src/components/garmin/ActivityCharts.tsx
@@ -52,6 +52,7 @@ interface ChartConfig {
   color: string
   unit: string
   hasData: boolean
+  precision: number
 }
 
 function activeMetricValue(
@@ -60,6 +61,61 @@ function activeMetricValue(
 ): number | null {
   const value = point?.[dataKey]
   return typeof value === 'number' && Number.isFinite(value) ? value : null
+}
+
+function averageMetricValue(
+  data: ChartDataPoint[],
+  dataKey: MetricKey,
+): number | null {
+  const values = data
+    .map((point) => activeMetricValue(point, dataKey))
+    .filter((value): value is number => value != null)
+
+  if (values.length === 0) return null
+
+  return values.reduce((sum, value) => sum + value, 0) / values.length
+}
+
+function formatNumber(value: number | null, precision: number): string {
+  return value != null ? value.toFixed(precision) : '--'
+}
+
+function formatMetricValue(
+  value: number | null,
+  chart: Pick<ChartConfig, 'precision' | 'unit'>,
+): string {
+  return `${formatNumber(value, chart.precision)} ${chart.unit}`
+}
+
+function formatXAxisValue(value: unknown, mode: XAxisMode): string | undefined {
+  const numeric = typeof value === 'number' ? value : Number(value)
+  if (!Number.isFinite(numeric)) return undefined
+
+  return mode === 'distance'
+    ? `${numeric.toFixed(1)} mi`
+    : `${numeric.toFixed(0)} min`
+}
+
+interface ChartTooltipProps {
+  label?: unknown
+  payload?: ReadonlyArray<{ value?: unknown }>
+  chart: ChartConfig
+  xMode: XAxisMode
+}
+
+function ChartTooltip({ label, payload, chart, xMode }: ChartTooltipProps) {
+  const metricValue =
+    typeof payload?.[0]?.value === 'number' && Number.isFinite(payload[0].value)
+      ? payload[0].value
+      : null
+  const xValue = formatXAxisValue(label, xMode)
+
+  return (
+    <div className="space-y-1 rounded bg-neutral-950/90 px-2 py-1 text-xs text-white shadow-md">
+      {xValue && <div>{xValue}</div>}
+      <div>{formatMetricValue(metricValue, chart)}</div>
+    </div>
+  )
 }
 
 function pointFromTooltipState(
@@ -125,9 +181,10 @@ export function ActivityCharts({
     {
       title: 'Elevation',
       dataKey: 'elevation',
-      color: '#6b7280',
+      color: '#55b922',
       unit: 'ft',
       hasData: hasElevation,
+      precision: 0,
     },
     {
       title: 'Speed',
@@ -135,6 +192,7 @@ export function ActivityCharts({
       color: '#3b82f6',
       unit: 'mph',
       hasData: hasSpeed,
+      precision: 1,
     },
     {
       title: 'Heart Rate',
@@ -142,6 +200,7 @@ export function ActivityCharts({
       color: '#ef4444',
       unit: 'bpm',
       hasData: hasHeartRate,
+      precision: 0,
     },
   ]
 
@@ -181,7 +240,29 @@ export function ActivityCharts({
       {activeCharts.map((chart) => (
         <Card key={chart.dataKey} data-testid={`chart-${chart.dataKey}`}>
           <CardHeader className="pb-2">
-            <CardTitle className="text-base">{chart.title}</CardTitle>
+            <div className="flex items-center justify-between gap-3">
+              <CardTitle className="flex items-center gap-2 text-base font-medium">
+                <span
+                  aria-hidden="true"
+                  className="size-3 rounded-full"
+                  style={{ backgroundColor: chart.color }}
+                />
+                {chart.title}
+              </CardTitle>
+              <div
+                aria-label={`${chart.title} average ${formatMetricValue(
+                  averageMetricValue(chartData, chart.dataKey),
+                  chart,
+                )}`}
+                className="rounded bg-neutral-950/70 px-2 py-1 text-xs text-white"
+              >
+                Avg:{' '}
+                {formatMetricValue(
+                  averageMetricValue(chartData, chart.dataKey),
+                  chart,
+                )}
+              </div>
+            </div>
           </CardHeader>
           <CardContent>
             <ResponsiveContainer width="100%" height={200}>
@@ -237,7 +318,14 @@ export function ActivityCharts({
                 />
                 <Tooltip
                   cursor={{ stroke: 'currentColor', strokeOpacity: 0.4 }}
-                  content={() => null}
+                  content={({ label, payload }) => (
+                    <ChartTooltip
+                      label={label}
+                      payload={payload}
+                      chart={chart}
+                      xMode={effectiveXMode}
+                    />
+                  )}
                 />
                 {activeX != null && (
                   <ReferenceLine

--- a/src/components/garmin/ActivityCharts.tsx
+++ b/src/components/garmin/ActivityCharts.tsx
@@ -67,13 +67,18 @@ function averageMetricValue(
   data: ChartDataPoint[],
   dataKey: MetricKey,
 ): number | null {
-  const values = data
-    .map((point) => activeMetricValue(point, dataKey))
-    .filter((value): value is number => value != null)
+  let sum = 0
+  let count = 0
 
-  if (values.length === 0) return null
+  for (const point of data) {
+    const value = activeMetricValue(point, dataKey)
+    if (value == null) continue
 
-  return values.reduce((sum, value) => sum + value, 0) / values.length
+    sum += value
+    count += 1
+  }
+
+  return count > 0 ? sum / count : null
 }
 
 function formatNumber(value: number | null, precision: number): string {
@@ -205,6 +210,13 @@ export function ActivityCharts({
   ]
 
   const activeCharts = charts.filter((c) => c.hasData)
+  const activeChartLabels = activeCharts.map((chart) => ({
+    chart,
+    averageLabel: formatMetricValue(
+      averageMetricValue(chartData, chart.dataKey),
+      chart,
+    ),
+  }))
 
   if (activeCharts.length === 0) return null
 
@@ -237,7 +249,7 @@ export function ActivityCharts({
         </Button>
       </div>
 
-      {activeCharts.map((chart) => (
+      {activeChartLabels.map(({ chart, averageLabel }) => (
         <Card key={chart.dataKey} data-testid={`chart-${chart.dataKey}`}>
           <CardHeader className="pb-2">
             <div className="flex items-center justify-between gap-3">
@@ -250,17 +262,10 @@ export function ActivityCharts({
                 {chart.title}
               </CardTitle>
               <div
-                aria-label={`${chart.title} average ${formatMetricValue(
-                  averageMetricValue(chartData, chart.dataKey),
-                  chart,
-                )}`}
+                aria-label={`${chart.title} average ${averageLabel}`}
                 className="rounded bg-neutral-950/70 px-2 py-1 text-xs text-white"
               >
-                Avg:{' '}
-                {formatMetricValue(
-                  averageMetricValue(chartData, chart.dataKey),
-                  chart,
-                )}
+                Avg: {averageLabel}
               </div>
             </div>
           </CardHeader>

--- a/src/components/garmin/ActivityCharts.tsx
+++ b/src/components/garmin/ActivityCharts.tsx
@@ -19,6 +19,11 @@ import {
   type ChartDataPoint,
   type SavedPoint,
 } from './ActivityChartData'
+import {
+  coerceTooltipMetricValue,
+  formatXAxisValue,
+  type XAxisMode,
+} from './ActivityChartTooltip'
 
 interface ActivityChartsProps {
   trackPoints: ActivityChartTrackPoint[]
@@ -41,8 +46,6 @@ interface ActivityChartsProps {
    */
   onPointToggle?: (point: ChartDataPoint) => void
 }
-
-type XAxisMode = 'distance' | 'time'
 
 type MetricKey = 'elevation' | 'speed' | 'heartRate'
 
@@ -92,15 +95,6 @@ function formatMetricValue(
   return `${formatNumber(value, chart.precision)} ${chart.unit}`
 }
 
-function formatXAxisValue(value: unknown, mode: XAxisMode): string | undefined {
-  const numeric = typeof value === 'number' ? value : Number(value)
-  if (!Number.isFinite(numeric)) return undefined
-
-  return mode === 'distance'
-    ? `${numeric.toFixed(1)} mi`
-    : `${numeric.toFixed(0)} min`
-}
-
 interface ChartTooltipProps {
   label?: unknown
   payload?: ReadonlyArray<{ value?: unknown }>
@@ -109,10 +103,7 @@ interface ChartTooltipProps {
 }
 
 function ChartTooltip({ label, payload, chart, xMode }: ChartTooltipProps) {
-  const metricValue =
-    typeof payload?.[0]?.value === 'number' && Number.isFinite(payload[0].value)
-      ? payload[0].value
-      : null
+  const metricValue = coerceTooltipMetricValue(payload?.[0]?.value)
   const xValue = formatXAxisValue(label, xMode)
 
   return (


### PR DESCRIPTION
## Summary

Refs #196
Supersedes #197

Adds Garmin-style labels to the Garmin activity detail charts:

- Metric labels now include chart-colored dots for Elevation, Speed, and Heart Rate.
- Each chart header shows an average value badge using the chart's display units.
- Recharts hover now renders a compact callout with the active x-axis value and metric value instead of hiding tooltip content.
- Addresses review feedback from #197 by calculating chart averages in a single pass and reusing each average label within the badge render.
- Adds a focused unit test for the visible chart label and average behavior.

## Impact

The activity detail charts are easier to scan and more closely match the Garmin Connect reference UI without changing the chart data model or GraphQL contract.

## Validation

- `npm run test:run -- src/components/garmin/ActivityCharts.test.tsx`
- `npm run type-check`
- `npx eslint src/components/garmin/ActivityCharts.tsx src/components/garmin/ActivityCharts.test.tsx`
- `npx prettier --check src/components/garmin/ActivityCharts.tsx src/components/garmin/ActivityCharts.test.tsx`

Note: #197 used a `codex/*` source branch, which violates the repo branch policy. This replacement PR uses `feature/196-garmin-chart-labels`.