### PR TITLE
[codex] Add collapsible Garmin activity graphs

### DIFF
--- a/src/components/garmin/ActivityCharts.test.tsx
+++ b/src/components/garmin/ActivityCharts.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { describe, expect, it } from 'vitest'
 import { ActivityCharts } from './ActivityCharts'
 import { getActivityYAxisConfig } from './ActivityChartYAxis'
@@ -136,6 +137,61 @@ describe('ActivityCharts', () => {
     expect(
       screen.getByLabelText('Respiration Rate average 27 brpm'),
     ).toBeInTheDocument()
+  })
+
+  it('minimizes and restores each chart independently while keeping its header', async () => {
+    const user = userEvent.setup()
+    render(
+      <ActivityCharts
+        trackPoints={[
+          {
+            timestamp: '2026-03-14T09:00:00Z',
+            distance_from_start_km: 0,
+            altitude: 10,
+            speed_kmh: 22,
+            heart_rate: 118,
+            respiration_rate: 24,
+          },
+          {
+            timestamp: '2026-03-14T09:10:00Z',
+            distance_from_start_km: 5,
+            altitude: 30,
+            speed_kmh: 28,
+            heart_rate: 152,
+            respiration_rate: 30,
+          },
+        ]}
+      />,
+    )
+
+    const minimizeElevation = screen.getByRole('button', {
+      name: 'Minimize Elevation graph',
+    })
+    expect(
+      screen.getAllByRole('button', { name: /^Minimize .* graph$/ }),
+    ).toHaveLength(4)
+    expect(minimizeElevation).toHaveAttribute('aria-expanded', 'true')
+    expect(document.getElementById('chart-content-elevation')).toBeVisible()
+    expect(document.getElementById('chart-content-speed')).toBeInTheDocument()
+
+    await user.click(minimizeElevation)
+
+    expect(
+      screen.getByRole('button', { name: 'Expand Elevation graph' }),
+    ).toHaveAttribute('aria-expanded', 'false')
+    expect(document.getElementById('chart-content-elevation')).not.toBeVisible()
+    expect(document.getElementById('chart-content-speed')).toBeVisible()
+    expect(screen.getByText('Elevation')).toBeInTheDocument()
+    expect(screen.getByLabelText('Elevation average 66 ft')).toBeInTheDocument()
+
+    await user.click(
+      screen.getByRole('button', { name: 'Expand Elevation graph' }),
+    )
+
+    expect(
+      screen.getByRole('button', { name: 'Minimize Elevation graph' }),
+    ).toHaveAttribute('aria-expanded', 'true')
+    expect(document.getElementById('chart-content-elevation')).toBeVisible()
   })
 
   it('ignores nullish and empty x-axis tooltip labels', () => {

--- a/src/components/garmin/ActivityCharts.tsx
+++ b/src/components/garmin/ActivityCharts.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { ChevronDown, ChevronUp } from 'lucide-react'
 import {
   AreaChart,
   Area,
@@ -139,6 +140,9 @@ export function ActivityCharts({
   onPointToggle,
 }: ActivityChartsProps) {
   const [xMode, setXMode] = useState<XAxisMode>('distance')
+  const [collapsedCharts, setCollapsedCharts] = useState<Set<MetricKey>>(
+    () => new Set(),
+  )
   const { chartData, hasReliableDistance } = useMemo(
     () => buildActivityChartData(trackPoints),
     [trackPoints],
@@ -259,6 +263,15 @@ export function ActivityCharts({
 
   if (activeCharts.length === 0) return null
 
+  const toggleChart = (dataKey: MetricKey) => {
+    setCollapsedCharts((current) => {
+      const next = new Set(current)
+      if (next.has(dataKey)) next.delete(dataKey)
+      else next.add(dataKey)
+      return next
+    })
+  }
+
   return (
     <div className="space-y-4">
       {/* Toggle buttons */}
@@ -290,7 +303,9 @@ export function ActivityCharts({
 
       {activeChartLabels.map(({ chart, yAxisConfig, averageLabel }) => (
         <Card key={chart.dataKey} data-testid={`chart-${chart.dataKey}`}>
-          <CardHeader className="pb-2">
+          <CardHeader
+            className={collapsedCharts.has(chart.dataKey) ? 'pb-6' : 'pb-2'}
+          >
             <div className="flex items-center justify-between gap-3">
               <CardTitle className="flex items-center gap-2 text-base font-medium">
                 <span
@@ -300,15 +315,37 @@ export function ActivityCharts({
                 />
                 {chart.title}
               </CardTitle>
-              <div
-                aria-label={`${chart.title} average ${averageLabel}`}
-                className="rounded bg-neutral-950/70 px-2 py-1 text-xs text-white"
-              >
-                Avg: {averageLabel}
+              <div className="flex items-center gap-2">
+                <div
+                  aria-label={`${chart.title} average ${averageLabel}`}
+                  className="rounded bg-neutral-950/70 px-2 py-1 text-xs text-white"
+                >
+                  Avg: {averageLabel}
+                </div>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon"
+                  className="size-8"
+                  aria-label={`${collapsedCharts.has(chart.dataKey) ? 'Expand' : 'Minimize'} ${chart.title} graph`}
+                  title={`${collapsedCharts.has(chart.dataKey) ? 'Expand' : 'Minimize'} ${chart.title} graph`}
+                  aria-controls={`chart-content-${chart.dataKey}`}
+                  aria-expanded={!collapsedCharts.has(chart.dataKey)}
+                  onClick={() => toggleChart(chart.dataKey)}
+                >
+                  {collapsedCharts.has(chart.dataKey) ? (
+                    <ChevronDown aria-hidden="true" />
+                  ) : (
+                    <ChevronUp aria-hidden="true" />
+                  )}
+                </Button>
               </div>
             </div>
           </CardHeader>
-          <CardContent>
+          <CardContent
+            id={`chart-content-${chart.dataKey}`}
+            hidden={collapsedCharts.has(chart.dataKey)}
+          >
             <ResponsiveContainer width="100%" height={200}>
               <AreaChart
                 data={chartData}


### PR DESCRIPTION
## Summary

Refs #208

Adds an independent minimize/restore control to every rendered Garmin Activity graph. Collapsed cards keep the metric header and average visible while removing the chart body from the page layout, allowing lower graphs to align with the map. Controls include accessible labels, `aria-expanded`, and `aria-controls`.

## Type of Change

- [x] UI enhancement (non-breaking)

## Checklist

- [x] Read `README.md` and relevant docs
- [x] No secrets or credentials committed
- [x] Environment variables use `VITE_` prefix
- [x] Ran `npm run lint:all` locally (hooks passing)
- [x] Ran `npm run test:run` (201 tests passing)
- [x] Ran `npm run type-check` (no type errors)
- [x] Ran `npm run build`

## Deployment

- [ ] Does this need k8s-gitops manifest changes? No manifest change is expected; the normal UI image update workflow applies.

## Testing

```bash
npm run test:run
npm run lint:all
npm run type-check
npm run build
```

Component coverage verifies all four graph controls render, one graph can collapse independently while its header remains visible, and it can be restored.

## Post-Merge Validation

- [ ] Docker image built and pushed (CI)
- [ ] k8s-gitops deployment PR created and merged
- [ ] Argo CD synced to cluster
- [ ] Acceptance criteria validated against deployed behavior
- [ ] Final validation comment posted on issue #208
- [ ] Issue closed manually after validation

## Notes

`npm run lint:all` passes with one pre-existing warning in `scripts/dedupe-generated-types.cjs` about an unused ESLint disable directive.