### PR TITLE
fix(dashboard): trim empty leading activity years

### DIFF
--- a/src/components/dashboard/GarminActivityTotals.test.tsx
+++ b/src/components/dashboard/GarminActivityTotals.test.tsx
@@ -201,6 +201,14 @@ describe('GarminActivityTotals', () => {
       data: {
         garminActivityTotals: [
           {
+            period_start: `2010-${currentMonth}-01`,
+            activity_count: 1,
+            total_distance_km: 3,
+            total_duration_seconds: 1200,
+            total_ascent_m: 20,
+            total_calories: 100,
+          },
+          {
             period_start: `2024-${currentMonth}-01`,
             activity_count: 2,
             total_distance_km: 10,
@@ -285,6 +293,56 @@ describe('GarminActivityTotals', () => {
           activity_count: 0,
           distance_km: 0,
         }),
+      ]),
+    )
+  })
+
+  it('omits empty years before the earliest returned activity bucket', () => {
+    const selectedMonth = new Date().getMonth()
+    const currentMonth = String(selectedMonth + 1).padStart(2, '0')
+    hooks.useGarminDateRangeQuery.mockReturnValue({
+      data: {
+        garminDateRange: { min_date: '1999-01-01', max_date: '2026-12-31' },
+      },
+      loading: false,
+    })
+    hooks.useGarminActivityTotalsQuery.mockReturnValue({
+      data: {
+        garminActivityTotals: [
+          {
+            period_start: `2010-${currentMonth}-01`,
+            activity_count: 1,
+            total_distance_km: 10,
+            total_duration_seconds: 3600,
+            total_ascent_m: 100,
+            total_calories: 500,
+          },
+          {
+            period_start: `2012-${currentMonth}-01`,
+            activity_count: 1,
+            total_distance_km: 12,
+            total_duration_seconds: 3600,
+            total_ascent_m: 120,
+            total_calories: 600,
+          },
+        ],
+      },
+      loading: false,
+      error: undefined,
+      refetch: vi.fn(),
+    })
+
+    render(<GarminActivityTotals />)
+
+    expect(latestBarChartData[0]).toEqual(
+      expect.objectContaining({ label: '2010', distance_km: 10 }),
+    )
+    expect(latestBarChartData.map(({ label }) => label)).not.toContain('1999')
+    expect(latestBarChartData.map(({ label }) => label)).not.toContain('2009')
+    expect(latestBarChartData).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ label: '2011', distance_km: 0 }),
+        expect.objectContaining({ label: '2012', distance_km: 12 }),
       ]),
     )
   })

--- a/src/components/dashboard/GarminActivityTotals.tsx
+++ b/src/components/dashboard/GarminActivityTotals.tsx
@@ -394,10 +394,34 @@ export function GarminActivityTotals() {
       return []
     }
 
-    // Seed every year in the known Garmin range with a zero bucket so the
-    // chart shows a continuous x-axis even when some years have no activity.
+    const relevantBuckets = mapped.flatMap((bucket) => {
+      const bucketDate = parseISO(bucket.period_start)
+      if (Number.isNaN(bucketDate.getTime())) {
+        return []
+      }
+
+      if (period === 'month' && bucketDate.getMonth() !== selectedMonth) {
+        return []
+      }
+
+      return [{ bucket, year: format(bucketDate, 'yyyy') }]
+    })
+
+    if (relevantBuckets.length === 0) {
+      return []
+    }
+
+    // Date-range metadata can predate the first real activity. Start at the
+    // earliest returned bucket, then zero-fill subsequent years so the chart
+    // remains continuous without rendering empty leading years.
+    const earliestDataYear = Math.min(
+      ...relevantBuckets.map(({ year }) => Number(year)),
+    )
     const byYear = new Map<string, ChartBucket>()
     for (const year of yearList) {
+      if (year < earliestDataYear) {
+        continue
+      }
       const yearStr = String(year)
       const periodStart =
         period === 'month'
@@ -414,17 +438,7 @@ export function GarminActivityTotals() {
       })
     }
 
-    for (const bucket of mapped) {
-      const bucketDate = parseISO(bucket.period_start)
-      if (Number.isNaN(bucketDate.getTime())) {
-        continue
-      }
-
-      if (period === 'month' && bucketDate.getMonth() !== selectedMonth) {
-        continue
-      }
-
-      const year = format(bucketDate, 'yyyy')
+    for (const { bucket, year } of relevantBuckets) {
       const existing = byYear.get(year)
 
       if (!existing) {


### PR DESCRIPTION
## Summary

Refs #200

Start monthly and yearly Activity Totals chart data at the earliest returned activity bucket instead of blindly zero-filling from potentially broader date-range metadata. Interior missing years remain zero-filled, and weekly behavior is unchanged.

Adds regression coverage where date-range metadata begins in 1999 but activity totals begin in 2010.

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New page / component
- [ ] UI enhancement (non-breaking)
- [ ] GraphQL query / mutation change
- [ ] CI/CD pipeline change
- [ ] Documentation update

## Checklist

- [x] Read `README.md` and relevant docs
- [x] No secrets or credentials committed
- [x] Environment variables use `VITE_` prefix (no environment changes)
- [x] Ran `npm run lint:all` locally (hooks passing)
- [x] Ran `npm run test:run` (198 tests passing)
- [x] Ran `npm run type-check` (no type errors)

## Deployment

- [ ] Does this need k8s-gitops manifest changes?

No manifest changes are required; the normal UI image build and deployment flow applies.

## Testing

```bash
npm run lint:all
npm run test:run
npm run test:coverage
npm run type-check
npm run build
```

Coverage: 83.63% statements, 73.3% branches, 82.59% functions, 85.7% lines.

## Post-Merge Validation

- [ ] Docker image built and pushed (CI)
- [ ] k8s-gitops deployment PR created and merged
- [ ] Argo CD synced to cluster
- [ ] Acceptance criteria validated against deployed behavior
- [ ] Final validation comment posted on the linked issue
- [ ] Issue closed manually after all criteria confirmed

## Notes

`npm run lint:all` passes with one pre-existing warning in `scripts/dedupe-generated-types.cjs`; this PR does not modify that file.