### PR TITLE
feat(dashboard): add weekly Cycling In Focus card

### DIFF
--- a/e2e/cycling-in-focus.spec.ts
+++ b/e2e/cycling-in-focus.spec.ts
@@ -68,4 +68,32 @@ test.describe('Cycling In Focus card', () => {
       fullPage: true,
     })
   })
+
+  test('chart tooltip matches the heatmap popover style', async ({ page }) => {
+    const prefix = `cycling-in-focus-${test.info().project.name}`
+
+    const card = page.locator('[data-testid="cycling-in-focus-card"]')
+    await expect(card).toBeVisible({ timeout: 15_000 })
+
+    // Hover a chart bar to surface the Recharts tooltip.
+    const bar = card.locator('.recharts-bar-rectangle').first()
+    await expect(bar).toBeVisible()
+    await bar.hover({ force: true })
+
+    // Tooltip should use the heatmap day-popover layout: a date header plus a
+    // Sport / Distance / Duration table.
+    const tooltip = card.locator('.recharts-tooltip-wrapper')
+    await expect(tooltip).toBeVisible()
+    await expect(tooltip.getByText('Sport')).toBeVisible()
+    await expect(tooltip.getByText('Distance')).toBeVisible()
+    await expect(tooltip.getByText('Duration')).toBeVisible()
+    await expect(tooltip.getByText('Cycling')).toBeVisible()
+    await expect(
+      tooltip.getByText(/^\w{3}, \w{3} \d{1,2}, \d{4}$/),
+    ).toBeVisible()
+
+    await card.screenshot({
+      path: path.join(SCREENSHOT_DIR, `${prefix}-03-tooltip.png`),
+    })
+  })
 })

--- a/e2e/cycling-in-focus.spec.ts
+++ b/e2e/cycling-in-focus.spec.ts
@@ -1,0 +1,71 @@
+import { test, expect } from '@playwright/test'
+import fs from 'fs'
+import path from 'path'
+
+const SCREENSHOT_DIR = path.join('e2e', 'screenshots', 'cycling-in-focus')
+
+fs.mkdirSync(SCREENSHOT_DIR, { recursive: true })
+
+/**
+ * Validates the "Cycling In Focus" dashboard card layout:
+ * - The last-4-weeks activity strip renders all dots on a single row.
+ * - The "Last 4w" label sits BELOW the dots (not beside them).
+ *
+ * Screenshots are saved to e2e/screenshots/cycling-in-focus/ for review.
+ */
+test.describe('Cycling In Focus card', () => {
+  test.setTimeout(60_000)
+
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/', { waitUntil: 'domcontentloaded' })
+    await expect(page.getByText('Total Locations')).toBeVisible({
+      timeout: 30_000,
+    })
+  })
+
+  test('activity dots render on one line with the label below', async ({
+    page,
+  }) => {
+    const prefix = `cycling-in-focus-${test.info().project.name}`
+
+    const card = page.locator('[data-testid="cycling-in-focus-card"]')
+    await expect(card).toBeVisible({ timeout: 15_000 })
+
+    const strip = card.locator('[data-testid="in-focus-activity-strip"]')
+    await expect(strip).toBeVisible()
+
+    // The strip should render one dot per day across the last 4 weeks (28).
+    const dots = strip.locator('span')
+    await expect(dots).toHaveCount(28)
+
+    // All dots must sit on the same horizontal line: every dot shares the
+    // same top coordinate as the first dot (within a 2px tolerance).
+    const count = await dots.count()
+    const firstBox = await dots.first().boundingBox()
+    expect(firstBox).not.toBeNull()
+    for (let i = 1; i < count; i += 1) {
+      const box = await dots.nth(i).boundingBox()
+      expect(box).not.toBeNull()
+      expect(Math.abs((box?.y ?? 0) - (firstBox?.y ?? 0))).toBeLessThan(2)
+    }
+
+    // The "Last 4w" label must be positioned BELOW the dots.
+    const label = card.getByText(/Last 4w/)
+    await expect(label).toBeVisible()
+    const stripBox = await strip.boundingBox()
+    const labelBox = await label.boundingBox()
+    expect(stripBox).not.toBeNull()
+    expect(labelBox).not.toBeNull()
+    expect(labelBox?.y ?? 0).toBeGreaterThanOrEqual(
+      (stripBox?.y ?? 0) + (stripBox?.height ?? 0) - 1,
+    )
+
+    await card.screenshot({
+      path: path.join(SCREENSHOT_DIR, `${prefix}-01-card.png`),
+    })
+    await page.screenshot({
+      path: path.join(SCREENSHOT_DIR, `${prefix}-02-dashboard.png`),
+      fullPage: true,
+    })
+  })
+})

--- a/src/components/dashboard/CyclingInFocus.test.tsx
+++ b/src/components/dashboard/CyclingInFocus.test.tsx
@@ -1,0 +1,172 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Freeze the clock so the default trailing 7-day window is deterministic.
+// 2026-06-23 is a Tuesday => window is Jun 17 (Wed) .. Jun 23 (Tue).
+const FROZEN_NOW = new Date('2026-06-23T12:00:00Z')
+
+let latestBarChartData: Array<Record<string, unknown>> = []
+
+const hooks = vi.hoisted(() => ({
+  useGarminActivitiesQuery: vi.fn(),
+}))
+
+vi.mock('@/__generated__/graphql', () => hooks)
+
+// Keep Recharts lightweight and expose BarChart data for assertions.
+vi.mock('recharts', () => ({
+  ResponsiveContainer: ({ children }: { children: React.ReactNode }) => (
+    <div style={{ width: 800, height: 200 }}>{children}</div>
+  ),
+  BarChart: ({
+    data,
+    children,
+  }: {
+    data?: Array<Record<string, unknown>>
+    children?: React.ReactNode
+  }) => {
+    latestBarChartData = data ?? []
+    return <div data-testid="bar-chart">{children}</div>
+  },
+  Bar: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+  Cell: () => null,
+  XAxis: () => null,
+  Tooltip: () => null,
+}))
+
+import { CyclingInFocus } from './CyclingInFocus'
+
+const SAMPLE_ITEMS = [
+  {
+    activity_id: 'a1',
+    sport: 'cycling',
+    start_time: '2026-06-18T08:00:00',
+    distance_km: 50,
+    duration_seconds: 3600,
+  },
+  {
+    activity_id: 'a2',
+    sport: 'cycling',
+    start_time: '2026-06-20T08:00:00',
+    distance_km: 50,
+    duration_seconds: 7200,
+  },
+]
+
+function mockActivities(items: typeof SAMPLE_ITEMS) {
+  hooks.useGarminActivitiesQuery.mockReturnValue({
+    data: { garminActivities: { items, total: items.length } },
+    loading: false,
+    error: undefined,
+    refetch: vi.fn(),
+  })
+}
+
+describe('CyclingInFocus', () => {
+  beforeEach(() => {
+    vi.useFakeTimers({
+      now: FROZEN_NOW,
+      shouldAdvanceTime: true,
+      toFake: ['Date'],
+    })
+    latestBarChartData = []
+    hooks.useGarminActivitiesQuery.mockReset()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('queries cycling activities for the current trailing week', () => {
+    mockActivities(SAMPLE_ITEMS)
+
+    render(<CyclingInFocus />)
+
+    expect(hooks.useGarminActivitiesQuery).toHaveBeenCalledWith(
+      expect.objectContaining({
+        variables: expect.objectContaining({
+          sport: 'cycling',
+          date_from: '2026-06-17',
+          date_to: '2026-06-23',
+        }),
+      }),
+    )
+    expect(screen.getByTestId('in-focus-week-range')).toHaveTextContent(
+      'Jun 17 – Jun 23',
+    )
+  })
+
+  it('aggregates distance (mi) and total time across the week', () => {
+    mockActivities(SAMPLE_ITEMS)
+
+    render(<CyclingInFocus />)
+
+    // 100 km total => 62.14 mi
+    expect(screen.getByTestId('in-focus-total-distance')).toHaveTextContent(
+      '62.14',
+    )
+    // 3600 + 7200 = 10800s => 3:00:00
+    expect(screen.getByText('3:00:00')).toBeInTheDocument()
+    expect(screen.getByText('2 rides this week')).toBeInTheDocument()
+  })
+
+  it('builds seven daily buckets with weekday initials and per-day distance', () => {
+    mockActivities(SAMPLE_ITEMS)
+
+    render(<CyclingInFocus />)
+
+    expect(latestBarChartData).toHaveLength(7)
+    expect(latestBarChartData.map((d) => d.label)).toEqual([
+      'W',
+      'T',
+      'F',
+      'S',
+      'S',
+      'M',
+      'T',
+    ])
+    const jun18 = latestBarChartData.find((d) => d.key === '2026-06-18')
+    expect(jun18?.distance_mi).toBeCloseTo(31.07, 1)
+  })
+
+  it('navigates to the previous week and re-queries', async () => {
+    const user = userEvent.setup()
+    mockActivities(SAMPLE_ITEMS)
+
+    render(<CyclingInFocus />)
+
+    await user.click(screen.getByRole('button', { name: 'Previous week' }))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('in-focus-week-range')).toHaveTextContent(
+        'Jun 10 – Jun 16',
+      )
+    })
+    expect(hooks.useGarminActivitiesQuery).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        variables: expect.objectContaining({
+          date_from: '2026-06-10',
+          date_to: '2026-06-16',
+        }),
+      }),
+    )
+  })
+
+  it('renders an error state with a retry action', async () => {
+    const user = userEvent.setup()
+    const refetch = vi.fn()
+    hooks.useGarminActivitiesQuery.mockReturnValue({
+      data: undefined,
+      loading: false,
+      error: new Error('activities failed'),
+      refetch,
+    })
+
+    render(<CyclingInFocus />)
+
+    expect(screen.getByText('activities failed')).toBeInTheDocument()
+    await user.click(screen.getByRole('button', { name: 'Retry' }))
+    expect(refetch).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/components/dashboard/CyclingInFocus.test.tsx
+++ b/src/components/dashboard/CyclingInFocus.test.tsx
@@ -108,7 +108,7 @@ describe('CyclingInFocus', () => {
     )
     // 3600 + 7200 = 10800s => 3:00:00
     expect(screen.getByText('3:00:00')).toBeInTheDocument()
-    expect(screen.getByText('2 rides this week')).toBeInTheDocument()
+    expect(screen.getByText('Last 4w · 2 rides')).toBeInTheDocument()
   })
 
   it('builds seven daily buckets with weekday initials and per-day distance', () => {

--- a/src/components/dashboard/CyclingInFocus.test.tsx
+++ b/src/components/dashboard/CyclingInFocus.test.tsx
@@ -169,4 +169,22 @@ describe('CyclingInFocus', () => {
     await user.click(screen.getByRole('button', { name: 'Retry' }))
     expect(refetch).toHaveBeenCalledTimes(1)
   })
+
+  it('disables the Next week arrow on the current week and re-enables it after paging back', async () => {
+    const user = userEvent.setup()
+    mockActivities(SAMPLE_ITEMS)
+
+    render(<CyclingInFocus />)
+
+    const nextButton = screen.getByRole('button', { name: 'Next week' })
+    expect(nextButton).toBeDisabled()
+
+    await user.click(screen.getByRole('button', { name: 'Previous week' }))
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole('button', { name: 'Next week' }),
+      ).not.toBeDisabled()
+    })
+  })
 })

--- a/src/components/dashboard/CyclingInFocus.tsx
+++ b/src/components/dashboard/CyclingInFocus.tsx
@@ -13,7 +13,7 @@ import { useGarminActivitiesQuery } from '@/__generated__/graphql'
 import { Card, CardContent } from '@/components/ui/card'
 import { ErrorState } from '@/components/shared/ErrorState'
 import { cn } from '@/lib/utils'
-import { formatDuration, kmToMi } from '@/lib/units'
+import { formatDuration, formatDurationShort, kmToMi } from '@/lib/units'
 
 const SPORT = 'cycling'
 const BAR_COLOR = '#2563eb'
@@ -31,6 +31,70 @@ interface DayBucket {
   label: string
   /** Total distance for the day, in miles. */
   distance_mi: number
+  /** Total moving time for the day, in seconds. */
+  duration_seconds: number
+  /** Number of rides completed that day. */
+  count: number
+}
+
+// Recharts tooltip styled to match the Garmin Activity heatmap day popover.
+function ActivityTooltip({
+  active,
+  payload,
+}: {
+  active?: boolean
+  payload?: Array<{ payload: DayBucket }>
+}) {
+  const day = payload?.[0]?.payload
+  if (!active || !day) return null
+
+  const formattedDate = format(
+    new Date(`${day.key}T00:00:00`),
+    'EEE, MMM d, yyyy',
+  )
+
+  return (
+    <div className="overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-md">
+      <div className="border-b px-3 py-1.5">
+        <p className="text-xs font-semibold">{formattedDate}</p>
+        <p className="text-[11px] text-muted-foreground">
+          {day.count} {day.count === 1 ? 'activity' : 'activities'}
+        </p>
+      </div>
+      {day.count > 0 ? (
+        <table className="w-full text-xs">
+          <thead>
+            <tr className="border-b">
+              <th className="px-3 py-1 text-left font-medium text-muted-foreground">
+                Sport
+              </th>
+              <th className="px-2 py-1 text-right font-medium text-muted-foreground">
+                Distance
+              </th>
+              <th className="px-3 py-1 text-right font-medium text-muted-foreground">
+                Duration
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td className="px-3 py-1">Cycling</td>
+              <td className="px-2 py-1 text-right tabular-nums">
+                {day.distance_mi.toFixed(2)} mi
+              </td>
+              <td className="px-3 py-1 text-right tabular-nums">
+                {formatDurationShort(day.duration_seconds)}
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      ) : (
+        <p className="px-3 py-2 text-[11px] text-muted-foreground">
+          No activities.
+        </p>
+      )}
+    </div>
+  )
 }
 
 export function CyclingInFocus() {
@@ -73,6 +137,8 @@ export function CyclingInFocus() {
         key: format(day, 'yyyy-MM-dd'),
         label: DAY_INITIALS[day.getDay()],
         distance_mi: 0,
+        duration_seconds: 0,
+        count: 0,
       })
     }
     const byKey = new Map(buckets.map((bucket) => [bucket.key, bucket]))
@@ -84,9 +150,12 @@ export function CyclingInFocus() {
       const bucket = byKey.get(activity.start_time.slice(0, 10))
       if (!bucket) continue
       const km = activity.distance_km ?? 0
+      const dur = activity.duration_seconds ?? 0
       bucket.distance_mi += kmToMi(km)
+      bucket.duration_seconds += dur
+      bucket.count += 1
       totalKm += km
-      seconds += activity.duration_seconds ?? 0
+      seconds += dur
     }
 
     return {
@@ -199,11 +268,7 @@ export function CyclingInFocus() {
                   />
                   <Tooltip
                     cursor={{ fill: 'transparent' }}
-                    formatter={(value) => {
-                      const num =
-                        typeof value === 'number' ? value : Number(value)
-                      return [`${num.toFixed(2)} mi`, 'Distance']
-                    }}
+                    content={<ActivityTooltip />}
                   />
                   <Bar dataKey="distance_mi" radius={[4, 4, 0, 0]}>
                     {days.map((day) => (

--- a/src/components/dashboard/CyclingInFocus.tsx
+++ b/src/components/dashboard/CyclingInFocus.tsx
@@ -99,10 +99,7 @@ export function CyclingInFocus() {
   )
 
   return (
-    <Card
-      data-testid="cycling-in-focus-card"
-      className="border-slate-200 bg-white text-slate-900 shadow-sm"
-    >
+    <Card data-testid="cycling-in-focus-card">
       <CardContent className="space-y-3 p-4">
         {error ? (
           <ErrorState message={error.message} onRetry={() => refetch()} />
@@ -114,7 +111,7 @@ export function CyclingInFocus() {
                 Cycling
                 <span
                   data-testid="in-focus-week-range"
-                  className="font-normal text-slate-500"
+                  className="font-normal text-muted-foreground"
                 >
                   · {weekRangeLabel}
                 </span>
@@ -126,7 +123,7 @@ export function CyclingInFocus() {
                 <button
                   type="button"
                   aria-label="Previous week"
-                  className="rounded-full p-1 text-slate-500 hover:bg-slate-100 hover:text-slate-900"
+                  className="rounded-full p-1 text-muted-foreground hover:bg-muted hover:text-foreground"
                   onClick={() => setWeekEnd((d) => subDays(d, 7))}
                 >
                   <ChevronLeft className="h-4 w-4" />
@@ -134,7 +131,8 @@ export function CyclingInFocus() {
                 <button
                   type="button"
                   aria-label="Next week"
-                  className="rounded-full p-1 text-slate-500 hover:bg-slate-100 hover:text-slate-900"
+                  disabled={weekOffset <= 0}
+                  className="rounded-full p-1 text-muted-foreground hover:bg-muted hover:text-foreground disabled:pointer-events-none disabled:opacity-40"
                   onClick={() => setWeekEnd((d) => addDays(d, 7))}
                 >
                   <ChevronRight className="h-4 w-4" />
@@ -148,12 +146,12 @@ export function CyclingInFocus() {
                 className="text-3xl font-bold tabular-nums"
               >
                 {totalDistanceMi.toFixed(2)}
-                <span className="ml-1 text-base font-normal text-slate-500">
+                <span className="ml-1 text-base font-normal text-muted-foreground">
                   mi
                 </span>
               </span>
-              <span className="text-xs text-slate-500">
-                <span className="block font-semibold tabular-nums text-slate-900">
+              <span className="text-xs text-muted-foreground">
+                <span className="block font-semibold tabular-nums text-foreground">
                   {formatDuration(totalSeconds)}
                 </span>
                 Total Time
@@ -171,7 +169,7 @@ export function CyclingInFocus() {
                     tickLine={false}
                     axisLine={false}
                     interval={0}
-                    tick={{ fontSize: 11, fill: '#64748b' }}
+                    tick={{ fontSize: 11, fill: 'currentColor' }}
                   />
                   <Tooltip
                     cursor={{ fill: 'transparent' }}
@@ -194,7 +192,7 @@ export function CyclingInFocus() {
               </ResponsiveContainer>
             </div>
 
-            <div className="flex items-center justify-between border-t border-slate-200 pt-2">
+            <div className="flex items-center justify-between border-t pt-2">
               <div
                 className="flex items-center gap-1.5"
                 aria-label="Recent weeks"
@@ -217,14 +215,14 @@ export function CyclingInFocus() {
                       className={cn(
                         'h-2 w-2 rounded-full transition-colors',
                         active
-                          ? 'bg-slate-700'
-                          : 'bg-slate-300 hover:bg-slate-400',
+                          ? 'bg-foreground'
+                          : 'bg-muted-foreground/30 hover:bg-muted-foreground/60',
                       )}
                     />
                   )
                 })}
               </div>
-              <span className="text-xs text-slate-500">
+              <span className="text-xs text-muted-foreground">
                 {loading
                   ? 'Loading…'
                   : `Last 4w · ${activityCount} ${

--- a/src/components/dashboard/CyclingInFocus.tsx
+++ b/src/components/dashboard/CyclingInFocus.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState } from 'react'
-import { addDays, format, subDays } from 'date-fns'
+import { addDays, differenceInCalendarDays, format, subDays } from 'date-fns'
 import {
   Bar,
   BarChart,
@@ -10,14 +10,15 @@ import {
 } from 'recharts'
 import { Bike, ChevronLeft, ChevronRight } from 'lucide-react'
 import { useGarminActivitiesQuery } from '@/__generated__/graphql'
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
-import { Button } from '@/components/ui/button'
+import { Card, CardContent } from '@/components/ui/card'
 import { ErrorState } from '@/components/shared/ErrorState'
+import { cn } from '@/lib/utils'
 import { formatDuration, kmToMi } from '@/lib/units'
 
 const SPORT = 'cycling'
 const BAR_COLOR = '#2563eb'
 const ACTIVITY_LIMIT = 200
+const RECENT_WEEK_DOTS = 4
 
 // Weekday initial keyed by Date#getDay() (0 = Sunday).
 const DAY_INITIALS = ['S', 'M', 'T', 'W', 'T', 'F', 'S']
@@ -32,8 +33,11 @@ interface DayBucket {
 }
 
 export function CyclingInFocus() {
+  // `today` is fixed at mount so the "Last 4w" dots stay anchored to the
+  // current week regardless of how far the user pages back/forward.
+  const [today] = useState<Date>(() => new Date())
   // Anchor date for the trailing 7-day window. Defaults to today; Prev/Next
-  // pages by 7 days. Mirrors the weekly navigation in GarminActivityTotals.
+  // pages by 7 days.
   const [weekEnd, setWeekEnd] = useState<Date>(() => new Date())
   const weekStart = useMemo(() => subDays(weekEnd, 6), [weekEnd])
 
@@ -88,71 +92,75 @@ export function CyclingInFocus() {
     [weekStart, weekEnd],
   )
 
+  // How many whole weeks back from today the current window sits (0 = current).
+  const weekOffset = useMemo(
+    () => Math.round(differenceInCalendarDays(today, weekEnd) / 7),
+    [today, weekEnd],
+  )
+
   return (
-    <Card data-testid="cycling-in-focus-card">
-      <CardHeader className="space-y-2 pb-2">
-        <div className="flex items-center justify-between">
-          <CardTitle className="flex items-center gap-2 text-base">
-            <Bike className="h-4 w-4 text-green-600" />
-            Cycling
-            <span
-              data-testid="in-focus-week-range"
-              className="text-sm font-normal text-muted-foreground"
-            >
-              · {weekRangeLabel}
-            </span>
-          </CardTitle>
-          <div
-            className="inline-flex items-center gap-1"
-            aria-label="Week range navigation"
-          >
-            <Button
-              type="button"
-              variant="outline"
-              size="sm"
-              className="h-7 px-2"
-              aria-label="Previous week"
-              onClick={() => setWeekEnd((d) => subDays(d, 7))}
-            >
-              <ChevronLeft className="h-3.5 w-3.5" />
-            </Button>
-            <Button
-              type="button"
-              variant="outline"
-              size="sm"
-              className="h-7 px-2"
-              aria-label="Next week"
-              onClick={() => setWeekEnd((d) => addDays(d, 7))}
-            >
-              <ChevronRight className="h-3.5 w-3.5" />
-            </Button>
-          </div>
-        </div>
-      </CardHeader>
-      <CardContent>
+    <Card
+      data-testid="cycling-in-focus-card"
+      className="border-slate-200 bg-white text-slate-900 shadow-sm"
+    >
+      <CardContent className="space-y-3 p-4">
         {error ? (
           <ErrorState message={error.message} onRetry={() => refetch()} />
         ) : (
-          <div className="space-y-4">
-            <div className="flex items-baseline gap-4">
+          <>
+            <div className="flex items-start justify-between">
+              <div className="flex items-center gap-2 text-sm font-semibold">
+                <Bike className="h-4 w-4 text-green-600" />
+                Cycling
+                <span
+                  data-testid="in-focus-week-range"
+                  className="font-normal text-slate-500"
+                >
+                  · {weekRangeLabel}
+                </span>
+              </div>
+              <div
+                className="inline-flex items-center gap-1"
+                aria-label="Week range navigation"
+              >
+                <button
+                  type="button"
+                  aria-label="Previous week"
+                  className="rounded-full p-1 text-slate-500 hover:bg-slate-100 hover:text-slate-900"
+                  onClick={() => setWeekEnd((d) => subDays(d, 7))}
+                >
+                  <ChevronLeft className="h-4 w-4" />
+                </button>
+                <button
+                  type="button"
+                  aria-label="Next week"
+                  className="rounded-full p-1 text-slate-500 hover:bg-slate-100 hover:text-slate-900"
+                  onClick={() => setWeekEnd((d) => addDays(d, 7))}
+                >
+                  <ChevronRight className="h-4 w-4" />
+                </button>
+              </div>
+            </div>
+
+            <div className="flex items-baseline gap-3">
               <span
                 data-testid="in-focus-total-distance"
                 className="text-3xl font-bold tabular-nums"
               >
                 {totalDistanceMi.toFixed(2)}
-                <span className="ml-1 text-base font-normal text-muted-foreground">
+                <span className="ml-1 text-base font-normal text-slate-500">
                   mi
                 </span>
               </span>
-              <span className="text-sm text-muted-foreground">
-                <span className="font-medium tabular-nums text-foreground">
+              <span className="text-xs text-slate-500">
+                <span className="block font-semibold tabular-nums text-slate-900">
                   {formatDuration(totalSeconds)}
                 </span>
-                <span className="ml-1">Total Time</span>
+                Total Time
               </span>
             </div>
 
-            <div className="h-28 w-full">
+            <div className="h-24 w-full">
               <ResponsiveContainer width="100%" height="100%">
                 <BarChart
                   data={days}
@@ -163,12 +171,13 @@ export function CyclingInFocus() {
                     tickLine={false}
                     axisLine={false}
                     interval={0}
-                    tick={{ fontSize: 12, fill: 'currentColor' }}
+                    tick={{ fontSize: 11, fill: '#64748b' }}
                   />
                   <Tooltip
                     cursor={{ fill: 'transparent' }}
                     formatter={(value) => {
-                      const num = typeof value === 'number' ? value : Number(value)
+                      const num =
+                        typeof value === 'number' ? value : Number(value)
                       return [`${num.toFixed(2)} mi`, 'Distance']
                     }}
                   />
@@ -177,7 +186,7 @@ export function CyclingInFocus() {
                       <Cell
                         key={day.key}
                         fill={BAR_COLOR}
-                        fillOpacity={day.distance_mi > 0 ? 1 : 0.25}
+                        fillOpacity={day.distance_mi > 0 ? 1 : 0.2}
                       />
                     ))}
                   </Bar>
@@ -185,14 +194,45 @@ export function CyclingInFocus() {
               </ResponsiveContainer>
             </div>
 
-            <p className="text-xs text-muted-foreground">
-              {loading
-                ? 'Loading cycling activity…'
-                : `${activityCount} ${
-                    activityCount === 1 ? 'ride' : 'rides'
-                  } this week`}
-            </p>
-          </div>
+            <div className="flex items-center justify-between border-t border-slate-200 pt-2">
+              <div
+                className="flex items-center gap-1.5"
+                aria-label="Recent weeks"
+              >
+                {Array.from({ length: RECENT_WEEK_DOTS }).map((_, idx) => {
+                  // Dots run oldest → newest (left → right); newest = offset 0.
+                  const dotOffset = RECENT_WEEK_DOTS - 1 - idx
+                  const active = dotOffset === weekOffset
+                  return (
+                    <button
+                      key={dotOffset}
+                      type="button"
+                      aria-label={
+                        dotOffset === 0
+                          ? 'This week'
+                          : `${dotOffset} week${dotOffset > 1 ? 's' : ''} ago`
+                      }
+                      aria-current={active ? 'true' : undefined}
+                      onClick={() => setWeekEnd(subDays(today, dotOffset * 7))}
+                      className={cn(
+                        'h-2 w-2 rounded-full transition-colors',
+                        active
+                          ? 'bg-slate-700'
+                          : 'bg-slate-300 hover:bg-slate-400',
+                      )}
+                    />
+                  )
+                })}
+              </div>
+              <span className="text-xs text-slate-500">
+                {loading
+                  ? 'Loading…'
+                  : `Last 4w · ${activityCount} ${
+                      activityCount === 1 ? 'ride' : 'rides'
+                    }`}
+              </span>
+            </div>
+          </>
         )}
       </CardContent>
     </Card>

--- a/src/components/dashboard/CyclingInFocus.tsx
+++ b/src/components/dashboard/CyclingInFocus.tsx
@@ -18,7 +18,8 @@ import { formatDuration, kmToMi } from '@/lib/units'
 const SPORT = 'cycling'
 const BAR_COLOR = '#2563eb'
 const ACTIVITY_LIMIT = 200
-const RECENT_WEEK_DOTS = 4
+// One dot per day across the last 4 weeks (28 days).
+const RECENT_DAYS = 28
 
 // Weekday initial keyed by Date#getDay() (0 = Sunday).
 const DAY_INITIALS = ['S', 'M', 'T', 'W', 'T', 'F', 'S']
@@ -33,13 +34,24 @@ interface DayBucket {
 }
 
 export function CyclingInFocus() {
-  // `today` is fixed at mount so the "Last 4w" dots stay anchored to the
-  // current week regardless of how far the user pages back/forward.
+  // `today` is fixed at mount so the "Last 4w" strip stays anchored to the
+  // current date regardless of how far the user pages back/forward.
   const [today] = useState<Date>(() => new Date())
   // Anchor date for the trailing 7-day window. Defaults to today; Prev/Next
   // pages by 7 days.
   const [weekEnd, setWeekEnd] = useState<Date>(() => new Date())
   const weekStart = useMemo(() => subDays(weekEnd, 6), [weekEnd])
+
+  // Trailing 4-week (28-day) window for the activity strip + ride count.
+  const recentStart = useMemo(() => subDays(today, RECENT_DAYS - 1), [today])
+  const { data: recentData } = useGarminActivitiesQuery({
+    variables: {
+      sport: SPORT,
+      date_from: format(recentStart, 'yyyy-MM-dd'),
+      date_to: format(today, 'yyyy-MM-dd'),
+      limit: ACTIVITY_LIMIT,
+    },
+  })
 
   const dateFrom = format(weekStart, 'yyyy-MM-dd')
   const dateTo = format(weekEnd, 'yyyy-MM-dd')
@@ -53,7 +65,7 @@ export function CyclingInFocus() {
     },
   })
 
-  const { days, totalDistanceMi, totalSeconds, activityCount } = useMemo(() => {
+  const { days, totalDistanceMi, totalSeconds } = useMemo(() => {
     const buckets: DayBucket[] = []
     for (let i = 0; i < 7; i += 1) {
       const day = addDays(weekStart, i)
@@ -67,7 +79,6 @@ export function CyclingInFocus() {
 
     let totalKm = 0
     let seconds = 0
-    let count = 0
     for (const activity of data?.garminActivities?.items ?? []) {
       if (!activity.start_time) continue
       const bucket = byKey.get(activity.start_time.slice(0, 10))
@@ -76,14 +87,12 @@ export function CyclingInFocus() {
       bucket.distance_mi += kmToMi(km)
       totalKm += km
       seconds += activity.duration_seconds ?? 0
-      count += 1
     }
 
     return {
       days: buckets,
       totalDistanceMi: kmToMi(totalKm),
       totalSeconds: seconds,
-      activityCount: count,
     }
   }, [data, weekStart])
 
@@ -97,6 +106,23 @@ export function CyclingInFocus() {
     () => Math.round(differenceInCalendarDays(today, weekEnd) / 7),
     [today, weekEnd],
   )
+
+  // One dot per day across the last 4 weeks; filled when a ride was completed.
+  const { recentDays, recentRideCount } = useMemo(() => {
+    const activeDays = new Set<string>()
+    let count = 0
+    for (const activity of recentData?.garminActivities?.items ?? []) {
+      if (!activity.start_time) continue
+      activeDays.add(activity.start_time.slice(0, 10))
+      count += 1
+    }
+    const strip = Array.from({ length: RECENT_DAYS }).map((_, i) => {
+      const day = addDays(recentStart, i)
+      const key = format(day, 'yyyy-MM-dd')
+      return { key, active: activeDays.has(key) }
+    })
+    return { recentDays: strip, recentRideCount: count }
+  }, [recentData, recentStart])
 
   return (
     <Card data-testid="cycling-in-focus-card">
@@ -140,17 +166,17 @@ export function CyclingInFocus() {
               </div>
             </div>
 
-            <div className="flex items-baseline gap-3">
+            <div className="flex items-start gap-3">
               <span
                 data-testid="in-focus-total-distance"
-                className="text-3xl font-bold tabular-nums"
+                className="text-3xl font-bold leading-none tabular-nums"
               >
                 {totalDistanceMi.toFixed(2)}
                 <span className="ml-1 text-base font-normal text-muted-foreground">
                   mi
                 </span>
               </span>
-              <span className="text-xs text-muted-foreground">
+              <span className="text-xs leading-tight text-muted-foreground">
                 <span className="block font-semibold tabular-nums text-foreground">
                   {formatDuration(totalSeconds)}
                 </span>
@@ -194,39 +220,26 @@ export function CyclingInFocus() {
 
             <div className="flex items-center justify-between border-t pt-2">
               <div
-                className="flex items-center gap-1.5"
-                aria-label="Recent weeks"
+                className="flex flex-1 flex-wrap items-center gap-1"
+                aria-label={`${recentRideCount} ride${
+                  recentRideCount === 1 ? '' : 's'
+                } in the last 4 weeks`}
               >
-                {Array.from({ length: RECENT_WEEK_DOTS }).map((_, idx) => {
-                  // Dots run oldest → newest (left → right); newest = offset 0.
-                  const dotOffset = RECENT_WEEK_DOTS - 1 - idx
-                  const active = dotOffset === weekOffset
-                  return (
-                    <button
-                      key={dotOffset}
-                      type="button"
-                      aria-label={
-                        dotOffset === 0
-                          ? 'This week'
-                          : `${dotOffset} week${dotOffset > 1 ? 's' : ''} ago`
-                      }
-                      aria-current={active ? 'true' : undefined}
-                      onClick={() => setWeekEnd(subDays(today, dotOffset * 7))}
-                      className={cn(
-                        'h-2 w-2 rounded-full transition-colors',
-                        active
-                          ? 'bg-foreground'
-                          : 'bg-muted-foreground/30 hover:bg-muted-foreground/60',
-                      )}
-                    />
-                  )
-                })}
+                {recentDays.map((day) => (
+                  <span
+                    key={day.key}
+                    className={cn(
+                      'h-1.5 w-1.5 rounded-full',
+                      day.active ? 'bg-foreground' : 'bg-muted-foreground/25',
+                    )}
+                  />
+                ))}
               </div>
-              <span className="text-xs text-muted-foreground">
+              <span className="ml-2 shrink-0 text-xs text-muted-foreground">
                 {loading
                   ? 'Loading…'
-                  : `Last 4w · ${activityCount} ${
-                      activityCount === 1 ? 'ride' : 'rides'
+                  : `Last 4w · ${recentRideCount} ${
+                      recentRideCount === 1 ? 'ride' : 'rides'
                     }`}
               </span>
             </div>

--- a/src/components/dashboard/CyclingInFocus.tsx
+++ b/src/components/dashboard/CyclingInFocus.tsx
@@ -1,0 +1,200 @@
+import { useMemo, useState } from 'react'
+import { addDays, format, subDays } from 'date-fns'
+import {
+  Bar,
+  BarChart,
+  Cell,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+} from 'recharts'
+import { Bike, ChevronLeft, ChevronRight } from 'lucide-react'
+import { useGarminActivitiesQuery } from '@/__generated__/graphql'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import { ErrorState } from '@/components/shared/ErrorState'
+import { formatDuration, kmToMi } from '@/lib/units'
+
+const SPORT = 'cycling'
+const BAR_COLOR = '#2563eb'
+const ACTIVITY_LIMIT = 200
+
+// Weekday initial keyed by Date#getDay() (0 = Sunday).
+const DAY_INITIALS = ['S', 'M', 'T', 'W', 'T', 'F', 'S']
+
+interface DayBucket {
+  /** ISO day key (yyyy-MM-dd). */
+  key: string
+  /** Single-letter weekday label. */
+  label: string
+  /** Total distance for the day, in miles. */
+  distance_mi: number
+}
+
+export function CyclingInFocus() {
+  // Anchor date for the trailing 7-day window. Defaults to today; Prev/Next
+  // pages by 7 days. Mirrors the weekly navigation in GarminActivityTotals.
+  const [weekEnd, setWeekEnd] = useState<Date>(() => new Date())
+  const weekStart = useMemo(() => subDays(weekEnd, 6), [weekEnd])
+
+  const dateFrom = format(weekStart, 'yyyy-MM-dd')
+  const dateTo = format(weekEnd, 'yyyy-MM-dd')
+
+  const { data, loading, error, refetch } = useGarminActivitiesQuery({
+    variables: {
+      sport: SPORT,
+      date_from: dateFrom,
+      date_to: dateTo,
+      limit: ACTIVITY_LIMIT,
+    },
+  })
+
+  const { days, totalDistanceMi, totalSeconds, activityCount } = useMemo(() => {
+    const buckets: DayBucket[] = []
+    for (let i = 0; i < 7; i += 1) {
+      const day = addDays(weekStart, i)
+      buckets.push({
+        key: format(day, 'yyyy-MM-dd'),
+        label: DAY_INITIALS[day.getDay()],
+        distance_mi: 0,
+      })
+    }
+    const byKey = new Map(buckets.map((bucket) => [bucket.key, bucket]))
+
+    let totalKm = 0
+    let seconds = 0
+    let count = 0
+    for (const activity of data?.garminActivities?.items ?? []) {
+      if (!activity.start_time) continue
+      const bucket = byKey.get(activity.start_time.slice(0, 10))
+      if (!bucket) continue
+      const km = activity.distance_km ?? 0
+      bucket.distance_mi += kmToMi(km)
+      totalKm += km
+      seconds += activity.duration_seconds ?? 0
+      count += 1
+    }
+
+    return {
+      days: buckets,
+      totalDistanceMi: kmToMi(totalKm),
+      totalSeconds: seconds,
+      activityCount: count,
+    }
+  }, [data, weekStart])
+
+  const weekRangeLabel = useMemo(
+    () => `${format(weekStart, 'MMM d')} – ${format(weekEnd, 'MMM d')}`,
+    [weekStart, weekEnd],
+  )
+
+  return (
+    <Card data-testid="cycling-in-focus-card">
+      <CardHeader className="space-y-2 pb-2">
+        <div className="flex items-center justify-between">
+          <CardTitle className="flex items-center gap-2 text-base">
+            <Bike className="h-4 w-4 text-green-600" />
+            Cycling
+            <span
+              data-testid="in-focus-week-range"
+              className="text-sm font-normal text-muted-foreground"
+            >
+              · {weekRangeLabel}
+            </span>
+          </CardTitle>
+          <div
+            className="inline-flex items-center gap-1"
+            aria-label="Week range navigation"
+          >
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              className="h-7 px-2"
+              aria-label="Previous week"
+              onClick={() => setWeekEnd((d) => subDays(d, 7))}
+            >
+              <ChevronLeft className="h-3.5 w-3.5" />
+            </Button>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              className="h-7 px-2"
+              aria-label="Next week"
+              onClick={() => setWeekEnd((d) => addDays(d, 7))}
+            >
+              <ChevronRight className="h-3.5 w-3.5" />
+            </Button>
+          </div>
+        </div>
+      </CardHeader>
+      <CardContent>
+        {error ? (
+          <ErrorState message={error.message} onRetry={() => refetch()} />
+        ) : (
+          <div className="space-y-4">
+            <div className="flex items-baseline gap-4">
+              <span
+                data-testid="in-focus-total-distance"
+                className="text-3xl font-bold tabular-nums"
+              >
+                {totalDistanceMi.toFixed(2)}
+                <span className="ml-1 text-base font-normal text-muted-foreground">
+                  mi
+                </span>
+              </span>
+              <span className="text-sm text-muted-foreground">
+                <span className="font-medium tabular-nums text-foreground">
+                  {formatDuration(totalSeconds)}
+                </span>
+                <span className="ml-1">Total Time</span>
+              </span>
+            </div>
+
+            <div className="h-28 w-full">
+              <ResponsiveContainer width="100%" height="100%">
+                <BarChart
+                  data={days}
+                  margin={{ top: 4, right: 4, bottom: 0, left: 4 }}
+                >
+                  <XAxis
+                    dataKey="label"
+                    tickLine={false}
+                    axisLine={false}
+                    interval={0}
+                    tick={{ fontSize: 12, fill: 'currentColor' }}
+                  />
+                  <Tooltip
+                    cursor={{ fill: 'transparent' }}
+                    formatter={(value) => {
+                      const num = typeof value === 'number' ? value : Number(value)
+                      return [`${num.toFixed(2)} mi`, 'Distance']
+                    }}
+                  />
+                  <Bar dataKey="distance_mi" radius={[4, 4, 0, 0]}>
+                    {days.map((day) => (
+                      <Cell
+                        key={day.key}
+                        fill={BAR_COLOR}
+                        fillOpacity={day.distance_mi > 0 ? 1 : 0.25}
+                      />
+                    ))}
+                  </Bar>
+                </BarChart>
+              </ResponsiveContainer>
+            </div>
+
+            <p className="text-xs text-muted-foreground">
+              {loading
+                ? 'Loading cycling activity…'
+                : `${activityCount} ${
+                    activityCount === 1 ? 'ride' : 'rides'
+                  } this week`}
+            </p>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  )
+}

--- a/src/components/dashboard/CyclingInFocus.tsx
+++ b/src/components/dashboard/CyclingInFocus.tsx
@@ -218,9 +218,10 @@ export function CyclingInFocus() {
               </ResponsiveContainer>
             </div>
 
-            <div className="flex items-center justify-between border-t pt-2">
+            <div className="space-y-1.5 border-t pt-2">
               <div
-                className="flex flex-1 flex-wrap items-center gap-1"
+                data-testid="in-focus-activity-strip"
+                className="flex items-center justify-between"
                 aria-label={`${recentRideCount} ride${
                   recentRideCount === 1 ? '' : 's'
                 } in the last 4 weeks`}
@@ -229,13 +230,13 @@ export function CyclingInFocus() {
                   <span
                     key={day.key}
                     className={cn(
-                      'h-1.5 w-1.5 rounded-full',
+                      'h-1.5 w-1.5 shrink-0 rounded-full',
                       day.active ? 'bg-foreground' : 'bg-muted-foreground/25',
                     )}
                   />
                 ))}
               </div>
-              <span className="ml-2 shrink-0 text-xs text-muted-foreground">
+              <span className="block text-xs text-muted-foreground">
                 {loading
                   ? 'Loading…'
                   : `Last 4w · ${recentRideCount} ${

--- a/src/components/dashboard/CyclingInFocus.tsx
+++ b/src/components/dashboard/CyclingInFocus.tsx
@@ -108,19 +108,21 @@ export function CyclingInFocus() {
 
   // Trailing 4-week (28-day) window for the activity strip + ride count.
   const recentStart = useMemo(() => subDays(today, RECENT_DAYS - 1), [today])
-  const { data: recentData } = useGarminActivitiesQuery({
-    variables: {
-      sport: SPORT,
-      date_from: format(recentStart, 'yyyy-MM-dd'),
-      date_to: format(today, 'yyyy-MM-dd'),
-      limit: ACTIVITY_LIMIT,
+  const { data: recentData, loading: recentLoading } = useGarminActivitiesQuery(
+    {
+      variables: {
+        sport: SPORT,
+        date_from: format(recentStart, 'yyyy-MM-dd'),
+        date_to: format(today, 'yyyy-MM-dd'),
+        limit: ACTIVITY_LIMIT,
+      },
     },
-  })
+  )
 
   const dateFrom = format(weekStart, 'yyyy-MM-dd')
   const dateTo = format(weekEnd, 'yyyy-MM-dd')
 
-  const { data, loading, error, refetch } = useGarminActivitiesQuery({
+  const { data, error, refetch } = useGarminActivitiesQuery({
     variables: {
       sport: SPORT,
       date_from: dateFrom,
@@ -302,7 +304,7 @@ export function CyclingInFocus() {
                 ))}
               </div>
               <span className="block text-xs text-muted-foreground">
-                {loading
+                {recentLoading
                   ? 'Loading…'
                   : `Last 4w · ${recentRideCount} ${
                       recentRideCount === 1 ? 'ride' : 'rides'

--- a/src/pages/DashboardPage.test.tsx
+++ b/src/pages/DashboardPage.test.tsx
@@ -137,8 +137,6 @@ describe('DashboardPage', () => {
     expect(screen.getByText('16')).toBeInTheDocument()
     expect(screen.getByText('healthy')).toBeInTheDocument()
     expect(screen.getByText('v1.2.3')).toBeInTheDocument()
-    expect(screen.getByText('watch')).toBeInTheDocument()
-    expect(screen.getByText('phone')).toBeInTheDocument()
     expect(screen.getByText('running')).toBeInTheDocument()
     expect(screen.getByText('cycling')).toBeInTheDocument()
   })

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -4,7 +4,7 @@ import {
   useDevicesQuery,
   useGarminSportsQuery,
 } from '@/__generated__/graphql'
-import { MapPin, Activity, Database, Heart } from 'lucide-react'
+import { MapPin, Activity, Heart } from 'lucide-react'
 import { StatsCard } from '@/components/shared/StatsCard'
 import { LoadingState } from '@/components/shared/LoadingState'
 import { ErrorState } from '@/components/shared/ErrorState'
@@ -13,6 +13,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { GarminSyncCard } from '@/components/dashboard/GarminSyncCard'
 import { GarminActivityHeatmap } from '@/components/dashboard/GarminActivityHeatmap'
 import { GarminActivityTotals } from '@/components/dashboard/GarminActivityTotals'
+import { CyclingInFocus } from '@/components/dashboard/CyclingInFocus'
 
 export function DashboardPage() {
   const { data: healthData, loading: healthLoading } = useHealthQuery()
@@ -53,18 +54,12 @@ export function DashboardPage() {
         </p>
       </div>
 
-      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
+      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
         <StatsCard
           title="Total Locations"
           value={totalLocations.toLocaleString()}
           icon={<MapPin className="h-4 w-4" />}
           description="OwnTracks GPS points"
-        />
-        <StatsCard
-          title="Devices"
-          value={totalDevices}
-          icon={<Database className="h-4 w-4" />}
-          description="Tracked devices"
         />
         <StatsCard
           title="Garmin Activities"
@@ -80,10 +75,13 @@ export function DashboardPage() {
         />
       </div>
 
+      <CyclingInFocus />
+
       <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
         <Card>
-          <CardHeader>
+          <CardHeader className="flex flex-row items-center justify-between space-y-0">
             <CardTitle>Devices</CardTitle>
+            <Badge variant="secondary">{totalDevices}</Badge>
           </CardHeader>
           <CardContent>
             {devicesData?.devices?.length ? (

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -1,7 +1,6 @@
 import {
   useHealthQuery,
   useLocationCountQuery,
-  useDevicesQuery,
   useGarminSportsQuery,
 } from '@/__generated__/graphql'
 import { MapPin, Activity, Heart } from 'lucide-react'
@@ -23,10 +22,9 @@ export function DashboardPage() {
     error: countError,
     refetch: refetchCount,
   } = useLocationCountQuery()
-  const { loading: devicesLoading } = useDevicesQuery()
   const { data: sportsData, loading: sportsLoading } = useGarminSportsQuery()
 
-  if (countLoading && devicesLoading && sportsLoading && healthLoading) {
+  if (countLoading && sportsLoading && healthLoading) {
     return <LoadingState message="Loading dashboard..." />
   }
 

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -23,7 +23,7 @@ export function DashboardPage() {
     error: countError,
     refetch: refetchCount,
   } = useLocationCountQuery()
-  const { data: devicesData, loading: devicesLoading } = useDevicesQuery()
+  const { loading: devicesLoading } = useDevicesQuery()
   const { data: sportsData, loading: sportsLoading } = useGarminSportsQuery()
 
   if (countLoading && devicesLoading && sportsLoading && healthLoading) {
@@ -37,7 +37,6 @@ export function DashboardPage() {
   }
 
   const totalLocations = countData?.locationCount?.count ?? 0
-  const totalDevices = devicesData?.devices?.length ?? 0
   const totalSports = sportsData?.garminSports?.length ?? 0
   const totalActivities =
     sportsData?.garminSports?.reduce(
@@ -75,28 +74,8 @@ export function DashboardPage() {
         />
       </div>
 
-      <CyclingInFocus />
-
       <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
-        <Card>
-          <CardHeader className="flex flex-row items-center justify-between space-y-0">
-            <CardTitle>Devices</CardTitle>
-            <Badge variant="secondary">{totalDevices}</Badge>
-          </CardHeader>
-          <CardContent>
-            {devicesData?.devices?.length ? (
-              <div className="flex flex-wrap gap-2">
-                {devicesData.devices.map((d: { device_id: string }) => (
-                  <Badge key={d.device_id} variant="secondary">
-                    {d.device_id}
-                  </Badge>
-                ))}
-              </div>
-            ) : (
-              <p className="text-sm text-muted-foreground">No devices found</p>
-            )}
-          </CardContent>
-        </Card>
+        <CyclingInFocus />
 
         <Card>
           <CardHeader>


### PR DESCRIPTION
## Summary

Replaces the **Devices** stat tile on the Dashboard with a new **Cycling In Focus** card (a Garmin Connect–style weekly cycling widget), built entirely on the existing `GARMIN_ACTIVITIES_QUERY` — no backend/schema/codegen changes.

## Changes

- **New component** `CyclingInFocus` (`src/components/dashboard/CyclingInFocus.tsx`):
  - Header: green bike icon, `Cycling · MMM d – MMM d`, top-aligned total distance (mi) + `Total Time`.
  - Daily distance **bar chart** (W T F S S M T) with prev/next week navigation; the Next arrow is disabled at the current week so the range never goes past today.
  - **Last-4-weeks activity strip** — one dot per day (28 days), filled on days a ride was completed, with the `Last 4w · N rides` label below the dots on a single line.
  - **Tooltip** restyled to match the Garmin Activity heatmap day popover (date header, activity count, Sport/Distance/Duration table).
  - Uses the default dark card theme to match the other dashboard cards.
- **Dashboard layout** (`src/pages/DashboardPage.tsx`): top stat row reduced to 3 tiles; the Cycling In Focus card occupies the first slot of the second card row (replacing the old Devices card).

## Testing

- Unit tests: `CyclingInFocus.test.tsx` (aggregation, week range, navigation, disabled next-arrow, error state) + updated `DashboardPage.test.tsx`.
- Playwright: `e2e/cycling-in-focus.spec.ts` validates the single-line activity strip with label below and the heatmap-style tooltip.
- Full suite: `npm run lint:all`, `npm run type-check`, `npm run test:run` (217 passed), `npm run build` — all green. Playwright validated against the local stack.

## Notes

- The Devices list/count is no longer shown on the Dashboard (the Devices card was replaced). Can be relocated in a follow-up if desired.