### PR TITLE
[codex] Add Garmin respiration rate chart

### DIFF
--- a/e2e/garmin-charts.spec.ts
+++ b/e2e/garmin-charts.spec.ts
@@ -8,13 +8,14 @@ fs.mkdirSync(SCREENSHOT_DIR, { recursive: true })
 
 /**
  * Validates that the Garmin activity detail page renders
- * Elevation and Speed charts using Recharts.
+ * Elevation, Speed, Heart Rate, and Respiration Rate charts using Recharts.
  *
  * By default uses activity 9965963574 which has ~2 425 track points
  * with altitude / speed data from a Garmin FIT file.
  *
- * The activity ID can be overridden per-environment via the
- * PLAYWRIGHT_GARMIN_ACTIVITY_ID environment variable.
+ * The activity IDs can be overridden per-environment via the
+ * PLAYWRIGHT_GARMIN_ACTIVITY_ID and
+ * PLAYWRIGHT_GARMIN_RESPIRATION_ACTIVITY_ID environment variables.
  */
 const ACTIVITY_ID = process.env.PLAYWRIGHT_GARMIN_ACTIVITY_ID ?? '9965963574'
 const RESPIRATION_ACTIVITY_ID =
@@ -26,12 +27,11 @@ test.describe('Garmin Activity Charts', () => {
   }) => {
     await page.goto(`/garmin/${RESPIRATION_ACTIVITY_ID}`)
 
-    await expect(page.getByText(/Chart data failed:/i)).toHaveCount(0)
-
     const heartRateCard = page.getByTestId('chart-heartRate')
     const respirationCard = page.getByTestId('chart-respirationRate')
     await expect(heartRateCard).toBeVisible({ timeout: 20_000 })
     await expect(respirationCard).toBeVisible({ timeout: 20_000 })
+    await expect(page.getByText(/Chart data failed:/i)).toHaveCount(0)
     await expect(
       respirationCard.getByLabel(/Respiration Rate average \d+ brpm/i),
     ).toBeVisible()

--- a/e2e/garmin-charts.spec.ts
+++ b/e2e/garmin-charts.spec.ts
@@ -17,8 +17,34 @@ fs.mkdirSync(SCREENSHOT_DIR, { recursive: true })
  * PLAYWRIGHT_GARMIN_ACTIVITY_ID environment variable.
  */
 const ACTIVITY_ID = process.env.PLAYWRIGHT_GARMIN_ACTIVITY_ID ?? '9965963574'
+const RESPIRATION_ACTIVITY_ID =
+  process.env.PLAYWRIGHT_GARMIN_RESPIRATION_ACTIVITY_ID ?? '23300698725'
 
 test.describe('Garmin Activity Charts', () => {
+  test('renders respiration data without a chart query error', async ({
+    page,
+  }) => {
+    await page.goto(`/garmin/${RESPIRATION_ACTIVITY_ID}`)
+
+    await expect(page.getByText(/Chart data failed:/i)).toHaveCount(0)
+
+    const heartRateCard = page.getByTestId('chart-heartRate')
+    const respirationCard = page.getByTestId('chart-respirationRate')
+    await expect(heartRateCard).toBeVisible({ timeout: 20_000 })
+    await expect(respirationCard).toBeVisible({ timeout: 20_000 })
+    await expect(
+      respirationCard.getByLabel(/Respiration Rate average \d+ brpm/i),
+    ).toBeVisible()
+    await expect(respirationCard.locator('svg path').first()).toBeVisible()
+
+    const chartOrder = await page
+      .locator('[data-testid^="chart-"]')
+      .evaluateAll((charts) => charts.map((chart) => chart.dataset.testid))
+    expect(chartOrder.indexOf('chart-respirationRate')).toBeGreaterThan(
+      chartOrder.indexOf('chart-heartRate'),
+    )
+  })
+
   test('page loads and activity header is visible', async ({ page }) => {
     await page.goto(`/garmin/${ACTIVITY_ID}`)
     // The activity stats bar should always render

--- a/src/__generated__/graphql.ts
+++ b/src/__generated__/graphql.ts
@@ -968,7 +968,7 @@ export type GarminChartDataQueryVariables = Exact<{
 }>;
 
 
-export type GarminChartDataQuery = { garminChartData: Array<{ timestamp: string, altitude: number | null, distance_from_start_km: number | null, speed_kmh: number | null, heart_rate: number | null, cadence: number | null, temperature_c: number | null, latitude: number, longitude: number }> };
+export type GarminChartDataQuery = { garminChartData: Array<{ timestamp: string, altitude: number | null, distance_from_start_km: number | null, speed_kmh: number | null, heart_rate: number | null, respiration_rate: number | null, cadence: number | null, temperature_c: number | null, latitude: number, longitude: number }> };
 
 export type TriggerGarminSyncMutationVariables = Exact<{
   window_hours?: number | null | undefined;
@@ -1507,6 +1507,7 @@ export const GarminChartDataDocument = gql`
     distance_from_start_km
     speed_kmh
     heart_rate
+    respiration_rate
     cadence
     temperature_c
     latitude

--- a/src/components/garmin/ActivityChartData.test.ts
+++ b/src/components/garmin/ActivityChartData.test.ts
@@ -15,6 +15,7 @@ function point(
     distance_from_start_km: index,
     altitude: 100,
     speed_kmh: 16.0934,
+    respiration_rate: 27,
     latitude: 40 + index / 1000,
     longitude: -74 - index / 1000,
     ...overrides,
@@ -34,6 +35,7 @@ describe('ActivityChartData', () => {
     expect(chartPoint.time).toBeCloseTo(5 / 60)
     expect(chartPoint.elevation).toBeCloseTo(328.084)
     expect(chartPoint.speed).toBeCloseTo(10)
+    expect(chartPoint.respirationRate).toBe(27)
     expect(chartPoint.latitude).toBe(40.005)
     expect(chartPoint.longitude).toBe(-74.005)
   })

--- a/src/components/garmin/ActivityChartData.ts
+++ b/src/components/garmin/ActivityChartData.ts
@@ -6,6 +6,7 @@ export interface ActivityChartTrackPoint {
   altitude?: number | null
   speed_kmh?: number | null
   heart_rate?: number | null
+  respiration_rate?: number | null
   latitude?: number | null
   longitude?: number | null
 }
@@ -17,6 +18,7 @@ export interface ChartDataPoint {
   elevation: number | null
   speed: number | null
   heartRate: number | null
+  respirationRate: number | null
   latitude: number | null
   longitude: number | null
   timestamp: string
@@ -83,6 +85,7 @@ export function toChartDataPoint(
     elevation: pt.altitude != null ? metersToFeet(pt.altitude) : null,
     speed: pt.speed_kmh != null ? kmhToMph(pt.speed_kmh) : null,
     heartRate: pt.heart_rate ?? null,
+    respirationRate: pt.respiration_rate ?? null,
     latitude: pt.latitude ?? null,
     longitude: pt.longitude ?? null,
     timestamp: pt.timestamp,

--- a/src/components/garmin/ActivityChartYAxis.ts
+++ b/src/components/garmin/ActivityChartYAxis.ts
@@ -1,4 +1,8 @@
-type ActivityChartMetric = 'elevation' | 'speed' | 'heartRate'
+type ActivityChartMetric =
+  | 'elevation'
+  | 'speed'
+  | 'heartRate'
+  | 'respirationRate'
 
 interface ActivityYAxisConfig {
   domain?: [(dataMinimum: number) => number, (dataMaximum: number) => number]
@@ -15,6 +19,16 @@ export function getActivityYAxisConfig(
         (dataMaximum) => Math.max(dataMaximum, 200),
       ],
       ticks: [100, 150, 200],
+    }
+  }
+
+  if (dataKey === 'respirationRate') {
+    return {
+      domain: [
+        (dataMinimum) => Math.min(dataMinimum, 16),
+        (dataMaximum) => Math.max(dataMaximum, 40),
+      ],
+      ticks: [16, 24, 32, 40],
     }
   }
 

--- a/src/components/garmin/ActivityCharts.test.tsx
+++ b/src/components/garmin/ActivityCharts.test.tsx
@@ -8,7 +8,7 @@ import {
 } from './ActivityChartTooltip'
 
 describe('ActivityCharts', () => {
-  it('uses Garmin-style Y-axis ticks only for heart rate', () => {
+  it('uses Garmin-style Y-axis ticks for heart rate and respiration', () => {
     const heartRateAxis = getActivityYAxisConfig('heartRate')
     const [minimumDomain, maximumDomain] = heartRateAxis.domain ?? []
 

--- a/src/components/garmin/ActivityCharts.test.tsx
+++ b/src/components/garmin/ActivityCharts.test.tsx
@@ -17,6 +17,15 @@ describe('ActivityCharts', () => {
     expect(minimumDomain?.(80)).toBe(80)
     expect(maximumDomain?.(180)).toBe(200)
     expect(maximumDomain?.(220)).toBe(220)
+
+    const respirationAxis = getActivityYAxisConfig('respirationRate')
+    const [minimumRespiration, maximumRespiration] =
+      respirationAxis.domain ?? []
+    expect(respirationAxis.ticks).toEqual([16, 24, 32, 40])
+    expect(minimumRespiration?.(24)).toBe(16)
+    expect(minimumRespiration?.(12)).toBe(12)
+    expect(maximumRespiration?.(32)).toBe(40)
+    expect(maximumRespiration?.(44)).toBe(44)
     expect(getActivityYAxisConfig('elevation')).toEqual({})
     expect(getActivityYAxisConfig('speed')).toEqual({})
   })
@@ -51,6 +60,46 @@ describe('ActivityCharts', () => {
     expect(screen.getByText('Heart Rate')).toBeInTheDocument()
   })
 
+  it('renders respiration below heart rate only when samples exist', () => {
+    const points = [
+      {
+        timestamp: '2026-03-14T09:00:00Z',
+        distance_from_start_km: 0,
+        heart_rate: 118,
+        respiration_rate: 24,
+      },
+      {
+        timestamp: '2026-03-14T09:10:00Z',
+        distance_from_start_km: 5,
+        heart_rate: 152,
+        respiration_rate: 30,
+      },
+    ]
+    const { rerender } = render(<ActivityCharts trackPoints={points} />)
+
+    const heartRateChart = screen.getByTestId('chart-heartRate')
+    const respirationChart = screen.getByTestId('chart-respirationRate')
+    expect(heartRateChart.compareDocumentPosition(respirationChart)).toBe(
+      Node.DOCUMENT_POSITION_FOLLOWING,
+    )
+    expect(screen.getByText('Respiration Rate')).toBeInTheDocument()
+    expect(
+      screen.getByLabelText('Respiration Rate average 27 brpm'),
+    ).toBeInTheDocument()
+
+    rerender(
+      <ActivityCharts
+        trackPoints={points.map((point) => ({
+          ...point,
+          respiration_rate: null,
+        }))}
+      />,
+    )
+    expect(
+      screen.queryByTestId('chart-respirationRate'),
+    ).not.toBeInTheDocument()
+  })
+
   it('renders Garmin-style labels and average values for each chart', () => {
     render(
       <ActivityCharts
@@ -61,6 +110,7 @@ describe('ActivityCharts', () => {
             altitude: 10,
             speed_kmh: 22,
             heart_rate: 118,
+            respiration_rate: 24,
             latitude: 40.7,
             longitude: -74,
           },
@@ -70,6 +120,7 @@ describe('ActivityCharts', () => {
             altitude: 30,
             speed_kmh: 28,
             heart_rate: 152,
+            respiration_rate: 30,
             latitude: 40.71,
             longitude: -74.01,
           },
@@ -81,6 +132,9 @@ describe('ActivityCharts', () => {
     expect(screen.getByLabelText('Speed average 15.5 mph')).toBeInTheDocument()
     expect(
       screen.getByLabelText('Heart Rate average 135 bpm'),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByLabelText('Respiration Rate average 27 brpm'),
     ).toBeInTheDocument()
   })
 

--- a/src/components/garmin/ActivityCharts.tsx
+++ b/src/components/garmin/ActivityCharts.tsx
@@ -48,7 +48,7 @@ interface ActivityChartsProps {
   onPointToggle?: (point: ChartDataPoint) => void
 }
 
-type MetricKey = 'elevation' | 'speed' | 'heartRate'
+type MetricKey = 'elevation' | 'speed' | 'heartRate' | 'respirationRate'
 
 interface ChartConfig {
   title: string
@@ -194,6 +194,7 @@ export function ActivityCharts({
   const hasElevation = chartData.some((d) => d.elevation != null)
   const hasSpeed = chartData.some((d) => d.speed != null)
   const hasHeartRate = chartData.some((d) => d.heartRate != null)
+  const hasRespirationRate = chartData.some((d) => d.respirationRate != null)
 
   // Shaded regions between consecutive saved points (ordered along the x-axis).
   const savedPointsByX = savedPoints
@@ -234,6 +235,14 @@ export function ActivityCharts({
       color: '#ef4444',
       unit: 'bpm',
       hasData: hasHeartRate,
+      precision: 0,
+    },
+    {
+      title: 'Respiration Rate',
+      dataKey: 'respirationRate',
+      color: '#3fc1d3',
+      unit: 'brpm',
+      hasData: hasRespirationRate,
       precision: 0,
     },
   ]

--- a/src/components/garmin/ActivityHoverDetails.test.tsx
+++ b/src/components/garmin/ActivityHoverDetails.test.tsx
@@ -19,6 +19,7 @@ function chartPoint(overrides: Partial<ChartDataPoint> = {}): ChartDataPoint {
     elevation: 120.4,
     speed: 9.8,
     heartRate: 142,
+    respirationRate: 27,
     latitude: 40.71234,
     longitude: -74.00567,
     ...overrides,
@@ -55,6 +56,7 @@ describe('ActivityHoverDetails', () => {
 
     expect(screen.getByText('120.4 ft')).toBeInTheDocument()
     expect(screen.getByText('9.8 mph')).toBeInTheDocument()
+    expect(screen.getByText('27 brpm')).toBeInTheDocument()
     expect(screen.getByText('3.14 mi (5.05 km)')).toBeInTheDocument()
     expect(screen.getByText('40.71234, -74.00567')).toBeInTheDocument()
     expect(screen.getByText('Resolving…')).toBeInTheDocument()
@@ -85,13 +87,14 @@ describe('ActivityHoverDetails', () => {
           elevation: null,
           speed: null,
           heartRate: null,
+          respirationRate: null,
           distance: null,
           distanceKm: null,
         })}
       />,
     )
 
-    expect(screen.getAllByText('—')).toHaveLength(4)
+    expect(screen.getAllByText('—')).toHaveLength(5)
     expect(await screen.findByText('No address found')).toBeInTheDocument()
 
     geocoderMocks.reverseGeocode.mockRejectedValueOnce(new Error('offline'))

--- a/src/components/garmin/ActivityHoverDetails.tsx
+++ b/src/components/garmin/ActivityHoverDetails.tsx
@@ -151,6 +151,14 @@ export function ActivityHoverDetails({
             value={point.heartRate != null ? `${point.heartRate} bpm` : '—'}
           />
           <Field
+            label="Respiration Rate"
+            value={
+              point.respirationRate != null
+                ? `${point.respirationRate} brpm`
+                : '—'
+            }
+          />
+          <Field
             label="Time"
             value={`${timeStr} (${point.time.toFixed(1)} min)`}
           />

--- a/src/components/garmin/SegmentAnalysis.test.tsx
+++ b/src/components/garmin/SegmentAnalysis.test.tsx
@@ -14,6 +14,7 @@ function savedPoint(overrides: Partial<SavedPoint> = {}): SavedPoint {
     elevation: null,
     speed: null,
     heartRate: null,
+    respirationRate: null,
     latitude: null,
     longitude: null,
     ...overrides,

--- a/src/components/garmin/segmentAnalysis.test.ts
+++ b/src/components/garmin/segmentAnalysis.test.ts
@@ -13,6 +13,7 @@ function savedPoint(overrides: Partial<SavedPoint> = {}): SavedPoint {
     elevation: null,
     speed: null,
     heartRate: null,
+    respirationRate: null,
     latitude: null,
     longitude: null,
     ...overrides,

--- a/src/graphql/garmin.ts
+++ b/src/graphql/garmin.ts
@@ -185,6 +185,7 @@ export const GARMIN_CHART_DATA_QUERY = gql`
       distance_from_start_km
       speed_kmh
       heart_rate
+      respiration_rate
       cadence
       temperature_c
       latitude


### PR DESCRIPTION
## Summary

Refs #204

Add a cyan Respiration Rate chart below Heart Rate for Garmin activities with
per-track-point sensor data. The chart uses Garmin-style 16/24/32/40 brpm
reference ticks, expands for outliers, participates in the shared crosshair and
saved-point behavior, and is omitted when no respiration samples exist.

The chart query, generated operation types, transformed chart model, hover
details, unit tests, and Playwright coverage are updated together.

## Dependency

Depends on gateway PR stuartshay/otel-data-gateway#127. That PR must be merged
and deployed first; otherwise the deployed gateway rejects the
`respiration_rate` field and the activity chart query fails.

## Root Cause of the Reported Error

The initial UI implementation selected `respiration_rate` from
`GarminChartPoint`, but production GraphQL did not expose that field. Gateway
PR #127 adds the missing schema field and generated package types.

## Validation

- `npm run lint:all` — PASS (one pre-existing unrelated script warning)
- `npm run test:run` — PASS, 200/200 tests
- `npm run type-check` — PASS
- `npm run build` — PASS
- Playwright Chromium against local UI + fixed local gateway — PASS
  - Real activity: `23300698725`
  - No `Chart data failed` error
  - Heart Rate and Respiration Rate visible in order
  - Respiration average badge uses `brpm`
  - Respiration SVG graph is rendered

## Deployment

No direct k8s manifest changes are required. Deploy gateway PR #127 first,
then deploy this UI image through the normal GitOps flow.

## Post-Merge Validation

- [ ] Gateway PR #127 deployed and production schema verified
- [ ] UI image built and deployed
- [ ] Respiration chart verified on activity `23300698725`
- [ ] Final acceptance evidence posted on issue #204

The issue remains open until deployed acceptance validation is complete.
