### PR TITLE
[codex] Improve Garmin respiration-rate chart context

### DIFF
--- a/src/components/garmin/ActivityChartData.test.ts
+++ b/src/components/garmin/ActivityChartData.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it } from 'vitest'
 import {
+  addRespirationRollingAverage,
   buildActivityChartData,
   getActivityChartContext,
   toChartDataPoint,
   type ActivityChartTrackPoint,
+  type ChartDataPoint,
 } from './ActivityChartData'
 
 function point(
@@ -79,5 +81,20 @@ describe('ActivityChartData', () => {
 
     expect(result.hasReliableDistance).toBe(false)
     expect(result.chartData.every((p) => p.distance == null)).toBe(true)
+  })
+
+  it('calculates a one-minute respiration average using timestamps and preserves gaps', () => {
+    const data = [
+      { time: 0, respirationRate: 20 },
+      { time: 0.5, respirationRate: 40 },
+      { time: 1.5, respirationRate: 30 },
+      { time: 2, respirationRate: null },
+    ] as ChartDataPoint[]
+
+    expect(
+      addRespirationRollingAverage(data).map(
+        (point) => point.respirationRateSmoothed,
+      ),
+    ).toEqual([20, 30, 35, null])
   })
 })

--- a/src/components/garmin/ActivityChartData.ts
+++ b/src/components/garmin/ActivityChartData.ts
@@ -21,6 +21,7 @@ export interface ChartDataPoint {
   heartRate: number | null
   heartRateZone?: number | null
   respirationRate: number | null
+  respirationRateSmoothed?: number | null
   latitude: number | null
   longitude: number | null
   timestamp: string
@@ -127,9 +128,40 @@ export function buildActivityChartData(
   }
 
   const sampled = downsample(trackPoints, 800)
-  const chartData = sampled.map((pt) =>
-    toChartDataPoint(pt, context.startTime, context.hasReliableDistance),
+  const chartData = addRespirationRollingAverage(
+    sampled.map((pt) =>
+      toChartDataPoint(pt, context.startTime, context.hasReliableDistance),
+    ),
   )
 
   return { chartData, hasReliableDistance: context.hasReliableDistance }
+}
+
+/** Add a trailing one-minute rolling average without filling missing samples. */
+export function addRespirationRollingAverage(
+  data: ChartDataPoint[],
+  windowMinutes = 1,
+): ChartDataPoint[] {
+  const window: Array<{ time: number; value: number }> = []
+  let sum = 0
+
+  return data.map((point) => {
+    while (window.length > 0 && point.time - window[0].time > windowMinutes) {
+      sum -= window.shift()?.value ?? 0
+    }
+
+    const value = point.respirationRate
+    if (value != null && Number.isFinite(value)) {
+      window.push({ time: point.time, value })
+      sum += value
+    }
+
+    return {
+      ...point,
+      respirationRateSmoothed:
+        value != null && Number.isFinite(value) && window.length > 0
+          ? sum / window.length
+          : null,
+    }
+  })
 }

--- a/src/components/garmin/ActivityCharts.test.tsx
+++ b/src/components/garmin/ActivityCharts.test.tsx
@@ -157,7 +157,9 @@ describe('ActivityCharts', () => {
     )
     expect(screen.getByText('Respiration Rate')).toBeInTheDocument()
     expect(
-      screen.getByLabelText('Respiration Rate average 27 brpm'),
+      screen.getByLabelText(
+        'Respiration Rate statistics: average 27, minimum 24, maximum 30 breaths per minute',
+      ),
     ).toBeInTheDocument()
 
     rerender(
@@ -207,8 +209,44 @@ describe('ActivityCharts', () => {
       screen.getByLabelText('Heart Rate average 135 bpm'),
     ).toBeInTheDocument()
     expect(
-      screen.getByLabelText('Respiration Rate average 27 brpm'),
+      screen.getByLabelText(
+        'Respiration Rate statistics: average 27, minimum 24, maximum 30 breaths per minute',
+      ),
     ).toBeInTheDocument()
+  })
+
+  it('explains respiration rate and toggles between raw and smoothed data', async () => {
+    const user = userEvent.setup()
+    render(
+      <ActivityCharts
+        trackPoints={[
+          {
+            timestamp: '2026-03-14T09:00:00Z',
+            distance_from_start_km: 0,
+            respiration_rate: 24,
+          },
+          {
+            timestamp: '2026-03-14T09:01:00Z',
+            distance_from_start_km: 1,
+            respiration_rate: 30,
+          },
+        ]}
+      />,
+    )
+
+    expect(screen.getByLabelText('About respiration rate')).toHaveAttribute(
+      'title',
+      expect.stringContaining('Estimated breaths per minute'),
+    )
+    const raw = screen.getByRole('button', { name: 'Raw' })
+    const smoothed = screen.getByRole('button', { name: 'Smoothed' })
+    expect(raw).toHaveAttribute('aria-pressed', 'true')
+    expect(smoothed).toHaveAttribute('aria-pressed', 'false')
+
+    await user.click(smoothed)
+
+    expect(raw).toHaveAttribute('aria-pressed', 'false')
+    expect(smoothed).toHaveAttribute('aria-pressed', 'true')
   })
 
   it('minimizes and restores each chart independently while keeping its header', async () => {

--- a/src/components/garmin/ActivityCharts.test.tsx
+++ b/src/components/garmin/ActivityCharts.test.tsx
@@ -234,7 +234,7 @@ describe('ActivityCharts', () => {
       />,
     )
 
-    expect(screen.getByLabelText('About respiration rate')).toHaveAttribute(
+    expect(screen.getByLabelText(/^About Respiration Rate/)).toHaveAttribute(
       'title',
       expect.stringContaining('Estimated breaths per minute'),
     )

--- a/src/components/garmin/ActivityCharts.tsx
+++ b/src/components/garmin/ActivityCharts.tsx
@@ -337,7 +337,7 @@ export function ActivityCharts({
                 {chart.title}
                 {chart.description && (
                   <span
-                    aria-label="About respiration rate"
+                    aria-label={`About ${chart.title}: ${chart.description}`}
                     className="inline-flex text-muted-foreground"
                     role="note"
                     tabIndex={0}

--- a/src/components/garmin/ActivityCharts.tsx
+++ b/src/components/garmin/ActivityCharts.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { ChevronDown, ChevronUp } from 'lucide-react'
+import { CircleHelp, ChevronDown, ChevronUp } from 'lucide-react'
 import {
   AreaChart,
   Area,
@@ -60,6 +60,13 @@ interface ChartConfig {
   unit: string
   hasData: boolean
   precision: number
+  description?: string
+}
+
+interface MetricStatistics {
+  average: number | null
+  minimum: number | null
+  maximum: number | null
 }
 
 function activeMetricValue(
@@ -70,12 +77,14 @@ function activeMetricValue(
   return typeof value === 'number' && Number.isFinite(value) ? value : null
 }
 
-function averageMetricValue(
+function metricStatistics(
   data: ChartDataPoint[],
   dataKey: MetricKey,
-): number | null {
+): MetricStatistics {
   let sum = 0
   let count = 0
+  let minimum = Infinity
+  let maximum = -Infinity
 
   for (const point of data) {
     const value = activeMetricValue(point, dataKey)
@@ -83,9 +92,15 @@ function averageMetricValue(
 
     sum += value
     count += 1
+    minimum = Math.min(minimum, value)
+    maximum = Math.max(maximum, value)
   }
 
-  return count > 0 ? sum / count : null
+  return {
+    average: count > 0 ? sum / count : null,
+    minimum: count > 0 ? minimum : null,
+    maximum: count > 0 ? maximum : null,
+  }
 }
 
 function formatNumber(value: number | null, precision: number): string {
@@ -142,6 +157,7 @@ export function ActivityCharts({
   onPointToggle,
 }: ActivityChartsProps) {
   const [xMode, setXMode] = useState<XAxisMode>('distance')
+  const [smoothRespiration, setSmoothRespiration] = useState(false)
   const [collapsedCharts, setCollapsedCharts] = useState<Set<MetricKey>>(
     () => new Set(),
   )
@@ -247,21 +263,24 @@ export function ActivityCharts({
       title: 'Respiration Rate',
       dataKey: 'respirationRate',
       color: '#3fc1d3',
-      unit: 'brpm',
+      unit: 'breaths/min',
       hasData: hasRespirationRate,
       precision: 0,
+      description:
+        'Estimated breaths per minute recorded by Garmin. Higher values often accompany harder effort; brief spikes or drops may reflect sensor noise.',
     },
   ]
 
   const activeCharts = charts.filter((c) => c.hasData)
-  const activeChartLabels = activeCharts.map((chart) => ({
-    chart,
-    yAxisConfig: getActivityYAxisConfig(chart.dataKey),
-    averageLabel: formatMetricValue(
-      averageMetricValue(chartData, chart.dataKey),
+  const activeChartLabels = activeCharts.map((chart) => {
+    const statistics = metricStatistics(chartData, chart.dataKey)
+    return {
       chart,
-    ),
-  }))
+      stats: statistics,
+      yAxisConfig: getActivityYAxisConfig(chart.dataKey),
+      averageLabel: formatMetricValue(statistics.average, chart),
+    }
+  })
 
   if (activeCharts.length === 0) return null
 
@@ -303,7 +322,7 @@ export function ActivityCharts({
         </Button>
       </div>
 
-      {activeChartLabels.map(({ chart, yAxisConfig, averageLabel }) => (
+      {activeChartLabels.map(({ chart, stats, yAxisConfig, averageLabel }) => (
         <Card key={chart.dataKey} data-testid={`chart-${chart.dataKey}`}>
           <CardHeader
             className={collapsedCharts.has(chart.dataKey) ? 'pb-6' : 'pb-2'}
@@ -316,14 +335,62 @@ export function ActivityCharts({
                   style={{ backgroundColor: chart.color }}
                 />
                 {chart.title}
+                {chart.description && (
+                  <span
+                    aria-label="About respiration rate"
+                    className="inline-flex text-muted-foreground"
+                    role="note"
+                    tabIndex={0}
+                    title={chart.description}
+                  >
+                    <CircleHelp aria-hidden="true" className="size-4" />
+                  </span>
+                )}
               </CardTitle>
               <div className="flex items-center gap-2">
-                <div
-                  aria-label={`${chart.title} average ${averageLabel}`}
-                  className="rounded bg-neutral-950/70 px-2 py-1 text-xs text-white"
-                >
-                  Avg: {averageLabel}
-                </div>
+                {chart.dataKey === 'respirationRate' ? (
+                  <>
+                    <div
+                      aria-label={`Respiration Rate statistics: average ${formatNumber(stats.average, 0)}, minimum ${formatNumber(stats.minimum, 0)}, maximum ${formatNumber(stats.maximum, 0)} breaths per minute`}
+                      className="rounded bg-neutral-950/70 px-2 py-1 text-xs text-white"
+                    >
+                      Avg {formatNumber(stats.average, 0)} · Min{' '}
+                      {formatNumber(stats.minimum, 0)} · Max{' '}
+                      {formatNumber(stats.maximum, 0)} breaths/min
+                    </div>
+                    <div
+                      aria-label="Respiration rate display"
+                      className="flex rounded border p-0.5"
+                      role="group"
+                    >
+                      <Button
+                        aria-pressed={!smoothRespiration}
+                        className="h-6 px-2 text-xs"
+                        onClick={() => setSmoothRespiration(false)}
+                        size="sm"
+                        variant={!smoothRespiration ? 'secondary' : 'ghost'}
+                      >
+                        Raw
+                      </Button>
+                      <Button
+                        aria-pressed={smoothRespiration}
+                        className="h-6 px-2 text-xs"
+                        onClick={() => setSmoothRespiration(true)}
+                        size="sm"
+                        variant={smoothRespiration ? 'secondary' : 'ghost'}
+                      >
+                        Smoothed
+                      </Button>
+                    </div>
+                  </>
+                ) : (
+                  <div
+                    aria-label={`${chart.title} average ${averageLabel}`}
+                    className="rounded bg-neutral-950/70 px-2 py-1 text-xs text-white"
+                  >
+                    Avg: {averageLabel}
+                  </div>
+                )}
                 <Button
                   type="button"
                   variant="ghost"
@@ -350,7 +417,14 @@ export function ActivityCharts({
           >
             <ResponsiveContainer width="100%" height={200}>
               <AreaChart
-                data={chartData}
+                data={
+                  chart.dataKey === 'respirationRate' && smoothRespiration
+                    ? chartData.map((point) => ({
+                        ...point,
+                        respirationRate: point.respirationRateSmoothed ?? null,
+                      }))
+                    : chartData
+                }
                 margin={{
                   top: 5,
                   right: CHART_MARGIN_RIGHT,
@@ -416,6 +490,22 @@ export function ActivityCharts({
                     />
                   )}
                 />
+                {chart.dataKey === 'respirationRate' &&
+                  stats.average != null && (
+                    <ReferenceLine
+                      ifOverflow="extendDomain"
+                      label={{
+                        value: `Avg ${formatNumber(stats.average, 0)}`,
+                        position: 'insideTopRight',
+                        fill: chart.color,
+                        fontSize: 10,
+                      }}
+                      stroke={chart.color}
+                      strokeDasharray="5 4"
+                      strokeOpacity={0.8}
+                      y={stats.average}
+                    />
+                  )}
                 {activeX != null && (
                   <ReferenceLine
                     x={activeX}

--- a/src/components/garmin/ActivityHoverDetails.test.tsx
+++ b/src/components/garmin/ActivityHoverDetails.test.tsx
@@ -58,7 +58,7 @@ describe('ActivityHoverDetails', () => {
     expect(screen.getByText('120.4 ft')).toBeInTheDocument()
     expect(screen.getByText('9.8 mph')).toBeInTheDocument()
     expect(screen.getByText('Zone 3')).toBeInTheDocument()
-    expect(screen.getByText('27 brpm')).toBeInTheDocument()
+    expect(screen.getByText('27 breaths/min')).toBeInTheDocument()
     expect(screen.getByText('3.14 mi (5.05 km)')).toBeInTheDocument()
     expect(screen.getByText('40.71234, -74.00567')).toBeInTheDocument()
     expect(screen.getByText('Resolving…')).toBeInTheDocument()

--- a/src/components/garmin/ActivityHoverDetails.tsx
+++ b/src/components/garmin/ActivityHoverDetails.tsx
@@ -160,7 +160,7 @@ export function ActivityHoverDetails({
             label="Respiration Rate"
             value={
               point.respirationRate != null
-                ? `${point.respirationRate} brpm`
+                ? `${point.respirationRate} breaths/min`
                 : '—'
             }
           />

--- a/src/components/garmin/ActivityStatsPanel.tsx
+++ b/src/components/garmin/ActivityStatsPanel.tsx
@@ -253,21 +253,21 @@ export function ActivityStatsPanel({ activity: a }: ActivityStatsPanelProps) {
                 label: 'Avg Respiration',
                 value:
                   a.avg_respiration_rate != null
-                    ? `${a.avg_respiration_rate} brpm`
+                    ? `${a.avg_respiration_rate} breaths/min`
                     : '—',
               },
               {
                 label: 'Min Respiration',
                 value:
                   a.min_respiration_rate != null
-                    ? `${a.min_respiration_rate} brpm`
+                    ? `${a.min_respiration_rate} breaths/min`
                     : '—',
               },
               {
                 label: 'Max Respiration',
                 value:
                   a.max_respiration_rate != null
-                    ? `${a.max_respiration_rate} brpm`
+                    ? `${a.max_respiration_rate} breaths/min`
                     : '—',
               },
             ],


### PR DESCRIPTION
## Summary

- retain Garmin Connect's `Respiration Rate` terminology
- add an accessible explanation of breaths-per-minute data and possible sensor noise
- show average, minimum, and maximum values in the chart header
- draw a labeled dashed average reference line
- add Raw and Smoothed display controls with raw selected by default
- calculate smoothing as a trailing one-minute window using timestamps, preserving missing samples
- replace the abbreviated `brpm` display with `breaths/min`

## Why

The existing graph displayed a technically valid time series but did not explain what respiration rate represented or provide enough context to interpret its variation. The additional statistics and optional smoothing make the data easier to understand without inventing non-standard respiration zones.

## Impact

Users retain the exact Garmin metric name and raw readings while gaining summary context and an optional less noisy view. Activities without respiration data continue to hide the graph.

## Validation

- focused chart/data tests — 15 passed
- full UI suite — 38 files / 203 tests passed
- `npm run lint:all` — passed (one pre-existing unused eslint-disable warning)
- `npm run type-check` — passed
- `npm run build` — passed
- local browser validation against activity `23311387080`:
  - displayed Avg 29, Min 14, Max 40 breaths/min
  - rendered the dashed `Avg 29` reference line
  - explanation exposed through an accessible label/title
  - Raw/Smoothed state changed correctly and produced different SVG curves
  - no browser or API failures

This PR is independent of #213 and can be reviewed separately.

Refs #214
Related: #212 and #213