### PR TITLE
fix(dashboard): trim yearly totals by plotted metrics

### DIFF
--- a/src/components/dashboard/GarminActivityTotals.test.tsx
+++ b/src/components/dashboard/GarminActivityTotals.test.tsx
@@ -359,7 +359,7 @@ describe('GarminActivityTotals', () => {
         garminActivityTotals: [
           {
             period_start: '1999-01-01',
-            activity_count: 0,
+            activity_count: 3,
             total_distance_km: 0,
             total_duration_seconds: 0,
             total_ascent_m: 0,
@@ -367,7 +367,7 @@ describe('GarminActivityTotals', () => {
           },
           {
             period_start: '2009-01-01',
-            activity_count: 0,
+            activity_count: 4,
             total_distance_km: 0,
             total_duration_seconds: 0,
             total_ascent_m: 0,

--- a/src/components/dashboard/GarminActivityTotals.tsx
+++ b/src/components/dashboard/GarminActivityTotals.tsx
@@ -199,7 +199,6 @@ function formatBucketLabel(period_start: string, period: Period): string {
 
 function hasBucketData(bucket: ChartBucket): boolean {
   return (
-    bucket.activity_count > 0 ||
     bucket.distance_km > 0 ||
     bucket.duration_hours > 0 ||
     bucket.total_ascent_m > 0 ||


### PR DESCRIPTION
## Summary
- Treat activity-count-only leading years as empty for Activity Totals chart starts.
- Keeps yearly X-axis from starting at years with no plotted totals.
- Tightens the yearly regression to cover early buckets with activity_count but zero metric totals.

## Validation
- npm run test:run -- src/components/dashboard/GarminActivityTotals.test.tsx
- npm run lint:all
- npm run type-check