### PR TITLE
fix(garmin): count vigorous intensity minutes as 2x and show x2 badge

### DIFF
--- a/src/components/garmin/ActivityStatsPanel.test.tsx
+++ b/src/components/garmin/ActivityStatsPanel.test.tsx
@@ -85,4 +85,26 @@ describe('ActivityStatsPanel', () => {
     expect(screen.queryByText('34 min')).not.toBeInTheDocument()
     expect(screen.getByText('x2')).toBeInTheDocument()
   })
+
+  it('falls back to the stored total and hides the x2 badge when vigorous minutes are missing', () => {
+    render(
+      <ActivityStatsPanel
+        activity={{
+          distance_km: 10,
+          duration_seconds: 3661,
+          avg_heart_rate: 145,
+          moderate_intensity_minutes: 21,
+          // vigorous_intensity_minutes intentionally omitted.
+          total_intensity_minutes: 30,
+        }}
+      />,
+    )
+
+    expect(screen.getByText('Intensity Minutes')).toBeInTheDocument()
+    expect(screen.getByText('21 min')).toBeInTheDocument()
+    // Total falls back to the stored value when a component is missing.
+    expect(screen.getByText('30 min')).toBeInTheDocument()
+    // No x2 badge when vigorous minutes are absent.
+    expect(screen.queryByText('x2')).not.toBeInTheDocument()
+  })
 })

--- a/src/components/garmin/ActivityStatsPanel.test.tsx
+++ b/src/components/garmin/ActivityStatsPanel.test.tsx
@@ -61,4 +61,28 @@ describe('ActivityStatsPanel', () => {
     expect(screen.queryByText('Respiration')).not.toBeInTheDocument()
     expect(screen.queryByText('Intensity Minutes')).not.toBeInTheDocument()
   })
+
+  it('counts vigorous intensity minutes as 2x in the total and shows an x2 badge', () => {
+    render(
+      <ActivityStatsPanel
+        activity={{
+          distance_km: 10,
+          duration_seconds: 3661,
+          avg_heart_rate: 145,
+          moderate_intensity_minutes: 21,
+          vigorous_intensity_minutes: 13,
+          // Intentionally stale/incorrect stored total (naive 21 + 13).
+          total_intensity_minutes: 34,
+        }}
+      />,
+    )
+
+    expect(screen.getByText('Intensity Minutes')).toBeInTheDocument()
+    expect(screen.getByText('21 min')).toBeInTheDocument()
+    expect(screen.getByText('13 min')).toBeInTheDocument()
+    // Total is computed as 21 + 13 * 2 = 47, not the stale stored 34.
+    expect(screen.getByText('47 min')).toBeInTheDocument()
+    expect(screen.queryByText('34 min')).not.toBeInTheDocument()
+    expect(screen.getByText('x2')).toBeInTheDocument()
+  })
 })

--- a/src/components/garmin/ActivityStatsPanel.tsx
+++ b/src/components/garmin/ActivityStatsPanel.tsx
@@ -49,6 +49,7 @@ interface ActivityStatsPanelProps {
 interface StatRow {
   label: string
   value: string
+  badge?: string
 }
 
 interface StatSection {
@@ -294,13 +295,25 @@ export function ActivityStatsPanel({ activity: a }: ActivityStatsPanelProps) {
                   a.vigorous_intensity_minutes != null
                     ? `${a.vigorous_intensity_minutes} min`
                     : '—',
+                badge: 'x2',
               },
               {
                 label: 'Total',
-                value:
-                  a.total_intensity_minutes != null
+                value: (() => {
+                  // Garmin counts vigorous intensity minutes as 2x toward the
+                  // total. Compute it from the components when both are present
+                  // (self-consistent with the displayed values); otherwise fall
+                  // back to the stored total.
+                  if (
+                    a.moderate_intensity_minutes != null &&
+                    a.vigorous_intensity_minutes != null
+                  ) {
+                    return `${a.moderate_intensity_minutes + a.vigorous_intensity_minutes * 2} min`
+                  }
+                  return a.total_intensity_minutes != null
                     ? `${a.total_intensity_minutes} min`
-                    : '—',
+                    : '—'
+                })(),
               },
             ],
           } satisfies StatSection,
@@ -340,7 +353,14 @@ export function ActivityStatsPanel({ activity: a }: ActivityStatsPanelProps) {
             {section.rows.map((row, i) => (
               <div key={i} className="flex justify-between text-sm">
                 <span className="text-muted-foreground">{row.label}</span>
-                <span className="font-medium">{row.value}</span>
+                <span className="flex items-center gap-1.5 font-medium">
+                  {row.value}
+                  {row.badge && (
+                    <span className="rounded-full bg-muted px-1.5 py-0.5 text-[10px] font-semibold leading-none text-muted-foreground">
+                      {row.badge}
+                    </span>
+                  )}
+                </span>
               </div>
             ))}
           </CardContent>

--- a/src/components/garmin/ActivityStatsPanel.tsx
+++ b/src/components/garmin/ActivityStatsPanel.tsx
@@ -295,7 +295,10 @@ export function ActivityStatsPanel({ activity: a }: ActivityStatsPanelProps) {
                   a.vigorous_intensity_minutes != null
                     ? `${a.vigorous_intensity_minutes} min`
                     : '—',
-                badge: 'x2',
+                // Only show the x2 multiplier badge when a value is present.
+                ...(a.vigorous_intensity_minutes != null
+                  ? { badge: 'x2' }
+                  : {}),
               },
               {
                 label: 'Total',


### PR DESCRIPTION
Refs #220

## Summary
The Garmin activity detail **Intensity Minutes** card showed an incorrect **Total**. Garmin counts **vigorous** minutes as **2x** (`total = moderate + vigorous * 2`) and shows an `x2` badge. Activity `23321402669` showed `34 min` instead of `47 min`.

## Changes
- `ActivityStatsPanel.tsx`: Total now computes `moderate + vigorous * 2` from the displayed components, falling back to the stored total only when a component is missing. Added an `x2` badge to the Vigorous row.
- Added a component test (21 + 13*2 = 47, badge renders).

## Validation
- type-check, ESLint, Prettier, cspell clean.
- Vitest: ActivityStatsPanel suite passes (3/3).
- Production build succeeds.

## Related
- Source fix: otel-agents #121
- DB backfill: homelab-database-migrations #48