### PR TITLE
feat(garmin): show recording device on activity detail page

### DIFF
--- a/e2e/garmin-device-detail.spec.ts
+++ b/e2e/garmin-device-detail.spec.ts
@@ -1,0 +1,43 @@
+import { test, expect } from '@playwright/test'
+import fs from 'fs'
+import path from 'path'
+
+/**
+ * Validates that the Garmin activity detail page surfaces recording-device
+ * metadata (model + firmware) in the activity header.
+ *
+ * Uses an activity recorded by a device with known metadata. In the lab
+ * dataset, activity 23358057937 was recorded by an "Edge 540 Solar"
+ * (firmware 31.30). Override per-environment via
+ * PLAYWRIGHT_GARMIN_DEVICE_ACTIVITY_ID.
+ */
+const DEVICE_ACTIVITY_ID =
+  process.env.PLAYWRIGHT_GARMIN_DEVICE_ACTIVITY_ID ?? '23358057937'
+
+const SCREENSHOT_DIR = path.join('e2e', 'screenshots', 'garmin-device')
+
+fs.mkdirSync(SCREENSHOT_DIR, { recursive: true })
+
+test.describe('Garmin Activity Device Metadata', () => {
+  test('activity header shows the recording device model and firmware', async ({
+    page,
+  }) => {
+    await page.goto(`/garmin/${DEVICE_ACTIVITY_ID}`)
+
+    // The stats bar confirms the activity detail page has loaded.
+    await expect(page.getByText('Distance').first()).toBeVisible({
+      timeout: 15_000,
+    })
+
+    const deviceBadge = page.getByTestId('device-badge')
+    await expect(deviceBadge).toBeVisible({ timeout: 15_000 })
+
+    // The badge must show a non-empty device model and a firmware version.
+    await expect(deviceBadge).not.toHaveText('')
+    await expect(deviceBadge).toContainText(/v\d/)
+
+    await deviceBadge.screenshot({
+      path: path.join(SCREENSHOT_DIR, 'device-badge.png'),
+    })
+  })
+})

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@fontsource-variable/geist": "^5.2.8",
         "@newrelic/browser-agent": "^1.314.0",
         "@radix-ui/react-slot": "^1.3.0",
-        "@stuartshay/otel-graphql-types": "1.0.94",
+        "@stuartshay/otel-graphql-types": "1.0.95",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "date-fns": "^4.1.0",
@@ -6497,9 +6497,9 @@
       "license": "MIT"
     },
     "node_modules/@stuartshay/otel-graphql-types": {
-      "version": "1.0.94",
-      "resolved": "https://registry.npmjs.org/@stuartshay/otel-graphql-types/-/otel-graphql-types-1.0.94.tgz",
-      "integrity": "sha512-DKc+koeFvSEqVYHDR6tNqk6xzJDs3l+Emx9JIpn9GVDH87LtfdHg/Y3PXL4VyVyOhM9IlzauJdlq+qftKpGsug==",
+      "version": "1.0.95",
+      "resolved": "https://registry.npmjs.org/@stuartshay/otel-graphql-types/-/otel-graphql-types-1.0.95.tgz",
+      "integrity": "sha512-/ybSKz3OAuhBQ5/Mh4w9JOzDLedrwJra5dO3lzSrDkIbMGhpcpVaULEWxqvTo6eyCnBRs/HL+vmxB/O6la4Iww==",
       "license": "MIT"
     },
     "node_modules/@tailwindcss/node": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@fontsource-variable/geist": "^5.2.8",
     "@newrelic/browser-agent": "^1.314.0",
     "@radix-ui/react-slot": "^1.3.0",
-    "@stuartshay/otel-graphql-types": "1.0.94",
+    "@stuartshay/otel-graphql-types": "1.0.95",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "date-fns": "^4.1.0",

--- a/scripts/dedupe-generated-types.cjs
+++ b/scripts/dedupe-generated-types.cjs
@@ -83,7 +83,6 @@ function main() {
     const deduped = dedupeExportedTypes(original)
     if (deduped !== original) {
       fs.writeFileSync(file, deduped)
-      // eslint-disable-next-line no-console
       console.log(`[dedupe-generated-types] removed duplicate type declarations in ${file}`)
     }
   }

--- a/src/__generated__/graphql.ts
+++ b/src/__generated__/graphql.ts
@@ -119,6 +119,8 @@ export type GarminActivity = {
   calories?: Maybe<Scalars['Int']['output']>;
   /** UTC timestamp when the record was inserted */
   created_at?: Maybe<Scalars['String']['output']>;
+  /** Recording device metadata (manufacturer, model, firmware) */
+  device?: Maybe<GarminDevice>;
   /** Device manufacturer (e.g. garmin) */
   device_manufacturer?: Maybe<Scalars['String']['output']>;
   /** Total distance in kilometres */
@@ -286,6 +288,21 @@ export type GarminDateRange = {
   max_date: Scalars['DateTime']['output'];
   /** Earliest Garmin activity timestamp (ISO 8601) */
   min_date: Scalars['DateTime']['output'];
+};
+
+/** Recording device metadata captured from a Garmin activity's FIT file. */
+export type GarminDevice = {
+  __typename?: 'GarminDevice';
+  /** Recording device serial number */
+  device_id?: Maybe<Scalars['Float']['output']>;
+  /** Raw Garmin product enum id from the FIT file (e.g. 4061) */
+  garmin_product?: Maybe<Scalars['Int']['output']>;
+  /** Device manufacturer (e.g. garmin) */
+  manufacturer?: Maybe<Scalars['String']['output']>;
+  /** Friendly device model name (e.g. Edge 540 Solar) */
+  model?: Maybe<Scalars['String']['output']>;
+  /** Device firmware/software version (e.g. 31.30) */
+  software_version?: Maybe<Scalars['String']['output']>;
 };
 
 /** Result payload returned when triggering an on-demand Garmin sync. */
@@ -927,7 +944,7 @@ export type GarminActivityQueryVariables = Exact<{
 }>;
 
 
-export type GarminActivityQuery = { garminActivity: { activity_id: string, sport: string, sub_sport: string | null, start_time: string | null, end_time: string | null, distance_km: number | null, duration_seconds: number | null, avg_heart_rate: number | null, max_heart_rate: number | null, hr_available: boolean, min_heart_rate: number | null, aerobic_training_effect: number | null, anaerobic_training_effect: number | null, exercise_load: number | null, avg_respiration_rate: number | null, min_respiration_rate: number | null, max_respiration_rate: number | null, sweat_loss_ml: number | null, moderate_intensity_minutes: number | null, vigorous_intensity_minutes: number | null, total_intensity_minutes: number | null, paved_distance_km: number | null, unpaved_distance_km: number | null, avg_cadence: number | null, max_cadence: number | null, total_strokes: number | null, calories: number | null, avg_speed_kmh: number | null, max_speed_kmh: number | null, total_ascent_m: number | null, total_descent_m: number | null, total_distance: number | null, avg_pace: number | null, device_manufacturer: string | null, avg_temperature_c: number | null, min_temperature_c: number | null, max_temperature_c: number | null, total_elapsed_time: number | null, total_timer_time: number | null, created_at: string | null, uploaded_at: string | null, track_point_count: number | null } | null };
+export type GarminActivityQuery = { garminActivity: { activity_id: string, sport: string, sub_sport: string | null, start_time: string | null, end_time: string | null, distance_km: number | null, duration_seconds: number | null, avg_heart_rate: number | null, max_heart_rate: number | null, hr_available: boolean, min_heart_rate: number | null, aerobic_training_effect: number | null, anaerobic_training_effect: number | null, exercise_load: number | null, avg_respiration_rate: number | null, min_respiration_rate: number | null, max_respiration_rate: number | null, sweat_loss_ml: number | null, moderate_intensity_minutes: number | null, vigorous_intensity_minutes: number | null, total_intensity_minutes: number | null, paved_distance_km: number | null, unpaved_distance_km: number | null, avg_cadence: number | null, max_cadence: number | null, total_strokes: number | null, calories: number | null, avg_speed_kmh: number | null, max_speed_kmh: number | null, total_ascent_m: number | null, total_descent_m: number | null, total_distance: number | null, avg_pace: number | null, device_manufacturer: string | null, avg_temperature_c: number | null, min_temperature_c: number | null, max_temperature_c: number | null, total_elapsed_time: number | null, total_timer_time: number | null, created_at: string | null, uploaded_at: string | null, track_point_count: number | null, device: { device_id: number | null, manufacturer: string | null, garmin_product: number | null, model: string | null, software_version: string | null } | null } | null };
 
 export type GarminTrackPointsQueryVariables = Exact<{
   activity_id: string;
@@ -1239,6 +1256,13 @@ export const GarminActivityDocument = gql`
     total_distance
     avg_pace
     device_manufacturer
+    device {
+      device_id
+      manufacturer
+      garmin_product
+      model
+      software_version
+    }
     avg_temperature_c
     min_temperature_c
     max_temperature_c

--- a/src/components/garmin/ActivityHeader.test.tsx
+++ b/src/components/garmin/ActivityHeader.test.tsx
@@ -47,7 +47,10 @@ describe('ActivityHeader', () => {
     const badge = screen.getByTestId('device-badge')
     expect(badge).toHaveTextContent('Edge 540 Solar')
     expect(badge).toHaveTextContent('v31.30')
-    expect(badge).toHaveAttribute('title', 'Edge 540 Solar \u00b7 firmware 31.30')
+    expect(badge).toHaveAttribute(
+      'title',
+      'Edge 540 Solar \u00b7 firmware 31.30',
+    )
     // The raw manufacturer badge is superseded by the richer device badge.
     expect(screen.queryByText('garmin')).not.toBeInTheDocument()
   })

--- a/src/components/garmin/ActivityHeader.test.tsx
+++ b/src/components/garmin/ActivityHeader.test.tsx
@@ -27,4 +27,44 @@ describe('ActivityHeader', () => {
       '/garmin?page=2',
     )
   })
+
+  it('renders the device model and firmware when device metadata is present', () => {
+    render(
+      <MemoryRouter>
+        <ActivityHeader
+          sport="cycling"
+          startTime="2026-03-14T09:00:00Z"
+          deviceManufacturer="garmin"
+          device={{
+            manufacturer: 'garmin',
+            model: 'Edge 540 Solar',
+            software_version: '31.30',
+          }}
+        />
+      </MemoryRouter>,
+    )
+
+    const badge = screen.getByTestId('device-badge')
+    expect(badge).toHaveTextContent('Edge 540 Solar')
+    expect(badge).toHaveTextContent('v31.30')
+    expect(badge).toHaveAttribute('title', 'Edge 540 Solar \u00b7 firmware 31.30')
+    // The raw manufacturer badge is superseded by the richer device badge.
+    expect(screen.queryByText('garmin')).not.toBeInTheDocument()
+  })
+
+  it('falls back to the manufacturer badge when no device model is available', () => {
+    render(
+      <MemoryRouter>
+        <ActivityHeader
+          sport="cycling"
+          startTime="2026-03-14T09:00:00Z"
+          deviceManufacturer="garmin"
+          device={null}
+        />
+      </MemoryRouter>,
+    )
+
+    expect(screen.queryByTestId('device-badge')).not.toBeInTheDocument()
+    expect(screen.getByText('garmin')).toBeInTheDocument()
+  })
 })

--- a/src/components/garmin/ActivityHeader.tsx
+++ b/src/components/garmin/ActivityHeader.tsx
@@ -22,6 +22,11 @@ interface ActivityHeaderProps {
   subSport?: string | null
   startTime?: string | null
   deviceManufacturer?: string | null
+  device?: {
+    model?: string | null
+    software_version?: string | null
+    manufacturer?: string | null
+  } | null
   backTo?: string
 }
 
@@ -30,9 +35,14 @@ export function ActivityHeader({
   subSport,
   startTime,
   deviceManufacturer,
+  device,
   backTo = '/garmin',
 }: ActivityHeaderProps) {
   const icon = sportIcons[sport] ?? <Activity className="h-6 w-6" />
+
+  const deviceModel = device?.model
+  const deviceFirmware = device?.software_version
+  const deviceLabel = deviceManufacturer ?? device?.manufacturer
 
   return (
     <div className="flex items-center gap-4">
@@ -65,10 +75,29 @@ export function ActivityHeader({
             {subSport.replace(/_/g, ' ')}
           </Badge>
         )}
-        {deviceManufacturer && (
-          <Badge variant="outline" className="capitalize">
-            {deviceManufacturer}
+        {deviceModel ? (
+          <Badge
+            variant="outline"
+            data-testid="device-badge"
+            title={
+              deviceFirmware
+                ? `${deviceModel} \u00b7 firmware ${deviceFirmware}`
+                : deviceModel
+            }
+          >
+            {deviceModel}
+            {deviceFirmware && (
+              <span className="ml-1 text-muted-foreground">
+                v{deviceFirmware}
+              </span>
+            )}
           </Badge>
+        ) : (
+          deviceLabel && (
+            <Badge variant="outline" className="capitalize">
+              {deviceLabel}
+            </Badge>
+          )
         )}
       </div>
     </div>

--- a/src/graphql/garmin.ts
+++ b/src/graphql/garmin.ts
@@ -88,6 +88,13 @@ export const GARMIN_ACTIVITY_QUERY = gql`
       total_distance
       avg_pace
       device_manufacturer
+      device {
+        device_id
+        manufacturer
+        garmin_product
+        model
+        software_version
+      }
       avg_temperature_c
       min_temperature_c
       max_temperature_c

--- a/src/pages/GarminDetailPage.tsx
+++ b/src/pages/GarminDetailPage.tsx
@@ -416,6 +416,7 @@ export function GarminDetailPage() {
         subSport={a.sub_sport}
         startTime={a.start_time}
         deviceManufacturer={a.device_manufacturer}
+        device={a.device}
         backTo={backTo}
       />
 


### PR DESCRIPTION
## Summary
Phase 5 (final) of the Garmin per-activity device metadata feature. Surfaces the recording device (model + firmware) on the Garmin activity detail page, completing the DB → agent → API → gateway → **UI** chain.

## Changes
- **Query** (`src/graphql/garmin.ts`): add `device { device_id manufacturer garmin_product model software_version }` to `GARMIN_ACTIVITY_QUERY`.
- **UI** (`ActivityHeader.tsx`): render a device badge showing the model with firmware (`Edge 540 Solar v31.30`), full detail in the `title`. Falls back to the manufacturer badge when no device model is present.
- **Wiring** (`GarminDetailPage.tsx`): pass `activity.device` to the header.
- **Types**: depends on `@stuartshay/otel-graphql-types@1.0.95` (carried from develop via #235).
- **Tests**: unit tests for the device badge (present + manufacturer-fallback) and a Playwright spec (`e2e/garmin-device-detail.spec.ts`) asserting the badge + capturing a screenshot.

## Validation (local)
- `type-check` ✅ · `build` ✅ · `lint:all` ✅ · `test:run` → **117 passed** ✅

## ⚠️ Two notes for reviewers
1. **Generated `graphql.ts` hand-edit:** I added the `device` field to the committed `GarminActivityQuery` type by hand rather than via full codegen, because a **pre-existing schema drift blocks a clean codegen run** (see #2). The committed generated file was already stale (missing several query fields); the app relies on its `@ts-nocheck`. The hand-edit is the minimal change needed for `tsc` to accept `activity.device`.
2. **Pre-existing daily-summary drift (separate issue):** `src/graphql/unified.ts`'s `DAILY_SUMMARY_QUERY` selects fields directly on `dailySummary`, but the current gateway schema returns `DailySummaryConnection!` (with `items`). This list→Connection drift (exposed by the gateway #140 schema resync) makes `npm run codegen` fail. **It is unrelated to this feature** and likely means the daily-summary page is already mismatched with the live gateway — worth its own investigation/PR (I can file it).

## Deploy + validate
After merge → Docker build → k8s-gitops bump → Argo sync. I'll validate the device badge on the deployed UI (activity 23358057937 → Edge 540 Solar / v31.30) before closing.

Refs: Garmin device metadata feature (final phase).