### PR TITLE
fix(dashboard): trim leading empty activity total years

### DIFF
--- a/src/components/dashboard/GarminActivityTotals.test.tsx
+++ b/src/components/dashboard/GarminActivityTotals.test.tsx
@@ -347,6 +347,134 @@ describe('GarminActivityTotals', () => {
     )
   })
 
+  it('yearly mode omits leading zero buckets from the API but preserves later gaps', async () => {
+    hooks.useGarminDateRangeQuery.mockReturnValue({
+      data: {
+        garminDateRange: { min_date: '1999-01-01', max_date: '2026-12-31' },
+      },
+      loading: false,
+    })
+    hooks.useGarminActivityTotalsQuery.mockReturnValue({
+      data: {
+        garminActivityTotals: [
+          {
+            period_start: '1999-01-01',
+            activity_count: 0,
+            total_distance_km: 0,
+            total_duration_seconds: 0,
+            total_ascent_m: 0,
+            total_calories: 0,
+          },
+          {
+            period_start: '2009-01-01',
+            activity_count: 0,
+            total_distance_km: 0,
+            total_duration_seconds: 0,
+            total_ascent_m: 0,
+            total_calories: 0,
+          },
+          {
+            period_start: '2010-01-01',
+            activity_count: 1,
+            total_distance_km: 10,
+            total_duration_seconds: 3600,
+            total_ascent_m: 100,
+            total_calories: 500,
+          },
+          {
+            period_start: '2012-01-01',
+            activity_count: 1,
+            total_distance_km: 12,
+            total_duration_seconds: 3600,
+            total_ascent_m: 120,
+            total_calories: 600,
+          },
+        ],
+      },
+      loading: false,
+      error: undefined,
+      refetch: vi.fn(),
+    })
+
+    const user = userEvent.setup()
+    render(<GarminActivityTotals />)
+
+    await user.click(screen.getByRole('radio', { name: 'Yearly' }))
+
+    await waitFor(() => {
+      expect(latestBarChartData[0]).toEqual(
+        expect.objectContaining({ label: '2010', distance_km: 10 }),
+      )
+    })
+    expect(latestBarChartData.map(({ label }) => label)).not.toContain('1999')
+    expect(latestBarChartData.map(({ label }) => label)).not.toContain('2009')
+    expect(latestBarChartData).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ label: '2011', distance_km: 0 }),
+        expect.objectContaining({ label: '2012', distance_km: 12 }),
+      ]),
+    )
+  })
+
+  it('weekly mode omits leading zero projected years but preserves later gaps', async () => {
+    hooks.useGarminDateRangeQuery.mockReturnValue({
+      data: {
+        garminDateRange: { min_date: '1999-01-01', max_date: '2026-12-31' },
+      },
+      loading: false,
+    })
+    hooks.useGarminActivityTotalsQuery.mockReturnValue({
+      data: undefined,
+      loading: false,
+      error: undefined,
+      refetch: vi.fn(),
+    })
+    apolloMocks.query.mockImplementation(({ variables }) => {
+      const year = Number(variables.date_to.slice(0, 4))
+      const distanceByYear = new Map([
+        [2010, 10],
+        [2012, 12],
+      ])
+      const distance = distanceByYear.get(year) ?? 0
+      return Promise.resolve({
+        data: {
+          garminActivityTotals:
+            distance > 0
+              ? [
+                  {
+                    period_start: variables.date_from,
+                    activity_count: 1,
+                    total_distance_km: distance,
+                    total_duration_seconds: 3600,
+                    total_ascent_m: 100,
+                    total_calories: 500,
+                  },
+                ]
+              : [],
+        },
+      })
+    })
+
+    const user = userEvent.setup()
+    render(<GarminActivityTotals />)
+
+    await user.click(screen.getByRole('radio', { name: 'Weekly' }))
+
+    await waitFor(() => {
+      expect(latestBarChartData[0]).toEqual(
+        expect.objectContaining({ label: '2010', distance_km: 10 }),
+      )
+    })
+    expect(latestBarChartData.map(({ label }) => label)).not.toContain('1999')
+    expect(latestBarChartData.map(({ label }) => label)).not.toContain('2009')
+    expect(latestBarChartData).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ label: '2011', distance_km: 0 }),
+        expect.objectContaining({ label: '2012', distance_km: 12 }),
+      ]),
+    )
+  })
+
   it('weekly mode renders default 7-day window pill and projects per year', async () => {
     hooks.useGarminActivityTotalsQuery.mockReturnValue({
       data: undefined,

--- a/src/components/dashboard/GarminActivityTotals.tsx
+++ b/src/components/dashboard/GarminActivityTotals.tsx
@@ -197,6 +197,21 @@ function formatBucketLabel(period_start: string, period: Period): string {
   }
 }
 
+function hasBucketData(bucket: ChartBucket): boolean {
+  return (
+    bucket.activity_count > 0 ||
+    bucket.distance_km > 0 ||
+    bucket.duration_hours > 0 ||
+    bucket.total_ascent_m > 0 ||
+    bucket.total_calories > 0
+  )
+}
+
+function trimLeadingEmptyBuckets(buckets: ChartBucket[]): ChartBucket[] {
+  const firstDataIndex = buckets.findIndex(hasBucketData)
+  return firstDataIndex === -1 ? [] : buckets.slice(firstDataIndex)
+}
+
 export function GarminActivityTotals() {
   const [period, setPeriod] = useState<Period>('month')
   const [metric, setMetric] = useState<Metric>('distance')
@@ -349,7 +364,11 @@ export function GarminActivityTotals() {
           })
         }
         if (cancelled) return
-        setWeeklyByYear(results.sort((a, b) => a.label.localeCompare(b.label)))
+        setWeeklyByYear(
+          trimLeadingEmptyBuckets(
+            results.sort((a, b) => a.label.localeCompare(b.label)),
+          ),
+        )
         setWeeklyLoading(false)
       } catch (err) {
         if (cancelled) return
@@ -414,9 +433,15 @@ export function GarminActivityTotals() {
     // Date-range metadata can predate the first real activity. Start at the
     // earliest returned bucket, then zero-fill subsequent years so the chart
     // remains continuous without rendering empty leading years.
-    const earliestDataYear = Math.min(
-      ...relevantBuckets.map(({ year }) => Number(year)),
-    )
+    const dataYears = relevantBuckets
+      .filter(({ bucket }) => hasBucketData(bucket))
+      .map(({ year }) => Number(year))
+
+    if (dataYears.length === 0) {
+      return []
+    }
+
+    const earliestDataYear = Math.min(...dataYears)
     const byYear = new Map<string, ChartBucket>()
     for (const year of yearList) {
       if (year < earliestDataYear) {
@@ -439,6 +464,10 @@ export function GarminActivityTotals() {
     }
 
     for (const { bucket, year } of relevantBuckets) {
+      if (Number(year) < earliestDataYear) {
+        continue
+      }
+
       const existing = byYear.get(year)
 
       if (!existing) {


### PR DESCRIPTION
## Summary
- Trim leading empty years from weekly and yearly Activity Totals charts.
- Preserve zero-valued years after the first real activity year so gaps remain visible.
- Add regression coverage for weekly projected years and yearly API zero buckets.

## Validation
- npm run test:run -- src/components/dashboard/GarminActivityTotals.test.tsx
- npm run lint:all
- npm run type-check