### PR TITLE
fix(dashboard): map cycling tooltip dates by unique day

### DIFF
--- a/e2e/dashboard-cycling-in-focus-tooltip.spec.ts
+++ b/e2e/dashboard-cycling-in-focus-tooltip.spec.ts
@@ -1,6 +1,7 @@
 import { expect, test, type Page } from '@playwright/test'
 
-const GRAPHQL_ENDPOINT_PATTERN = '**/*'
+const GRAPHQL_ENDPOINT_PATTERN =
+  /^https:\/\/gateway\.lab\.informationcart\.com\/(?:\?.*)?$|^http:\/\/(?:localhost|127\.0\.0\.1):4000\/(?:\?.*)?$/
 
 const CYCLING_ACTIVITIES = [
   {
@@ -58,8 +59,7 @@ const CYCLING_ACTIVITIES = [
 async function mockDashboardGraphql(page: Page) {
   await page.route(GRAPHQL_ENDPOINT_PATTERN, async (route) => {
     const request = route.request()
-    const url = request.url()
-    if (request.method() !== 'POST' || !url.includes('gateway')) {
+    if (request.method() !== 'POST') {
       await route.continue()
       return
     }

--- a/e2e/dashboard-cycling-in-focus-tooltip.spec.ts
+++ b/e2e/dashboard-cycling-in-focus-tooltip.spec.ts
@@ -1,0 +1,157 @@
+import { expect, test, type Page } from '@playwright/test'
+
+const GRAPHQL_ENDPOINT_PATTERN = '**/*'
+
+const CYCLING_ACTIVITIES = [
+  {
+    activity_id: 'ride-thu',
+    sport: 'cycling',
+    sub_sport: null,
+    start_time: '2026-06-18T08:00:00',
+    end_time: '2026-06-18T09:00:00',
+    distance_km: 50,
+    duration_seconds: 3600,
+    avg_heart_rate: null,
+    max_heart_rate: null,
+    avg_cadence: null,
+    max_cadence: null,
+    total_strokes: null,
+    calories: null,
+    avg_speed_kmh: null,
+    max_speed_kmh: null,
+    total_ascent_m: null,
+    total_descent_m: null,
+    total_distance: null,
+    avg_pace: null,
+    device_manufacturer: null,
+    created_at: null,
+    uploaded_at: null,
+    track_point_count: null,
+  },
+  {
+    activity_id: 'ride-sun',
+    sport: 'cycling',
+    sub_sport: null,
+    start_time: '2026-06-21T08:00:00',
+    end_time: '2026-06-21T09:30:00',
+    distance_km: 75,
+    duration_seconds: 5400,
+    avg_heart_rate: null,
+    max_heart_rate: null,
+    avg_cadence: null,
+    max_cadence: null,
+    total_strokes: null,
+    calories: null,
+    avg_speed_kmh: null,
+    max_speed_kmh: null,
+    total_ascent_m: null,
+    total_descent_m: null,
+    total_distance: null,
+    avg_pace: null,
+    device_manufacturer: null,
+    created_at: null,
+    uploaded_at: null,
+    track_point_count: null,
+  },
+]
+
+async function mockDashboardGraphql(page: Page) {
+  await page.route(GRAPHQL_ENDPOINT_PATTERN, async (route) => {
+    const request = route.request()
+    const url = request.url()
+    if (request.method() !== 'POST' || !url.includes('gateway')) {
+      await route.continue()
+      return
+    }
+
+    const body = request.postDataJSON() as {
+      operationName?: string
+      variables?: Record<string, unknown>
+    }
+    const operationName = body.operationName
+
+    const dataByOperation: Record<string, unknown> = {
+      Health: { health: { status: 'ok', version: 'test' } },
+      LocationCount: {
+        locationCount: { count: 42, date: null, device_id: null },
+      },
+      GarminSports: {
+        garminSports: [{ sport: 'cycling', activity_count: 2 }],
+      },
+      GarminDateRange: {
+        garminDateRange: { min_date: '2026-01-01', max_date: '2026-06-24' },
+      },
+      DailySummary: {
+        dailySummary: { items: [], total: 0, limit: 365, offset: 0 },
+      },
+      GarminActivityTotals: { garminActivityTotals: [] },
+    }
+
+    if (operationName === 'GarminActivities') {
+      await route.fulfill({
+        contentType: 'application/json',
+        body: JSON.stringify({
+          data: {
+            garminActivities: {
+              items: CYCLING_ACTIVITIES,
+              total: CYCLING_ACTIVITIES.length,
+              limit: body.variables?.limit ?? 200,
+              offset: body.variables?.offset ?? 0,
+            },
+          },
+        }),
+      })
+      return
+    }
+
+    if (!operationName || !(operationName in dataByOperation)) {
+      await route.fulfill({
+        status: 500,
+        contentType: 'application/json',
+        body: JSON.stringify({ errors: [{ message: 'Unhandled operation' }] }),
+      })
+      return
+    }
+
+    await route.fulfill({
+      contentType: 'application/json',
+      body: JSON.stringify({ data: dataByOperation[operationName] }),
+    })
+  })
+}
+
+test.describe('Dashboard Cycling in Focus tooltip', () => {
+  test('maps duplicate one-letter weekday ticks to the correct dates', async ({
+    page,
+  }) => {
+    await page.clock.setFixedTime(new Date('2026-06-24T12:00:00Z'))
+    await mockDashboardGraphql(page)
+
+    await page.goto('/', { waitUntil: 'domcontentloaded' })
+
+    const card = page.getByTestId('cycling-in-focus-card')
+    await expect(card.getByTestId('in-focus-week-range')).toHaveText(
+      '· Jun 18 – Jun 24',
+    )
+
+    await expect
+      .poll(async () =>
+        card
+          .getByTestId('cycling-week-chart')
+          .locator('svg text')
+          .evaluateAll((ticks) => ticks.map((tick) => tick.textContent)),
+      )
+      .toEqual(['T', 'F', 'S', 'S', 'M', 'T', 'W'])
+
+    const bars = card
+      .getByTestId('cycling-week-chart')
+      .locator('.recharts-bar-rectangle path, .recharts-bar-rectangle rect')
+    await expect(bars).toHaveCount(2)
+
+    await bars.nth(0).hover()
+    await expect(page.getByText('Thu, Jun 18, 2026')).toBeVisible()
+
+    await bars.nth(1).hover()
+    await expect(page.getByText('Sun, Jun 21, 2026')).toBeVisible()
+  })
+})

--- a/src/components/dashboard/CyclingInFocus.test.tsx
+++ b/src/components/dashboard/CyclingInFocus.test.tsx
@@ -7,6 +7,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 const FROZEN_NOW = new Date('2026-06-23T12:00:00Z')
 
 let latestBarChartData: Array<Record<string, unknown>> = []
+let latestXAxisProps: Record<string, unknown> = {}
 
 const hooks = vi.hoisted(() => ({
   useGarminActivitiesQuery: vi.fn(),
@@ -31,7 +32,10 @@ vi.mock('recharts', () => ({
   },
   Bar: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
   Cell: () => null,
-  XAxis: () => null,
+  XAxis: (props: Record<string, unknown>) => {
+    latestXAxisProps = props
+    return null
+  },
   Tooltip: () => null,
 }))
 
@@ -71,6 +75,7 @@ describe('CyclingInFocus', () => {
       toFake: ['Date'],
     })
     latestBarChartData = []
+    latestXAxisProps = {}
     hooks.useGarminActivitiesQuery.mockReset()
   })
 
@@ -126,8 +131,24 @@ describe('CyclingInFocus', () => {
       'M',
       'T',
     ])
-    const jun18 = latestBarChartData.find((d) => d.key === '2026-06-18')
+    const jun18 = latestBarChartData.find((d) => d.date === '2026-06-18')
     expect(jun18?.distance_mi).toBeCloseTo(31.07, 1)
+  })
+
+  it('uses unique date keys for the chart axis while rendering one-letter ticks', () => {
+    mockActivities(SAMPLE_ITEMS)
+
+    render(<CyclingInFocus />)
+
+    expect(latestXAxisProps.dataKey).toBe('date')
+    const tickFormatter = latestXAxisProps.tickFormatter as (
+      value: unknown,
+      index: number,
+    ) => string
+    expect(tickFormatter('2026-06-18', 0)).toBe('W')
+    expect(tickFormatter('2026-06-18', 1)).toBe('T')
+    expect(tickFormatter('2026-06-21', 4)).toBe('S')
+    expect(new Set(latestBarChartData.map((d) => d.date)).size).toBe(7)
   })
 
   it('navigates to the previous week and re-queries', async () => {

--- a/src/components/dashboard/CyclingInFocus.tsx
+++ b/src/components/dashboard/CyclingInFocus.tsx
@@ -25,7 +25,7 @@ const RECENT_DAYS = 28
 const DAY_INITIALS = ['S', 'M', 'T', 'W', 'T', 'F', 'S']
 
 interface DayBucket {
-  /** ISO day key (yyyy-MM-dd). */
+  /** ISO date for the bucket (yyyy-MM-dd). */
   date: string
   /** Single-letter weekday label. */
   label: string

--- a/src/components/dashboard/CyclingInFocus.tsx
+++ b/src/components/dashboard/CyclingInFocus.tsx
@@ -26,7 +26,7 @@ const DAY_INITIALS = ['S', 'M', 'T', 'W', 'T', 'F', 'S']
 
 interface DayBucket {
   /** ISO day key (yyyy-MM-dd). */
-  key: string
+  date: string
   /** Single-letter weekday label. */
   label: string
   /** Total distance for the day, in miles. */
@@ -49,7 +49,7 @@ function ActivityTooltip({
   if (!active || !day) return null
 
   const formattedDate = format(
-    new Date(`${day.key}T00:00:00`),
+    new Date(`${day.date}T00:00:00`),
     'EEE, MMM d, yyyy',
   )
 
@@ -136,20 +136,20 @@ export function CyclingInFocus() {
     for (let i = 0; i < 7; i += 1) {
       const day = addDays(weekStart, i)
       buckets.push({
-        key: format(day, 'yyyy-MM-dd'),
+        date: format(day, 'yyyy-MM-dd'),
         label: DAY_INITIALS[day.getDay()],
         distance_mi: 0,
         duration_seconds: 0,
         count: 0,
       })
     }
-    const byKey = new Map(buckets.map((bucket) => [bucket.key, bucket]))
+    const byDate = new Map(buckets.map((bucket) => [bucket.date, bucket]))
 
     let totalKm = 0
     let seconds = 0
     for (const activity of data?.garminActivities?.items ?? []) {
       if (!activity.start_time) continue
-      const bucket = byKey.get(activity.start_time.slice(0, 10))
+      const bucket = byDate.get(activity.start_time.slice(0, 10))
       if (!bucket) continue
       const km = activity.distance_km ?? 0
       const dur = activity.duration_seconds ?? 0
@@ -255,17 +255,20 @@ export function CyclingInFocus() {
               </span>
             </div>
 
-            <div className="h-24 w-full">
+            <div data-testid="cycling-week-chart" className="h-24 w-full">
               <ResponsiveContainer width="100%" height="100%">
                 <BarChart
                   data={days}
                   margin={{ top: 4, right: 4, bottom: 0, left: 4 }}
                 >
                   <XAxis
-                    dataKey="label"
+                    dataKey="date"
                     tickLine={false}
                     axisLine={false}
                     interval={0}
+                    tickFormatter={(_, index: number) =>
+                      days[index]?.label ?? ''
+                    }
                     tick={{ fontSize: 11, fill: 'currentColor' }}
                   />
                   <Tooltip
@@ -275,7 +278,7 @@ export function CyclingInFocus() {
                   <Bar dataKey="distance_mi" radius={[4, 4, 0, 0]}>
                     {days.map((day) => (
                       <Cell
-                        key={day.key}
+                        key={day.date}
                         fill={BAR_COLOR}
                         fillOpacity={day.distance_mi > 0 ? 1 : 0.2}
                       />


### PR DESCRIPTION
## Summary
- Use the ISO date as the Cycling in Focus chart category so duplicate one-letter weekday labels do not collide.
- Keep the one-letter weekday labels via tick formatting.
- Add unit and Playwright regression coverage for Thursday/Sunday tooltip mapping.

## Validation
- npm run test:run -- src/components/dashboard/CyclingInFocus.test.tsx
- BASE_URL=http://127.0.0.1:5174 npx playwright test e2e/dashboard-cycling-in-focus-tooltip.spec.ts --project=chromium
- npm run lint:all
- npm run type-check