### PR TITLE
[codex] Align Garmin heart rate axis and smooth crosshair

### DIFF
--- a/src/components/garmin/ActivityChartYAxis.ts
+++ b/src/components/garmin/ActivityChartYAxis.ts
@@ -1,7 +1,7 @@
 type ActivityChartMetric = 'elevation' | 'speed' | 'heartRate'
 
 interface ActivityYAxisConfig {
-  domain?: [number, number]
+  domain?: [(dataMinimum: number) => number, (dataMaximum: number) => number]
   ticks?: number[]
 }
 
@@ -10,7 +10,10 @@ export function getActivityYAxisConfig(
 ): ActivityYAxisConfig {
   if (dataKey === 'heartRate') {
     return {
-      domain: [100, 200],
+      domain: [
+        (dataMinimum) => Math.min(dataMinimum, 100),
+        (dataMaximum) => Math.max(dataMaximum, 200),
+      ],
       ticks: [100, 150, 200],
     }
   }

--- a/src/components/garmin/ActivityChartYAxis.ts
+++ b/src/components/garmin/ActivityChartYAxis.ts
@@ -1,0 +1,19 @@
+type ActivityChartMetric = 'elevation' | 'speed' | 'heartRate'
+
+interface ActivityYAxisConfig {
+  domain?: [number, number]
+  ticks?: number[]
+}
+
+export function getActivityYAxisConfig(
+  dataKey: ActivityChartMetric,
+): ActivityYAxisConfig {
+  if (dataKey === 'heartRate') {
+    return {
+      domain: [100, 200],
+      ticks: [100, 150, 200],
+    }
+  }
+
+  return {}
+}

--- a/src/components/garmin/ActivityCharts.test.tsx
+++ b/src/components/garmin/ActivityCharts.test.tsx
@@ -1,12 +1,22 @@
 import { render, screen } from '@testing-library/react'
 import { describe, expect, it } from 'vitest'
 import { ActivityCharts } from './ActivityCharts'
+import { getActivityYAxisConfig } from './ActivityChartYAxis'
 import {
   coerceTooltipMetricValue,
   formatXAxisValue,
 } from './ActivityChartTooltip'
 
 describe('ActivityCharts', () => {
+  it('uses Garmin-style Y-axis ticks only for heart rate', () => {
+    expect(getActivityYAxisConfig('heartRate')).toEqual({
+      domain: [100, 200],
+      ticks: [100, 150, 200],
+    })
+    expect(getActivityYAxisConfig('elevation')).toEqual({})
+    expect(getActivityYAxisConfig('speed')).toEqual({})
+  })
+
   it('renders a heart-rate chart when heart-rate data is present', () => {
     render(
       <ActivityCharts

--- a/src/components/garmin/ActivityCharts.test.tsx
+++ b/src/components/garmin/ActivityCharts.test.tsx
@@ -9,10 +9,14 @@ import {
 
 describe('ActivityCharts', () => {
   it('uses Garmin-style Y-axis ticks only for heart rate', () => {
-    expect(getActivityYAxisConfig('heartRate')).toEqual({
-      domain: [100, 200],
-      ticks: [100, 150, 200],
-    })
+    const heartRateAxis = getActivityYAxisConfig('heartRate')
+    const [minimumDomain, maximumDomain] = heartRateAxis.domain ?? []
+
+    expect(heartRateAxis.ticks).toEqual([100, 150, 200])
+    expect(minimumDomain?.(120)).toBe(100)
+    expect(minimumDomain?.(80)).toBe(80)
+    expect(maximumDomain?.(180)).toBe(200)
+    expect(maximumDomain?.(220)).toBe(220)
     expect(getActivityYAxisConfig('elevation')).toEqual({})
     expect(getActivityYAxisConfig('speed')).toEqual({})
   })

--- a/src/components/garmin/ActivityCharts.tsx
+++ b/src/components/garmin/ActivityCharts.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import {
   AreaChart,
   Area,
@@ -24,6 +24,7 @@ import {
   formatXAxisValue,
   type XAxisMode,
 } from './ActivityChartTooltip'
+import { getActivityYAxisConfig } from './ActivityChartYAxis'
 
 interface ActivityChartsProps {
   trackPoints: ActivityChartTrackPoint[]
@@ -138,10 +139,42 @@ export function ActivityCharts({
   onPointToggle,
 }: ActivityChartsProps) {
   const [xMode, setXMode] = useState<XAxisMode>('distance')
+  const { chartData, hasReliableDistance } = useMemo(
+    () => buildActivityChartData(trackPoints),
+    [trackPoints],
+  )
+  const pendingActivePointRef = useRef<ChartDataPoint | null>(null)
+  const lastActivePointRef = useRef<ChartDataPoint | null>(null)
+  const activePointFrameRef = useRef<number | null>(null)
+
+  const queueActivePointChange = useCallback(
+    (point: ChartDataPoint | null) => {
+      pendingActivePointRef.current = point
+      if (activePointFrameRef.current != null) return
+
+      activePointFrameRef.current = window.requestAnimationFrame(() => {
+        activePointFrameRef.current = null
+        const nextPoint = pendingActivePointRef.current
+        if (lastActivePointRef.current?.timestamp === nextPoint?.timestamp) {
+          return
+        }
+        lastActivePointRef.current = nextPoint
+        onActivePointChange?.(nextPoint)
+      })
+    },
+    [onActivePointChange],
+  )
+
+  useEffect(
+    () => () => {
+      if (activePointFrameRef.current != null) {
+        window.cancelAnimationFrame(activePointFrameRef.current)
+      }
+    },
+    [],
+  )
 
   if (trackPoints.length === 0) return null
-
-  const { chartData, hasReliableDistance } = buildActivityChartData(trackPoints)
 
   // Fall back to time if distance data is too sparse
   const effectiveXMode =
@@ -203,6 +236,7 @@ export function ActivityCharts({
   const activeCharts = charts.filter((c) => c.hasData)
   const activeChartLabels = activeCharts.map((chart) => ({
     chart,
+    yAxisConfig: getActivityYAxisConfig(chart.dataKey),
     averageLabel: formatMetricValue(
       averageMetricValue(chartData, chart.dataKey),
       chart,
@@ -240,7 +274,7 @@ export function ActivityCharts({
         </Button>
       </div>
 
-      {activeChartLabels.map(({ chart, averageLabel }) => (
+      {activeChartLabels.map(({ chart, yAxisConfig, averageLabel }) => (
         <Card key={chart.dataKey} data-testid={`chart-${chart.dataKey}`}>
           <CardHeader className="pb-2">
             <div className="flex items-center justify-between gap-3">
@@ -270,7 +304,7 @@ export function ActivityCharts({
                   activeTooltipIndex?: number | string | null
                 }) => {
                   const point = pointFromTooltipState(state, chartData)
-                  if (point) onActivePointChange?.(point)
+                  if (point) queueActivePointChange(point)
                 }}
                 onDoubleClick={(state: {
                   activeTooltipIndex?: number | string | null
@@ -278,7 +312,7 @@ export function ActivityCharts({
                   const point = pointFromTooltipState(state, chartData)
                   if (point) onPointToggle?.(point)
                 }}
-                onMouseLeave={() => onActivePointChange?.(null)}
+                onMouseLeave={() => queueActivePointChange(null)}
               >
                 <CartesianGrid strokeDasharray="3 3" className="stroke-muted" />
                 {savedSegments.map((seg) => (
@@ -308,6 +342,7 @@ export function ActivityCharts({
                   className="text-xs"
                 />
                 <YAxis
+                  {...yAxisConfig}
                   tickFormatter={(v: number) => (v != null ? v.toFixed(0) : '')}
                   className="text-xs"
                   width={50}

--- a/src/components/garmin/ActivityCharts.tsx
+++ b/src/components/garmin/ActivityCharts.tsx
@@ -149,17 +149,22 @@ export function ActivityCharts({
 
   const queueActivePointChange = useCallback(
     (point: ChartDataPoint | null) => {
+      if (!onActivePointChange) return
+
       pendingActivePointRef.current = point
       if (activePointFrameRef.current != null) return
 
       activePointFrameRef.current = window.requestAnimationFrame(() => {
         activePointFrameRef.current = null
         const nextPoint = pendingActivePointRef.current
-        if (lastActivePointRef.current?.timestamp === nextPoint?.timestamp) {
+        if (
+          nextPoint !== null &&
+          lastActivePointRef.current?.timestamp === nextPoint.timestamp
+        ) {
           return
         }
         lastActivePointRef.current = nextPoint
-        onActivePointChange?.(nextPoint)
+        onActivePointChange(nextPoint)
       })
     },
     [onActivePointChange],


### PR DESCRIPTION
## Summary

Refs #202

Align the Garmin Activity Detail heart-rate chart with Garmin Connect by using
100, 150, and 200 bpm Y-axis reference ticks. Elevation and Speed retain their
existing automatic Y-axis behavior.

The crosshair path also now memoizes transformed chart data and coalesces
active-point updates to one per animation frame. This reduces parent/chart
rerender pressure while preserving the original compact idle-details card.

## Root Cause

The heart-rate chart relied on Recharts' default Y-axis calculation, which
started the area at zero and compressed the meaningful heart-rate variation.
Crosshair movement also rebuilt chart data and propagated raw pointer-event
updates without frame-level throttling.

## Type of Change

- [x] UI enhancement (non-breaking)
- [x] Performance improvement
- [ ] GraphQL query / mutation change
- [ ] Infrastructure / deployment change

## Validation

- `npm run lint:all` — PASS (one pre-existing unrelated script warning)
- `npm run test:run` — PASS, 199/199 tests
- `npm run test:coverage` — PASS, 83.66% statement coverage
- `npm run type-check` — PASS
- `npm run build` — PASS

## Deployment

No k8s-gitops manifest changes are required. The normal UI image build and
deployment flow applies.

## Post-Merge Validation

- [ ] Docker image built and pushed
- [ ] Deployment synced through Argo CD
- [ ] Heart Rate ticks verified in production
- [ ] Crosshair behavior verified in production
- [ ] Final acceptance evidence posted to issue #202

The issue must remain open until deployed behavior is validated.
