### PR TITLE
fix: open Stats tab in Garmin cadence Playwright test

### DIFF
--- a/e2e/garmin-total-strokes.spec.ts
+++ b/e2e/garmin-total-strokes.spec.ts
@@ -6,6 +6,7 @@ const ACTIVITY_ID =
 test.describe('Garmin cadence statistics', () => {
   test('shows cadence and total strokes for an activity', async ({ page }) => {
     await page.goto(`/garmin/${ACTIVITY_ID}`)
+    await page.getByRole('tab', { name: 'Stats' }).click()
 
     await expect(page.getByText('Cadence', { exact: true })).toBeVisible({
       timeout: 20_000,

--- a/e2e/garmin-total-strokes.spec.ts
+++ b/e2e/garmin-total-strokes.spec.ts
@@ -6,7 +6,7 @@ const ACTIVITY_ID =
 test.describe('Garmin cadence statistics', () => {
   test('shows cadence and total strokes for an activity', async ({ page }) => {
     await page.goto(`/garmin/${ACTIVITY_ID}`)
-    await page.getByRole('tab', { name: 'Stats' }).click()
+    await page.getByTestId('garmin-tab-stats').click()
 
     await expect(page.getByText('Cadence', { exact: true })).toBeVisible({
       timeout: 20_000,


### PR DESCRIPTION
## What changed

- select the Garmin activity Stats tab before asserting cadence statistics
- retain production assertions for Avg Cadence 61 rpm, Max Cadence 94 rpm, and Total Strokes 1,793

## Validation

- `BASE_URL=https://data-ui.lab.informationcart.com npx playwright test e2e/garmin-total-strokes.spec.ts --project=chromium` — 1 passed
- `npm run lint:all` — passed
- `npm run type-check` — passed

Refs #216
Follow-up to #217.