### PR TITLE
ci: allow test/* and codex/* PR source branches

### DIFF
--- a/.github/workflows/validate-pr-branch.yml
+++ b/.github/workflows/validate-pr-branch.yml
@@ -21,7 +21,7 @@ jobs:
           echo "Target branch: ${{ github.base_ref }}"
 
           # Check if source branch matches allowed patterns
-          if [[ "$HEAD_REF" =~ ^(develop|feature/.+|fix/.+|update-.+|renovate/.+)$ ]]; then
+          if [[ "$HEAD_REF" =~ ^(develop|feature/.+|fix/.+|test/.+|codex/.+|update-.+|renovate/.+)$ ]]; then
             echo "✅ Valid source branch: $HEAD_REF"
             echo "PR is from an allowed branch - APPROVED"
           else
@@ -35,6 +35,8 @@ jobs:
             echo "  ✓ develop branch"
             echo "  ✓ feature/* branches"
             echo "  ✓ fix/* branches"
+            echo "  ✓ test/* branches"
+            echo "  ✓ codex/* branches"
             echo "  ✓ update-* branches (automated dependency updates)"
             echo "  ✓ renovate/* branches (Renovate dependency updates)"
             echo ""


### PR DESCRIPTION
Refs #226

## Summary
The `Validate PR Branch` workflow rejected PRs from `test/*` and `codex/*` branches (e.g. PR #225 from `test/224-hr-zone-ribbon-e2e`). This adds both prefixes to the allowed-source-branch regex and the help text.

## Change
`.github/workflows/validate-pr-branch.yml`:
- Regex now: `^(develop|feature/.+|fix/.+|test/.+|codex/.+|update-.+|renovate/.+)$`
- Help text lists test/* and codex/*.

## Note
After this merges, PR #225 (`test/*`) needs a rebase onto master (or a re-run after rebase) to pick up the updated workflow and pass the check.