### PR TITLE
[codex] Hold GraphQL at v16 in Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -14,6 +14,11 @@
       "enabled": false
     },
     {
+      "description": "Hold GraphQL at v16 until dependent tooling supports v17",
+      "matchPackageNames": ["graphql"],
+      "allowedVersions": "<17"
+    },
+    {
       "description": "Auto-merge patch updates for npm dependencies",
       "matchManagers": ["npm"],
       "matchUpdateTypes": ["patch"],


### PR DESCRIPTION
## Summary

- constrain Renovate-managed `graphql` updates to versions below 17
- continue allowing compatible GraphQL 16 patch releases
- prevent repeated invalid GraphQL 17 PR rebases and failing CI runs

## Root cause

GraphQL 17 is published, but the current GraphQL Codegen packages and `graphql-ws` declare peer support only through GraphQL 16. Renovate cannot produce a valid lockfile for PR #194, and each rebase retriggers CI that fails during `npm ci`.

## Validation

- `RENOVATE_CONFIG_FILE=renovate.json npx --yes --package renovate renovate-config-validator --strict`
- `npm run lint:all`
- `npm run type-check`
- `npm run build`
- `npm run test:run` — 200 tests passed
- `npm audit --audit-level=moderate` — reports three existing moderate `js-yaml`/`markdown-it` advisories; the offered fix is a breaking downgrade

## Dependency scope

No package versions or generated files are changed. Other outdated dependencies remain managed by their existing Renovate groups. This configuration supersedes the incompatible update proposed by #194 after Renovate reevaluates it.

Refs #206
Refs #194