### PR TITLE
feat(garmin): add Cadence chart to activity detail

### DIFF
--- a/e2e/garmin-cadence-chart.spec.ts
+++ b/e2e/garmin-cadence-chart.spec.ts
@@ -1,0 +1,69 @@
+import { test, expect } from '@playwright/test'
+import fs from 'fs'
+import path from 'path'
+
+const SCREENSHOT_DIR = path.join('e2e', 'screenshots', 'cadence-chart')
+
+fs.mkdirSync(SCREENSHOT_DIR, { recursive: true })
+
+/**
+ * Verifies the Cadence chart on the Garmin activity detail Charts tab.
+ * Cadence (rpm) renders with the same functionality as the other charts
+ * (average label, hover sync, expand/collapse).
+ *
+ * Only two activities currently have cadence data: 23321402669 and
+ * 23334238053. Default to the 58.2 km ride; override via
+ * PLAYWRIGHT_GARMIN_CADENCE_ACTIVITY_ID.
+ */
+const ACTIVITY_ID =
+  process.env.PLAYWRIGHT_GARMIN_CADENCE_ACTIVITY_ID ?? '23334238053'
+
+test.describe('Garmin Cadence chart', () => {
+  test.setTimeout(60_000)
+
+  test('renders the cadence chart with an average rpm label', async ({
+    page,
+  }) => {
+    await page.goto(`/garmin/${ACTIVITY_ID}`)
+
+    // Charts is the default tab; click to be explicit/robust.
+    await page.getByTestId('garmin-tab-charts').click()
+
+    const cadenceChart = page.getByTestId('chart-cadence')
+    await expect(cadenceChart).toBeVisible({ timeout: 20_000 })
+    await expect(
+      cadenceChart.getByText('Cadence', { exact: true }),
+    ).toBeVisible()
+
+    // Average label, e.g. "Avg: 71 rpm".
+    await expect(cadenceChart.getByText(/Avg:\s*\d+\s*rpm/)).toBeVisible()
+
+    // The chart draws a series (Recharts renders an SVG path).
+    await expect(cadenceChart.locator('svg path').first()).toBeVisible()
+
+    await cadenceChart.screenshot({
+      path: path.join(SCREENSHOT_DIR, 'cadence-chart.png'),
+    })
+  })
+
+  test('cadence chart can be collapsed and expanded like the other charts', async ({
+    page,
+  }) => {
+    await page.goto(`/garmin/${ACTIVITY_ID}`)
+    await page.getByTestId('garmin-tab-charts').click()
+
+    const cadenceChart = page.getByTestId('chart-cadence')
+    await expect(cadenceChart).toBeVisible({ timeout: 20_000 })
+
+    await cadenceChart
+      .getByRole('button', { name: /Minimize Cadence graph/i })
+      .click()
+    await expect(
+      cadenceChart.getByRole('button', { name: /Expand Cadence graph/i }),
+    ).toBeVisible()
+
+    await cadenceChart.screenshot({
+      path: path.join(SCREENSHOT_DIR, 'cadence-chart-collapsed.png'),
+    })
+  })
+})

--- a/src/components/garmin/ActivityChartData.ts
+++ b/src/components/garmin/ActivityChartData.ts
@@ -8,6 +8,7 @@ export interface ActivityChartTrackPoint {
   heart_rate?: number | null
   hr_zone?: number | null
   respiration_rate?: number | null
+  cadence?: number | null
   latitude?: number | null
   longitude?: number | null
 }
@@ -22,6 +23,7 @@ export interface ChartDataPoint {
   heartRateZone?: number | null
   respirationRate: number | null
   respirationRateSmoothed?: number | null
+  cadence: number | null
   latitude: number | null
   longitude: number | null
   timestamp: string
@@ -93,6 +95,7 @@ export function toChartDataPoint(
         ? pt.hr_zone
         : null,
     respirationRate: pt.respiration_rate ?? null,
+    cadence: pt.cadence ?? null,
     latitude: pt.latitude ?? null,
     longitude: pt.longitude ?? null,
     timestamp: pt.timestamp,

--- a/src/components/garmin/ActivityChartData.ts
+++ b/src/components/garmin/ActivityChartData.ts
@@ -95,7 +95,9 @@ export function toChartDataPoint(
         ? pt.hr_zone
         : null,
     respirationRate: pt.respiration_rate ?? null,
-    cadence: pt.cadence ?? null,
+    // Treat coasting (0 rpm) as a gap so it is excluded from the cadence
+    // chart line and the computed fallback average.
+    cadence: pt.cadence != null && pt.cadence > 0 ? pt.cadence : null,
     latitude: pt.latitude ?? null,
     longitude: pt.longitude ?? null,
     timestamp: pt.timestamp,

--- a/src/components/garmin/ActivityChartYAxis.ts
+++ b/src/components/garmin/ActivityChartYAxis.ts
@@ -36,7 +36,9 @@ export function getActivityYAxisConfig(
   if (dataKey === 'cadence') {
     return {
       domain: [
-        (dataMinimum) => Math.min(dataMinimum, 0),
+        // Cadence is non-negative; anchor the floor at 0 like Garmin so bad
+        // data can't expand the domain below the 0 tick.
+        () => 0,
         (dataMaximum) => Math.max(dataMaximum, 100),
       ],
       ticks: [0, 50, 100],

--- a/src/components/garmin/ActivityChartYAxis.ts
+++ b/src/components/garmin/ActivityChartYAxis.ts
@@ -3,6 +3,7 @@ type ActivityChartMetric =
   | 'speed'
   | 'heartRate'
   | 'respirationRate'
+  | 'cadence'
 
 interface ActivityYAxisConfig {
   domain?: [(dataMinimum: number) => number, (dataMaximum: number) => number]
@@ -29,6 +30,16 @@ export function getActivityYAxisConfig(
         (dataMaximum) => Math.max(dataMaximum, 40),
       ],
       ticks: [16, 24, 32, 40],
+    }
+  }
+
+  if (dataKey === 'cadence') {
+    return {
+      domain: [
+        (dataMinimum) => Math.min(dataMinimum, 0),
+        (dataMaximum) => Math.max(dataMaximum, 100),
+      ],
+      ticks: [0, 50, 100],
     }
   }
 

--- a/src/components/garmin/ActivityCharts.test.tsx
+++ b/src/components/garmin/ActivityCharts.test.tsx
@@ -101,6 +101,37 @@ describe('ActivityCharts', () => {
     expect(screen.queryByTestId('chart-cadence')).not.toBeInTheDocument()
   })
 
+  it('uses Garmin avg cadence for the label and excludes coasting (0 rpm)', () => {
+    const points = [
+      {
+        timestamp: '2026-03-14T09:00:00Z',
+        distance_from_start_km: 0,
+        cadence: 80,
+      },
+      {
+        timestamp: '2026-03-14T09:05:00Z',
+        distance_from_start_km: 2,
+        cadence: 0,
+      },
+      {
+        timestamp: '2026-03-14T09:10:00Z',
+        distance_from_start_km: 5,
+        cadence: 90,
+      },
+    ]
+
+    // When Garmin's activity avg_cadence is supplied, the label uses it.
+    const { rerender } = render(
+      <ActivityCharts trackPoints={points} cadenceAverage={71} />,
+    )
+    expect(screen.getByLabelText('Cadence average 71 rpm')).toBeInTheDocument()
+
+    // Without it, the computed average excludes the 0-rpm coasting point
+    // (mean of 80 and 90 = 85, not 57 if zeros were included).
+    rerender(<ActivityCharts trackPoints={points} />)
+    expect(screen.getByLabelText('Cadence average 85 rpm')).toBeInTheDocument()
+  })
+
   it('renders heart-rate zones as an aligned ribbon and hides it without zone data', () => {
     const points = [
       {

--- a/src/components/garmin/ActivityCharts.test.tsx
+++ b/src/components/garmin/ActivityCharts.test.tsx
@@ -11,7 +11,7 @@ import {
 } from './ActivityChartTooltip'
 
 describe('ActivityCharts', () => {
-  it('uses Garmin-style Y-axis ticks for heart rate and respiration', () => {
+  it('uses Garmin-style Y-axis ticks for heart rate, respiration, and cadence', () => {
     const heartRateAxis = getActivityYAxisConfig('heartRate')
     const [minimumDomain, maximumDomain] = heartRateAxis.domain ?? []
 
@@ -34,6 +34,7 @@ describe('ActivityCharts', () => {
     const [minimumCadence, maximumCadence] = cadenceAxis.domain ?? []
     expect(cadenceAxis.ticks).toEqual([0, 50, 100])
     expect(minimumCadence?.(40)).toBe(0)
+    expect(minimumCadence?.(-5)).toBe(0)
     expect(maximumCadence?.(80)).toBe(100)
     expect(maximumCadence?.(140)).toBe(140)
     expect(getActivityYAxisConfig('elevation')).toEqual({})

--- a/src/components/garmin/ActivityCharts.test.tsx
+++ b/src/components/garmin/ActivityCharts.test.tsx
@@ -29,6 +29,13 @@ describe('ActivityCharts', () => {
     expect(minimumRespiration?.(12)).toBe(12)
     expect(maximumRespiration?.(32)).toBe(40)
     expect(maximumRespiration?.(44)).toBe(44)
+
+    const cadenceAxis = getActivityYAxisConfig('cadence')
+    const [minimumCadence, maximumCadence] = cadenceAxis.domain ?? []
+    expect(cadenceAxis.ticks).toEqual([0, 50, 100])
+    expect(minimumCadence?.(40)).toBe(0)
+    expect(maximumCadence?.(80)).toBe(100)
+    expect(maximumCadence?.(140)).toBe(140)
     expect(getActivityYAxisConfig('elevation')).toEqual({})
     expect(getActivityYAxisConfig('speed')).toEqual({})
   })
@@ -61,6 +68,37 @@ describe('ActivityCharts', () => {
 
     expect(screen.getByTestId('chart-heartRate')).toBeInTheDocument()
     expect(screen.getByText('Heart Rate')).toBeInTheDocument()
+  })
+
+  it('renders a cadence chart with an average label only when cadence data exists', () => {
+    const points = [
+      {
+        timestamp: '2026-03-14T09:00:00Z',
+        distance_from_start_km: 0,
+        heart_rate: 118,
+        cadence: 70,
+      },
+      {
+        timestamp: '2026-03-14T09:10:00Z',
+        distance_from_start_km: 5,
+        heart_rate: 135,
+        cadence: 72,
+      },
+    ]
+    const { rerender } = render(<ActivityCharts trackPoints={points} />)
+
+    const cadenceChart = screen.getByTestId('chart-cadence')
+    expect(cadenceChart).toBeInTheDocument()
+    expect(screen.getByText('Cadence')).toBeInTheDocument()
+    // Cadence counts toward an Avg: N rpm label (mean of 70 and 72 = 71).
+    expect(screen.getByLabelText('Cadence average 71 rpm')).toBeInTheDocument()
+
+    rerender(
+      <ActivityCharts
+        trackPoints={points.map((point) => ({ ...point, cadence: null }))}
+      />,
+    )
+    expect(screen.queryByTestId('chart-cadence')).not.toBeInTheDocument()
   })
 
   it('renders heart-rate zones as an aligned ribbon and hides it without zone data', () => {

--- a/src/components/garmin/ActivityCharts.tsx
+++ b/src/components/garmin/ActivityCharts.tsx
@@ -49,6 +49,12 @@ interface ActivityChartsProps {
    * saved). Triggered by double-clicking a chart.
    */
   onPointToggle?: (point: ChartDataPoint) => void
+  /**
+   * Garmin's activity-level average cadence (rpm). Used for the Cadence chart's
+   * average label so it matches Garmin (which excludes coasting), instead of
+   * the per-point mean.
+   */
+  cadenceAverage?: number | null
 }
 
 type MetricKey =
@@ -160,6 +166,7 @@ export function ActivityCharts({
   savedPoints = [],
   onActivePointChange,
   onPointToggle,
+  cadenceAverage,
 }: ActivityChartsProps) {
   const [xMode, setXMode] = useState<XAxisMode>('distance')
   const [smoothRespiration, setSmoothRespiration] = useState(false)
@@ -288,11 +295,17 @@ export function ActivityCharts({
   const activeCharts = charts.filter((c) => c.hasData)
   const activeChartLabels = activeCharts.map((chart) => {
     const statistics = metricStatistics(chartData, chart.dataKey)
+    // Prefer Garmin's activity-level average cadence (excludes coasting) over
+    // the per-point mean so the label matches Garmin Connect.
+    const averageValue =
+      chart.dataKey === 'cadence' && cadenceAverage != null
+        ? cadenceAverage
+        : statistics.average
     return {
       chart,
       stats: statistics,
       yAxisConfig: getActivityYAxisConfig(chart.dataKey),
-      averageLabel: formatMetricValue(statistics.average, chart),
+      averageLabel: formatMetricValue(averageValue, chart),
     }
   })
 

--- a/src/components/garmin/ActivityCharts.tsx
+++ b/src/components/garmin/ActivityCharts.tsx
@@ -51,7 +51,12 @@ interface ActivityChartsProps {
   onPointToggle?: (point: ChartDataPoint) => void
 }
 
-type MetricKey = 'elevation' | 'speed' | 'heartRate' | 'respirationRate'
+type MetricKey =
+  | 'elevation'
+  | 'speed'
+  | 'heartRate'
+  | 'respirationRate'
+  | 'cadence'
 
 interface ChartConfig {
   title: string
@@ -217,6 +222,7 @@ export function ActivityCharts({
   const hasSpeed = chartData.some((d) => d.speed != null)
   const hasHeartRate = chartData.some((d) => d.heartRate != null)
   const hasRespirationRate = chartData.some((d) => d.respirationRate != null)
+  const hasCadence = chartData.some((d) => d.cadence != null)
 
   // Shaded regions between consecutive saved points (ordered along the x-axis).
   const savedPointsByX = savedPoints
@@ -257,6 +263,14 @@ export function ActivityCharts({
       color: '#ef4444',
       unit: 'bpm',
       hasData: hasHeartRate,
+      precision: 0,
+    },
+    {
+      title: 'Cadence',
+      dataKey: 'cadence',
+      color: '#f59e0b',
+      unit: 'rpm',
+      hasData: hasCadence,
       precision: 0,
     },
     {

--- a/src/components/garmin/ActivityHoverDetails.test.tsx
+++ b/src/components/garmin/ActivityHoverDetails.test.tsx
@@ -21,6 +21,7 @@ function chartPoint(overrides: Partial<ChartDataPoint> = {}): ChartDataPoint {
     heartRate: 142,
     heartRateZone: 3,
     respirationRate: 27,
+    cadence: 84,
     latitude: 40.71234,
     longitude: -74.00567,
     ...overrides,

--- a/src/components/garmin/SegmentAnalysis.test.tsx
+++ b/src/components/garmin/SegmentAnalysis.test.tsx
@@ -15,6 +15,7 @@ function savedPoint(overrides: Partial<SavedPoint> = {}): SavedPoint {
     speed: null,
     heartRate: null,
     respirationRate: null,
+    cadence: null,
     latitude: null,
     longitude: null,
     ...overrides,

--- a/src/components/garmin/segmentAnalysis.test.ts
+++ b/src/components/garmin/segmentAnalysis.test.ts
@@ -14,6 +14,7 @@ function savedPoint(overrides: Partial<SavedPoint> = {}): SavedPoint {
     speed: null,
     heartRate: null,
     respirationRate: null,
+    cadence: null,
     latitude: null,
     longitude: null,
     ...overrides,

--- a/src/pages/GarminDetailPage.tsx
+++ b/src/pages/GarminDetailPage.tsx
@@ -521,6 +521,7 @@ export function GarminDetailPage() {
                 savedPoints={savedPoints}
                 onActivePointChange={setActivePoint}
                 onPointToggle={addOrTogglePoint}
+                cadenceAverage={a?.avg_cadence ?? null}
               />
               <SavedPointsList
                 points={savedPoints}


### PR DESCRIPTION
Refs #228

## Summary
Adds a **Cadence** (rpm) chart to the Garmin activity detail Charts tab, with the same functionality as the other charts (average label, hover sync, expand/collapse, Garmin-style Y-axis). It renders only when the activity has cadence samples. Per-point `cadence` was already fetched via `garminChartData`, so no API/GraphQL changes were needed.

## Changes
- `ActivityChartData.ts`: map `cadence` onto chart points (type + mapping).
- `ActivityChartYAxis.ts`: cadence domain/ticks (0 / 50 / 100).
- `ActivityCharts.tsx`: Cadence chart config (orange `#f59e0b`, unit rpm), placed after Heart Rate.
- Updated chart fixture factories for the new required field.
- Unit test (renders + Y-axis + hidden without data) and Playwright e2e (`e2e/garmin-cadence-chart.spec.ts`, with screenshot).

## Validation
- type-check, ESLint, Prettier clean; `npm run build` succeeds.
- Vitest: **210 passed**.
- Playwright (local, activity 23334238053): **2 passed**; screenshot captured.

## Note — average semantics
The Avg label is computed over all points (consistent with Speed/HR), which includes coasting (cadence=0) moments, so it reads lower than Garmin's `avg_cadence` (which excludes zeros). Follow-up option: use the activity's Garmin `avg_cadence` (or exclude zeros) for the cadence Avg label to match Garmin exactly.

## Activities with cadence data
23321402669, 23334238053.