### PR TITLE
[codex] Display Garmin total strokes

### DIFF
--- a/e2e/garmin-total-strokes.spec.ts
+++ b/e2e/garmin-total-strokes.spec.ts
@@ -1,0 +1,31 @@
+import { test, expect } from '@playwright/test'
+
+const ACTIVITY_ID =
+  process.env.PLAYWRIGHT_GARMIN_CADENCE_ACTIVITY_ID ?? '23321402669'
+
+test.describe('Garmin cadence statistics', () => {
+  test('shows cadence and total strokes for an activity', async ({ page }) => {
+    await page.goto(`/garmin/${ACTIVITY_ID}`)
+
+    await expect(page.getByText('Cadence', { exact: true })).toBeVisible({
+      timeout: 20_000,
+    })
+
+    const averageCadenceRow = page
+      .getByText('Avg Cadence', { exact: true })
+      .locator('..')
+    const maximumCadenceRow = page
+      .getByText('Max Cadence', { exact: true })
+      .locator('..')
+    const totalStrokesRow = page
+      .getByText('Total Strokes', { exact: true })
+      .locator('..')
+    const formattedTotalStrokes = await page.evaluate(() =>
+      (1793).toLocaleString(),
+    )
+
+    await expect(averageCadenceRow).toContainText('61 rpm')
+    await expect(maximumCadenceRow).toContainText('94 rpm')
+    await expect(totalStrokesRow).toContainText(formattedTotalStrokes)
+  })
+})

--- a/src/__generated__/graphql.ts
+++ b/src/__generated__/graphql.ts
@@ -169,6 +169,8 @@ export type GarminActivity = {
   total_elapsed_time?: Maybe<Scalars['Float']['output']>;
   /** Total intensity minutes */
   total_intensity_minutes?: Maybe<Scalars['Int']['output']>;
+  /** Total activity strokes */
+  total_strokes?: Maybe<Scalars['Int']['output']>;
   /** Total timer time in seconds (active recording) */
   total_timer_time?: Maybe<Scalars['Float']['output']>;
   /** Number of GPS track points in this activity */
@@ -918,14 +920,14 @@ export type GarminActivitiesQueryVariables = Exact<{
 }>;
 
 
-export type GarminActivitiesQuery = { garminActivities: { total: number, limit: number, offset: number, items: Array<{ activity_id: string, sport: string, sub_sport: string | null, start_time: string | null, end_time: string | null, distance_km: number | null, duration_seconds: number | null, avg_heart_rate: number | null, max_heart_rate: number | null, avg_cadence: number | null, max_cadence: number | null, calories: number | null, avg_speed_kmh: number | null, max_speed_kmh: number | null, total_ascent_m: number | null, total_descent_m: number | null, total_distance: number | null, avg_pace: number | null, device_manufacturer: string | null, created_at: string | null, uploaded_at: string | null, track_point_count: number | null }> } };
+export type GarminActivitiesQuery = { garminActivities: { total: number, limit: number, offset: number, items: Array<{ activity_id: string, sport: string, sub_sport: string | null, start_time: string | null, end_time: string | null, distance_km: number | null, duration_seconds: number | null, avg_heart_rate: number | null, max_heart_rate: number | null, avg_cadence: number | null, max_cadence: number | null, total_strokes: number | null, calories: number | null, avg_speed_kmh: number | null, max_speed_kmh: number | null, total_ascent_m: number | null, total_descent_m: number | null, total_distance: number | null, avg_pace: number | null, device_manufacturer: string | null, created_at: string | null, uploaded_at: string | null, track_point_count: number | null }> } };
 
 export type GarminActivityQueryVariables = Exact<{
   activity_id: string;
 }>;
 
 
-export type GarminActivityQuery = { garminActivity: { activity_id: string, sport: string, sub_sport: string | null, start_time: string | null, end_time: string | null, distance_km: number | null, duration_seconds: number | null, avg_heart_rate: number | null, max_heart_rate: number | null, hr_available: boolean, min_heart_rate: number | null, aerobic_training_effect: number | null, anaerobic_training_effect: number | null, exercise_load: number | null, avg_respiration_rate: number | null, min_respiration_rate: number | null, max_respiration_rate: number | null, sweat_loss_ml: number | null, moderate_intensity_minutes: number | null, vigorous_intensity_minutes: number | null, total_intensity_minutes: number | null, paved_distance_km: number | null, unpaved_distance_km: number | null, avg_cadence: number | null, max_cadence: number | null, calories: number | null, avg_speed_kmh: number | null, max_speed_kmh: number | null, total_ascent_m: number | null, total_descent_m: number | null, total_distance: number | null, avg_pace: number | null, device_manufacturer: string | null, avg_temperature_c: number | null, min_temperature_c: number | null, max_temperature_c: number | null, total_elapsed_time: number | null, total_timer_time: number | null, created_at: string | null, uploaded_at: string | null, track_point_count: number | null } | null };
+export type GarminActivityQuery = { garminActivity: { activity_id: string, sport: string, sub_sport: string | null, start_time: string | null, end_time: string | null, distance_km: number | null, duration_seconds: number | null, avg_heart_rate: number | null, max_heart_rate: number | null, hr_available: boolean, min_heart_rate: number | null, aerobic_training_effect: number | null, anaerobic_training_effect: number | null, exercise_load: number | null, avg_respiration_rate: number | null, min_respiration_rate: number | null, max_respiration_rate: number | null, sweat_loss_ml: number | null, moderate_intensity_minutes: number | null, vigorous_intensity_minutes: number | null, total_intensity_minutes: number | null, paved_distance_km: number | null, unpaved_distance_km: number | null, avg_cadence: number | null, max_cadence: number | null, total_strokes: number | null, calories: number | null, avg_speed_kmh: number | null, max_speed_kmh: number | null, total_ascent_m: number | null, total_descent_m: number | null, total_distance: number | null, avg_pace: number | null, device_manufacturer: string | null, avg_temperature_c: number | null, min_temperature_c: number | null, max_temperature_c: number | null, total_elapsed_time: number | null, total_timer_time: number | null, created_at: string | null, uploaded_at: string | null, track_point_count: number | null } | null };
 
 export type GarminTrackPointsQueryVariables = Exact<{
   activity_id: string;
@@ -1139,6 +1141,7 @@ export const GarminActivitiesDocument = gql`
       max_heart_rate
       avg_cadence
       max_cadence
+      total_strokes
       calories
       avg_speed_kmh
       max_speed_kmh
@@ -1227,6 +1230,7 @@ export const GarminActivityDocument = gql`
     unpaved_distance_km
     avg_cadence
     max_cadence
+    total_strokes
     calories
     avg_speed_kmh
     max_speed_kmh

--- a/src/components/garmin/ActivityStatsPanel.test.tsx
+++ b/src/components/garmin/ActivityStatsPanel.test.tsx
@@ -35,7 +35,14 @@ describe('ActivityStatsPanel', () => {
     expect(screen.getByText('145 bpm')).toBeInTheDocument()
     expect(screen.getByText('68 °F')).toBeInTheDocument()
     expect(screen.getByText('720 kcal')).toBeInTheDocument()
-    expect(screen.getByText('1,793')).toBeInTheDocument()
+    expect(screen.getByText((1793).toLocaleString())).toBeInTheDocument()
+  })
+
+  it('shows a fallback when total strokes is unavailable', () => {
+    render(<ActivityStatsPanel activity={{ total_strokes: null }} />)
+
+    const totalStrokesLabel = screen.getByText('Total Strokes')
+    expect(totalStrokesLabel.nextElementSibling).toHaveTextContent('—')
   })
 
   it('hides HR-dependent sections when hr data is unavailable', () => {

--- a/src/components/garmin/ActivityStatsPanel.test.tsx
+++ b/src/components/garmin/ActivityStatsPanel.test.tsx
@@ -19,6 +19,7 @@ describe('ActivityStatsPanel', () => {
           max_heart_rate: 176,
           avg_cadence: 88,
           max_cadence: 98,
+          total_strokes: 1793,
           avg_temperature_c: 20,
           min_temperature_c: 18,
           max_temperature_c: 25,
@@ -34,6 +35,7 @@ describe('ActivityStatsPanel', () => {
     expect(screen.getByText('145 bpm')).toBeInTheDocument()
     expect(screen.getByText('68 °F')).toBeInTheDocument()
     expect(screen.getByText('720 kcal')).toBeInTheDocument()
+    expect(screen.getByText('1,793')).toBeInTheDocument()
   })
 
   it('hides HR-dependent sections when hr data is unavailable', () => {

--- a/src/components/garmin/ActivityStatsPanel.tsx
+++ b/src/components/garmin/ActivityStatsPanel.tsx
@@ -35,6 +35,7 @@ interface ActivityStatsPanelProps {
     unpaved_distance_km?: number | null
     avg_cadence?: number | null
     max_cadence?: number | null
+    total_strokes?: number | null
     total_ascent_m?: number | null
     total_descent_m?: number | null
     calories?: number | null
@@ -174,6 +175,13 @@ export function ActivityStatsPanel({ activity: a }: ActivityStatsPanelProps) {
         {
           label: 'Max Cadence',
           value: a.max_cadence != null ? `${a.max_cadence} rpm` : '—',
+        },
+        {
+          label: 'Total Strokes',
+          value:
+            a.total_strokes != null
+              ? a.total_strokes.toLocaleString('en-US')
+              : '—',
         },
       ],
     },

--- a/src/components/garmin/ActivityStatsPanel.tsx
+++ b/src/components/garmin/ActivityStatsPanel.tsx
@@ -179,9 +179,7 @@ export function ActivityStatsPanel({ activity: a }: ActivityStatsPanelProps) {
         {
           label: 'Total Strokes',
           value:
-            a.total_strokes != null
-              ? a.total_strokes.toLocaleString('en-US')
-              : '—',
+            a.total_strokes != null ? a.total_strokes.toLocaleString() : '—',
         },
       ],
     },

--- a/src/graphql/garmin.ts
+++ b/src/graphql/garmin.ts
@@ -31,6 +31,7 @@ export const GARMIN_ACTIVITIES_QUERY = gql`
         max_heart_rate
         avg_cadence
         max_cadence
+        total_strokes
         calories
         avg_speed_kmh
         max_speed_kmh
@@ -78,6 +79,7 @@ export const GARMIN_ACTIVITY_QUERY = gql`
       unpaved_distance_km
       avg_cadence
       max_cadence
+      total_strokes
       calories
       avg_speed_kmh
       max_speed_kmh


### PR DESCRIPTION
## What changed

- request `total_strokes` in Garmin list and detail queries
- display Total Strokes in the Cadence statistics card
- format counts with the browser runtime locale
- update generated GraphQL types and component tests
- add Playwright coverage for the deployed cadence values

## Why

Garmin Connect reports 1,793 total strokes for activity 23321402669, but the value was not available in the UI.

## Validation

- 207 tests passed
- lint, typecheck, and build passed
- locally verified Avg Cadence 61 rpm, Max Cadence 94 rpm, and Total Strokes 1,793

Refs #216