### PR TITLE
[codex] Add heart-rate zone ribbon to Garmin chart

### DIFF
--- a/src/__generated__/graphql.ts
+++ b/src/__generated__/graphql.ts
@@ -259,8 +259,6 @@ export type GarminChartPoint = {
   cadence?: Maybe<Scalars['Int']['output']>;
   /** Cumulative distance from activity start in km */
   distance_from_start_km?: Maybe<Scalars['Float']['output']>;
-  /** Effort classification label */
-  effort_level?: Maybe<Scalars['String']['output']>;
   /** Heart rate in beats per minute */
   heart_rate?: Maybe<Scalars['Int']['output']>;
   /** Heart-rate zone index (1-5) */
@@ -273,8 +271,6 @@ export type GarminChartPoint = {
   respiration_rate?: Maybe<Scalars['Int']['output']>;
   /** Instantaneous speed in km/h */
   speed_kmh?: Maybe<Scalars['Float']['output']>;
-  /** Road or terrain type */
-  surface_type?: Maybe<Scalars['String']['output']>;
   /** Ambient temperature in degrees C */
   temperature_c?: Maybe<Scalars['Float']['output']>;
   /** UTC timestamp of the data point */
@@ -968,7 +964,7 @@ export type GarminChartDataQueryVariables = Exact<{
 }>;
 
 
-export type GarminChartDataQuery = { garminChartData: Array<{ timestamp: string, altitude: number | null, distance_from_start_km: number | null, speed_kmh: number | null, heart_rate: number | null, respiration_rate: number | null, cadence: number | null, temperature_c: number | null, latitude: number, longitude: number }> };
+export type GarminChartDataQuery = { garminChartData: Array<{ timestamp: string, altitude: number | null, distance_from_start_km: number | null, speed_kmh: number | null, heart_rate: number | null, hr_zone: number | null, respiration_rate: number | null, cadence: number | null, temperature_c: number | null, latitude: number, longitude: number }> };
 
 export type TriggerGarminSyncMutationVariables = Exact<{
   window_hours?: number | null | undefined;
@@ -1507,6 +1503,7 @@ export const GarminChartDataDocument = gql`
     distance_from_start_km
     speed_kmh
     heart_rate
+    hr_zone
     respiration_rate
     cadence
     temperature_c

--- a/src/components/garmin/ActivityChartData.ts
+++ b/src/components/garmin/ActivityChartData.ts
@@ -6,6 +6,7 @@ export interface ActivityChartTrackPoint {
   altitude?: number | null
   speed_kmh?: number | null
   heart_rate?: number | null
+  hr_zone?: number | null
   respiration_rate?: number | null
   latitude?: number | null
   longitude?: number | null
@@ -18,6 +19,7 @@ export interface ChartDataPoint {
   elevation: number | null
   speed: number | null
   heartRate: number | null
+  heartRateZone?: number | null
   respirationRate: number | null
   latitude: number | null
   longitude: number | null
@@ -85,6 +87,10 @@ export function toChartDataPoint(
     elevation: pt.altitude != null ? metersToFeet(pt.altitude) : null,
     speed: pt.speed_kmh != null ? kmhToMph(pt.speed_kmh) : null,
     heartRate: pt.heart_rate ?? null,
+    heartRateZone:
+      pt.hr_zone != null && pt.hr_zone >= 1 && pt.hr_zone <= 5
+        ? pt.hr_zone
+        : null,
     respirationRate: pt.respiration_rate ?? null,
     latitude: pt.latitude ?? null,
     longitude: pt.longitude ?? null,

--- a/src/components/garmin/ActivityCharts.test.tsx
+++ b/src/components/garmin/ActivityCharts.test.tsx
@@ -124,6 +124,15 @@ describe('ActivityCharts', () => {
     ])
   })
 
+  it('renders a full-width segment for a single zoned point', () => {
+    expect(
+      buildHeartRateZoneSegments(
+        [{ distance: 3, time: 3, heartRateZone: 2 }] as ChartDataPoint[],
+        'distance',
+      ),
+    ).toEqual([{ zone: 2, startPercent: 0, widthPercent: 100 }])
+  })
+
   it('renders respiration below heart rate only when samples exist', () => {
     const points = [
       {

--- a/src/components/garmin/ActivityCharts.test.tsx
+++ b/src/components/garmin/ActivityCharts.test.tsx
@@ -2,6 +2,8 @@ import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { describe, expect, it } from 'vitest'
 import { ActivityCharts } from './ActivityCharts'
+import type { ChartDataPoint } from './ActivityChartData'
+import { buildHeartRateZoneSegments } from './heartRateZones'
 import { getActivityYAxisConfig } from './ActivityChartYAxis'
 import {
   coerceTooltipMetricValue,
@@ -59,6 +61,67 @@ describe('ActivityCharts', () => {
 
     expect(screen.getByTestId('chart-heartRate')).toBeInTheDocument()
     expect(screen.getByText('Heart Rate')).toBeInTheDocument()
+  })
+
+  it('renders heart-rate zones as an aligned ribbon and hides it without zone data', () => {
+    const points = [
+      {
+        timestamp: '2026-03-14T09:00:00Z',
+        distance_from_start_km: 0,
+        heart_rate: 118,
+        hr_zone: 2,
+      },
+      {
+        timestamp: '2026-03-14T09:10:00Z',
+        distance_from_start_km: 5,
+        heart_rate: 135,
+        hr_zone: 2,
+      },
+      {
+        timestamp: '2026-03-14T09:20:00Z',
+        distance_from_start_km: 10,
+        heart_rate: 158,
+        hr_zone: 4,
+      },
+      {
+        timestamp: '2026-03-14T09:30:00Z',
+        distance_from_start_km: 15,
+        heart_rate: 148,
+        hr_zone: 3,
+      },
+    ]
+    const { rerender } = render(<ActivityCharts trackPoints={points} />)
+
+    expect(screen.getByTestId('heart-rate-zone-ribbon')).toBeInTheDocument()
+    expect(screen.getByLabelText('Heart rate zone legend')).toHaveTextContent(
+      'Z1Z2Z3Z4Z5',
+    )
+
+    rerender(
+      <ActivityCharts
+        trackPoints={points.map((point) => ({ ...point, hr_zone: null }))}
+      />,
+    )
+    expect(
+      screen.queryByTestId('heart-rate-zone-ribbon'),
+    ).not.toBeInTheDocument()
+  })
+
+  it('consolidates adjacent heart-rate zone samples into ribbon segments', () => {
+    expect(
+      buildHeartRateZoneSegments(
+        [
+          { distance: 0, time: 0, heartRateZone: 2 },
+          { distance: 1, time: 1, heartRateZone: 2 },
+          { distance: 2, time: 2, heartRateZone: 4 },
+          { distance: 4, time: 4, heartRateZone: 3 },
+        ] as ChartDataPoint[],
+        'distance',
+      ),
+    ).toEqual([
+      { zone: 2, startPercent: 0, widthPercent: 50 },
+      { zone: 4, startPercent: 50, widthPercent: 50 },
+    ])
   })
 
   it('renders respiration below heart rate only when samples exist', () => {

--- a/src/components/garmin/ActivityCharts.tsx
+++ b/src/components/garmin/ActivityCharts.tsx
@@ -26,6 +26,7 @@ import {
   type XAxisMode,
 } from './ActivityChartTooltip'
 import { getActivityYAxisConfig } from './ActivityChartYAxis'
+import { CHART_MARGIN_RIGHT, CHART_Y_AXIS_WIDTH } from './chartLayout'
 import { HeartRateZoneRibbon } from './HeartRateZoneRibbon'
 
 interface ActivityChartsProps {
@@ -350,7 +351,12 @@ export function ActivityCharts({
             <ResponsiveContainer width="100%" height={200}>
               <AreaChart
                 data={chartData}
-                margin={{ top: 5, right: 20, left: 0, bottom: 5 }}
+                margin={{
+                  top: 5,
+                  right: CHART_MARGIN_RIGHT,
+                  left: 0,
+                  bottom: 5,
+                }}
                 syncId="garmin-activity"
                 onMouseMove={(state: {
                   activeTooltipIndex?: number | string | null
@@ -397,7 +403,7 @@ export function ActivityCharts({
                   {...yAxisConfig}
                   tickFormatter={(v: number) => (v != null ? v.toFixed(0) : '')}
                   className="text-xs"
-                  width={50}
+                  width={CHART_Y_AXIS_WIDTH}
                 />
                 <Tooltip
                   cursor={{ stroke: 'currentColor', strokeOpacity: 0.4 }}

--- a/src/components/garmin/ActivityCharts.tsx
+++ b/src/components/garmin/ActivityCharts.tsx
@@ -26,6 +26,7 @@ import {
   type XAxisMode,
 } from './ActivityChartTooltip'
 import { getActivityYAxisConfig } from './ActivityChartYAxis'
+import { HeartRateZoneRibbon } from './HeartRateZoneRibbon'
 
 interface ActivityChartsProps {
   trackPoints: ActivityChartTrackPoint[]
@@ -472,6 +473,9 @@ export function ActivityCharts({
                 />
               </AreaChart>
             </ResponsiveContainer>
+            {chart.dataKey === 'heartRate' && (
+              <HeartRateZoneRibbon data={chartData} xKey={xKey} />
+            )}
           </CardContent>
         </Card>
       ))}

--- a/src/components/garmin/ActivityHoverDetails.test.tsx
+++ b/src/components/garmin/ActivityHoverDetails.test.tsx
@@ -19,6 +19,7 @@ function chartPoint(overrides: Partial<ChartDataPoint> = {}): ChartDataPoint {
     elevation: 120.4,
     speed: 9.8,
     heartRate: 142,
+    heartRateZone: 3,
     respirationRate: 27,
     latitude: 40.71234,
     longitude: -74.00567,
@@ -56,6 +57,7 @@ describe('ActivityHoverDetails', () => {
 
     expect(screen.getByText('120.4 ft')).toBeInTheDocument()
     expect(screen.getByText('9.8 mph')).toBeInTheDocument()
+    expect(screen.getByText('Zone 3')).toBeInTheDocument()
     expect(screen.getByText('27 brpm')).toBeInTheDocument()
     expect(screen.getByText('3.14 mi (5.05 km)')).toBeInTheDocument()
     expect(screen.getByText('40.71234, -74.00567')).toBeInTheDocument()
@@ -87,6 +89,7 @@ describe('ActivityHoverDetails', () => {
           elevation: null,
           speed: null,
           heartRate: null,
+          heartRateZone: null,
           respirationRate: null,
           distance: null,
           distanceKm: null,
@@ -94,7 +97,7 @@ describe('ActivityHoverDetails', () => {
       />,
     )
 
-    expect(screen.getAllByText('—')).toHaveLength(5)
+    expect(screen.getAllByText('—')).toHaveLength(6)
     expect(await screen.findByText('No address found')).toBeInTheDocument()
 
     geocoderMocks.reverseGeocode.mockRejectedValueOnce(new Error('offline'))

--- a/src/components/garmin/ActivityHoverDetails.tsx
+++ b/src/components/garmin/ActivityHoverDetails.tsx
@@ -151,6 +151,12 @@ export function ActivityHoverDetails({
             value={point.heartRate != null ? `${point.heartRate} bpm` : '—'}
           />
           <Field
+            label="Heart Rate Zone"
+            value={
+              point.heartRateZone != null ? `Zone ${point.heartRateZone}` : '—'
+            }
+          />
+          <Field
             label="Respiration Rate"
             value={
               point.respirationRate != null

--- a/src/components/garmin/HeartRateZoneRibbon.tsx
+++ b/src/components/garmin/HeartRateZoneRibbon.tsx
@@ -1,0 +1,54 @@
+import type { ChartDataPoint } from './ActivityChartData'
+import { buildHeartRateZoneSegments, ZONE_COLORS } from './heartRateZones'
+
+export function HeartRateZoneRibbon({
+  data,
+  xKey,
+}: {
+  data: ChartDataPoint[]
+  xKey: 'distance' | 'time'
+}) {
+  const segments = buildHeartRateZoneSegments(data, xKey)
+  if (segments.length === 0) return null
+
+  return (
+    <div className="ml-[50px] mr-5 mt-1 space-y-1">
+      <div
+        aria-label="Heart rate zones across activity"
+        className="relative h-2 overflow-hidden rounded-full bg-muted/40"
+        data-testid="heart-rate-zone-ribbon"
+        role="img"
+      >
+        {segments.map((segment, index) => (
+          <span
+            aria-label={`Zone ${segment.zone}`}
+            className="absolute inset-y-0"
+            data-zone={segment.zone}
+            key={`${segment.startPercent}-${segment.zone}-${index}`}
+            style={{
+              backgroundColor: ZONE_COLORS[segment.zone],
+              left: `${segment.startPercent}%`,
+              width: `${segment.widthPercent}%`,
+            }}
+            title={`Heart rate zone ${segment.zone}`}
+          />
+        ))}
+      </div>
+      <div
+        aria-label="Heart rate zone legend"
+        className="flex justify-end gap-3 text-[10px] text-muted-foreground"
+      >
+        {[1, 2, 3, 4, 5].map((zone) => (
+          <span className="flex items-center gap-1" key={zone}>
+            <span
+              aria-hidden="true"
+              className="size-2 rounded-full"
+              style={{ backgroundColor: ZONE_COLORS[zone] }}
+            />
+            Z{zone}
+          </span>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/src/components/garmin/HeartRateZoneRibbon.tsx
+++ b/src/components/garmin/HeartRateZoneRibbon.tsx
@@ -1,4 +1,5 @@
 import type { ChartDataPoint } from './ActivityChartData'
+import { CHART_MARGIN_RIGHT, CHART_Y_AXIS_WIDTH } from './chartLayout'
 import { buildHeartRateZoneSegments, ZONE_COLORS } from './heartRateZones'
 
 export function HeartRateZoneRibbon({
@@ -12,7 +13,13 @@ export function HeartRateZoneRibbon({
   if (segments.length === 0) return null
 
   return (
-    <div className="ml-[50px] mr-5 mt-1 space-y-1">
+    <div
+      className="mt-1 space-y-1"
+      style={{
+        marginLeft: CHART_Y_AXIS_WIDTH,
+        marginRight: CHART_MARGIN_RIGHT,
+      }}
+    >
       <div
         aria-label="Heart rate zones across activity"
         className="relative h-2 overflow-hidden rounded-full bg-muted/40"
@@ -21,7 +28,7 @@ export function HeartRateZoneRibbon({
       >
         {segments.map((segment, index) => (
           <span
-            aria-label={`Zone ${segment.zone}`}
+            aria-hidden="true"
             className="absolute inset-y-0"
             data-zone={segment.zone}
             key={`${segment.startPercent}-${segment.zone}-${index}`}

--- a/src/components/garmin/chartLayout.ts
+++ b/src/components/garmin/chartLayout.ts
@@ -1,0 +1,10 @@
+/**
+ * Shared layout constants for the Garmin activity charts.
+ *
+ * These are the single source of truth for the chart plot-area insets so that
+ * overlays rendered outside the Recharts `<AreaChart>` (e.g. the heart-rate
+ * zone ribbon) stay aligned with the plotted X axis. Keep the chart's
+ * `<YAxis width>` and `margin.right` wired to these values to avoid drift.
+ */
+export const CHART_Y_AXIS_WIDTH = 50
+export const CHART_MARGIN_RIGHT = 20

--- a/src/components/garmin/heartRateZones.ts
+++ b/src/components/garmin/heartRateZones.ts
@@ -1,0 +1,65 @@
+import type { ChartDataPoint } from './ActivityChartData'
+
+export const ZONE_COLORS: Record<number, string> = {
+  1: '#60a5fa',
+  2: '#22c55e',
+  3: '#eab308',
+  4: '#f97316',
+  5: '#ef4444',
+}
+
+interface ZoneSegment {
+  zone: number
+  startPercent: number
+  widthPercent: number
+}
+
+function validZone(value: number | null | undefined): number | null {
+  return value != null && Number.isInteger(value) && value >= 1 && value <= 5
+    ? value
+    : null
+}
+
+export function buildHeartRateZoneSegments(
+  data: ChartDataPoint[],
+  xKey: 'distance' | 'time',
+): ZoneSegment[] {
+  const points = data.filter(
+    (point) => point[xKey] != null && Number.isFinite(point[xKey]),
+  )
+  if (
+    points.length === 0 ||
+    !points.some((point) => validZone(point.heartRateZone))
+  ) {
+    return []
+  }
+
+  const domainMax = Math.max(...points.map((point) => point[xKey] as number))
+  if (domainMax <= 0) {
+    const zone = validZone(points[0].heartRateZone)
+    return zone == null ? [] : [{ zone, startPercent: 0, widthPercent: 100 }]
+  }
+
+  const segments: ZoneSegment[] = []
+  for (let index = 0; index < points.length - 1; index += 1) {
+    const start = points[index][xKey] as number
+    const end = points[index + 1][xKey] as number
+    const zone = validZone(points[index].heartRateZone)
+    if (zone == null || end <= start) continue
+
+    const startPercent = (start / domainMax) * 100
+    const widthPercent = ((end - start) / domainMax) * 100
+    const previous = segments.at(-1)
+    if (
+      previous?.zone === zone &&
+      Math.abs(previous.startPercent + previous.widthPercent - startPercent) <
+        0.001
+    ) {
+      previous.widthPercent += widthPercent
+    } else {
+      segments.push({ zone, startPercent, widthPercent })
+    }
+  }
+
+  return segments
+}

--- a/src/components/garmin/heartRateZones.ts
+++ b/src/components/garmin/heartRateZones.ts
@@ -35,8 +35,10 @@ export function buildHeartRateZoneSegments(
   }
 
   const domainMax = Math.max(...points.map((point) => point[xKey] as number))
-  if (domainMax <= 0) {
-    const zone = validZone(points[0].heartRateZone)
+  if (domainMax <= 0 || points.length === 1) {
+    const zone = points
+      .map((point) => validZone(point.heartRateZone))
+      .find((value) => value != null)
     return zone == null ? [] : [{ zone, startPercent: 0, widthPercent: 100 }]
   }
 

--- a/src/graphql/garmin.ts
+++ b/src/graphql/garmin.ts
@@ -185,6 +185,7 @@ export const GARMIN_CHART_DATA_QUERY = gql`
       distance_from_start_km
       speed_kmh
       heart_rate
+      hr_zone
       respiration_rate
       cadence
       temperature_c


### PR DESCRIPTION
## Summary

- carry `hr_zone` from Garmin chart data into the UI chart model
- render a compact Z1–Z5 color ribbon aligned with the distance or time axis
- consolidate adjacent samples in the same zone to keep the DOM efficient
- show the selected point's heart-rate zone in shared hover details
- hide the ribbon gracefully when zone data is unavailable

## Design

Heart-rate zones are categorical values, so they are presented as a thin contextual ribbon rather than plotted against the BPM axis. The existing heart-rate line and area remain unchanged.

## Impact

Users can see intensity changes across the activity while retaining the familiar heart-rate graph. Hovering a chart point also reports its exact zone.

## Validation

- focused chart/data/hover tests — 18 passed
- full UI suite — 38 files / 203 tests passed
- `npm run lint:all` — passed (one pre-existing unused eslint-disable warning)
- `npm run type-check` — passed
- `npm run build` — passed
- local browser validation against activity `23311387080`:
  - 9,891 chart points and 9,850 populated zones
  - 109 consolidated ribbon segments across Zones 1–4
  - Z1–Z5 legend rendered
  - hover details displayed `Heart Rate Zone — Zone 2`
  - no browser or API failures

## Dependency

Requires stuartshay/otel-data-gateway#131, which now exposes `hr_zone` on `GarminChartPoint`. Merge and deploy the gateway compatibility change before deploying this UI PR.

Refs #212
Related: #210 and stuartshay/otel-data-gateway#130