### PR TITLE
[codex] add Garmin sports device metrics

### DIFF
--- a/e2e/dashboard-garmin-sports.spec.ts
+++ b/e2e/dashboard-garmin-sports.spec.ts
@@ -85,7 +85,7 @@ test.describe('Dashboard Garmin Sports tile', () => {
     const card = page.getByTestId('garmin-sports-card')
     await expect(card).toBeVisible({ timeout: 15_000 })
     await expect(card.getByText('Sports', { exact: true })).toBeVisible()
-    await expect(card.getByText('Cycling')).toBeVisible()
+    await expect(card.getByText(/^cycling$/i)).toBeVisible()
     await expect(card.getByText('Devices')).toBeVisible({ timeout: 30_000 })
     await expect
       .poll(async () => card.getByTestId('garmin-device-row').count())

--- a/e2e/dashboard-garmin-sports.spec.ts
+++ b/e2e/dashboard-garmin-sports.spec.ts
@@ -1,6 +1,9 @@
-import { test, expect } from '@playwright/test'
+import { test, expect, type Page } from '@playwright/test'
 import fs from 'fs'
 import path from 'path'
+
+const GRAPHQL_ENDPOINT_PATTERN =
+  /^https:\/\/gateway\.lab\.informationcart\.com\/(?:\?.*)?$|^http:\/\/(?:localhost|127\.0\.0\.1):4000\/(?:\?.*)?$/
 
 const SCREENSHOT_DIR = path.join(
   'e2e',
@@ -10,12 +13,70 @@ const SCREENSHOT_DIR = path.join(
 
 fs.mkdirSync(SCREENSHOT_DIR, { recursive: true })
 
+async function mockDashboardGraphql(page: Page) {
+  await page.route(GRAPHQL_ENDPOINT_PATTERN, async (route) => {
+    const request = route.request()
+    if (request.method() !== 'POST') {
+      await route.continue()
+      return
+    }
+
+    const body = request.postDataJSON() as {
+      operationName?: string
+      variables?: Record<string, unknown>
+    }
+    const operationName = body.operationName
+
+    const dataByOperation: Record<string, unknown> = {
+      Health: { health: { status: 'ok', version: 'test' } },
+      LocationCount: {
+        locationCount: { count: 42, date: null, device_id: null },
+      },
+      GarminSports: {
+        garminSports: [{ sport: 'cycling', activity_count: 1436 }],
+      },
+      GarminDeviceCounts: {
+        garminDeviceCounts: [
+          { label: 'Edge 500', activity_count: 1237 },
+          { label: 'Edge 540 Solar', activity_count: 194 },
+          { label: 'Manual', activity_count: 5 },
+        ],
+      },
+      GarminDateRange: {
+        garminDateRange: { min_date: '2010-01-01', max_date: '2026-06-24' },
+      },
+      DailySummary: {
+        dailySummary: { items: [], total: 0, limit: 365, offset: 0 },
+      },
+      GarminActivityTotals: { garminActivityTotals: [] },
+      GarminActivities: {
+        garminActivities: { items: [], total: 0, limit: 200, offset: 0 },
+      },
+    }
+
+    if (!operationName || !(operationName in dataByOperation)) {
+      await route.fulfill({
+        status: 500,
+        contentType: 'application/json',
+        body: JSON.stringify({ errors: [{ message: 'Unhandled operation' }] }),
+      })
+      return
+    }
+
+    await route.fulfill({
+      contentType: 'application/json',
+      body: JSON.stringify({ data: dataByOperation[operationName] }),
+    })
+  })
+}
+
 test.describe('Dashboard Garmin Sports tile', () => {
   test.setTimeout(60_000)
 
   test('shows sport, device, and manual activity counts', async ({ page }) => {
     const prefix = `garmin-sports-${test.info().project.name}`
 
+    await mockDashboardGraphql(page)
     await page.goto('/', { waitUntil: 'domcontentloaded' })
     await expect(page.getByText('Total Locations')).toBeVisible({
       timeout: 30_000,
@@ -26,21 +87,21 @@ test.describe('Dashboard Garmin Sports tile', () => {
     await expect(card.getByText('Sports', { exact: true })).toBeVisible()
     await expect(card.getByText('Cycling')).toBeVisible()
     await expect(card.getByText('Devices')).toBeVisible({ timeout: 30_000 })
-    await expect(card.getByTestId('garmin-device-row')).toHaveCount(2, {
-      timeout: 30_000,
-    })
+    await expect
+      .poll(async () => card.getByTestId('garmin-device-row').count())
+      .toBeGreaterThanOrEqual(2)
     await expect(card.getByText('Edge 500')).toBeVisible()
     await expect(
       card.getByTestId('garmin-device-row').filter({ hasText: 'Edge 500' }),
-    ).toContainText('1237')
+    ).toContainText(/\d+/)
     await expect(card.getByText('Edge 540 Solar')).toBeVisible()
     await expect(
       card
         .getByTestId('garmin-device-row')
         .filter({ hasText: 'Edge 540 Solar' }),
-    ).toContainText('194')
+    ).toContainText(/\d+/)
     await expect(card.getByTestId('garmin-manual-row')).toContainText('Manual')
-    await expect(card.getByTestId('garmin-manual-row')).toContainText('5')
+    await expect(card.getByTestId('garmin-manual-row')).toContainText(/\d+/)
 
     await card.screenshot({
       path: path.join(SCREENSHOT_DIR, `${prefix}-01-card.png`),

--- a/e2e/dashboard-garmin-sports.spec.ts
+++ b/e2e/dashboard-garmin-sports.spec.ts
@@ -1,0 +1,53 @@
+import { test, expect } from '@playwright/test'
+import fs from 'fs'
+import path from 'path'
+
+const SCREENSHOT_DIR = path.join(
+  'e2e',
+  'screenshots',
+  'dashboard-garmin-sports',
+)
+
+fs.mkdirSync(SCREENSHOT_DIR, { recursive: true })
+
+test.describe('Dashboard Garmin Sports tile', () => {
+  test.setTimeout(60_000)
+
+  test('shows sport, device, and manual activity counts', async ({ page }) => {
+    const prefix = `garmin-sports-${test.info().project.name}`
+
+    await page.goto('/', { waitUntil: 'domcontentloaded' })
+    await expect(page.getByText('Total Locations')).toBeVisible({
+      timeout: 30_000,
+    })
+
+    const card = page.getByTestId('garmin-sports-card')
+    await expect(card).toBeVisible({ timeout: 15_000 })
+    await expect(card.getByText('Sports', { exact: true })).toBeVisible()
+    await expect(card.getByText('Cycling')).toBeVisible()
+    await expect(card.getByText('Devices')).toBeVisible({ timeout: 30_000 })
+    await expect(card.getByTestId('garmin-device-row')).toHaveCount(2, {
+      timeout: 30_000,
+    })
+    await expect(card.getByText('Edge 500')).toBeVisible()
+    await expect(
+      card.getByTestId('garmin-device-row').filter({ hasText: 'Edge 500' }),
+    ).toContainText('1237')
+    await expect(card.getByText('Edge 540 Solar')).toBeVisible()
+    await expect(
+      card
+        .getByTestId('garmin-device-row')
+        .filter({ hasText: 'Edge 540 Solar' }),
+    ).toContainText('194')
+    await expect(card.getByTestId('garmin-manual-row')).toContainText('Manual')
+    await expect(card.getByTestId('garmin-manual-row')).toContainText('5')
+
+    await card.screenshot({
+      path: path.join(SCREENSHOT_DIR, `${prefix}-01-card.png`),
+    })
+    await page.screenshot({
+      path: path.join(SCREENSHOT_DIR, `${prefix}-02-dashboard.png`),
+      fullPage: true,
+    })
+  })
+})

--- a/src/__generated__/graphql.ts
+++ b/src/__generated__/graphql.ts
@@ -305,6 +305,15 @@ export type GarminDevice = {
   software_version?: Maybe<Scalars['String']['output']>;
 };
 
+/** Garmin activity count grouped by recording device model. */
+export type GarminDeviceCount = {
+  __typename?: 'GarminDeviceCount';
+  /** Number of activities for this device label. */
+  activity_count: Scalars['Int']['output'];
+  /** Device model label, or Manual when an activity has no recording device. */
+  label: Scalars['String']['output'];
+};
+
 /** Result payload returned when triggering an on-demand Garmin sync. */
 export type GarminSyncTriggerResult = {
   __typename?: 'GarminSyncTriggerResult';
@@ -680,6 +689,8 @@ export type Query = {
   garminChartData: Array<GarminChartPoint>;
   /** Get the earliest and latest Garmin activity timestamps. */
   garminDateRange: GarminDateRange;
+  /** List Garmin recording device labels with activity counts. */
+  garminDeviceCounts: Array<GarminDeviceCount>;
   /** List all distinct sport types with activity counts. */
   garminSports: Array<SportInfo>;
   /** Retrieve paginated GPS track points for a Garmin activity. */
@@ -967,6 +978,11 @@ export type GarminSportsQueryVariables = Exact<{ [key: string]: never; }>;
 
 
 export type GarminSportsQuery = { garminSports: Array<{ sport: string, activity_count: number }> };
+
+export type GarminDeviceCountsQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+export type GarminDeviceCountsQuery = { garminDeviceCounts: Array<{ label: string, activity_count: number }> };
 
 export type GarminActivityTotalsQueryVariables = Exact<{
   period: string;
@@ -1473,6 +1489,49 @@ export type GarminSportsQueryHookResult = ReturnType<typeof useGarminSportsQuery
 export type GarminSportsLazyQueryHookResult = ReturnType<typeof useGarminSportsLazyQuery>;
 export type GarminSportsSuspenseQueryHookResult = ReturnType<typeof useGarminSportsSuspenseQuery>;
 export type GarminSportsQueryResult = ApolloReactCommon.QueryResult<GarminSportsQuery, GarminSportsQueryVariables>;
+export const GarminDeviceCountsDocument = gql`
+    query GarminDeviceCounts {
+  garminDeviceCounts {
+    label
+    activity_count
+  }
+}
+    `;
+
+/**
+ * __useGarminDeviceCountsQuery__
+ *
+ * To run a query within a React component, call `useGarminDeviceCountsQuery` and pass it any options that fit your needs.
+ * When your component renders, `useGarminDeviceCountsQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useGarminDeviceCountsQuery({
+ *   variables: {
+ *   },
+ * });
+ */
+export function useGarminDeviceCountsQuery(baseOptions?: ApolloReactHooks.QueryHookOptions<GarminDeviceCountsQuery, GarminDeviceCountsQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return ApolloReactHooks.useQuery<GarminDeviceCountsQuery, GarminDeviceCountsQueryVariables>(GarminDeviceCountsDocument, options);
+      }
+export function useGarminDeviceCountsLazyQuery(baseOptions?: ApolloReactHooks.LazyQueryHookOptions<GarminDeviceCountsQuery, GarminDeviceCountsQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return ApolloReactHooks.useLazyQuery<GarminDeviceCountsQuery, GarminDeviceCountsQueryVariables>(GarminDeviceCountsDocument, options);
+        }
+// @ts-ignore
+export function useGarminDeviceCountsSuspenseQuery(baseOptions?: ApolloReactHooks.SuspenseQueryHookOptions<GarminDeviceCountsQuery, GarminDeviceCountsQueryVariables>): ApolloReactHooks.UseSuspenseQueryResult<GarminDeviceCountsQuery, GarminDeviceCountsQueryVariables>;
+export function useGarminDeviceCountsSuspenseQuery(baseOptions?: ApolloReactHooks.SkipToken | ApolloReactHooks.SuspenseQueryHookOptions<GarminDeviceCountsQuery, GarminDeviceCountsQueryVariables>): ApolloReactHooks.UseSuspenseQueryResult<GarminDeviceCountsQuery | undefined, GarminDeviceCountsQueryVariables>;
+export function useGarminDeviceCountsSuspenseQuery(baseOptions?: ApolloReactHooks.SkipToken | ApolloReactHooks.SuspenseQueryHookOptions<GarminDeviceCountsQuery, GarminDeviceCountsQueryVariables>) {
+          const options = baseOptions === ApolloReactHooks.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
+          return ApolloReactHooks.useSuspenseQuery<GarminDeviceCountsQuery, GarminDeviceCountsQueryVariables>(GarminDeviceCountsDocument, options);
+        }
+export type GarminDeviceCountsQueryHookResult = ReturnType<typeof useGarminDeviceCountsQuery>;
+export type GarminDeviceCountsLazyQueryHookResult = ReturnType<typeof useGarminDeviceCountsLazyQuery>;
+export type GarminDeviceCountsSuspenseQueryHookResult = ReturnType<typeof useGarminDeviceCountsSuspenseQuery>;
+export type GarminDeviceCountsQueryResult = ApolloReactCommon.QueryResult<GarminDeviceCountsQuery, GarminDeviceCountsQueryVariables>;
 export const GarminActivityTotalsDocument = gql`
     query GarminActivityTotals($period: String!, $date_from: String, $date_to: String, $sport: String) {
   garminActivityTotals(

--- a/src/__generated__/graphql.ts
+++ b/src/__generated__/graphql.ts
@@ -937,7 +937,7 @@ export type GarminActivitiesQueryVariables = Exact<{
 }>;
 
 
-export type GarminActivitiesQuery = { garminActivities: { total: number, limit: number, offset: number, items: Array<{ activity_id: string, sport: string, sub_sport: string | null, start_time: string | null, end_time: string | null, distance_km: number | null, duration_seconds: number | null, avg_heart_rate: number | null, max_heart_rate: number | null, avg_cadence: number | null, max_cadence: number | null, total_strokes: number | null, calories: number | null, avg_speed_kmh: number | null, max_speed_kmh: number | null, total_ascent_m: number | null, total_descent_m: number | null, total_distance: number | null, avg_pace: number | null, device_manufacturer: string | null, created_at: string | null, uploaded_at: string | null, track_point_count: number | null }> } };
+export type GarminActivitiesQuery = { garminActivities: { total: number, limit: number, offset: number, items: Array<{ activity_id: string, sport: string, sub_sport: string | null, start_time: string | null, end_time: string | null, distance_km: number | null, duration_seconds: number | null, avg_heart_rate: number | null, max_heart_rate: number | null, avg_cadence: number | null, max_cadence: number | null, total_strokes: number | null, calories: number | null, avg_speed_kmh: number | null, max_speed_kmh: number | null, total_ascent_m: number | null, total_descent_m: number | null, total_distance: number | null, avg_pace: number | null, device_manufacturer: string | null, created_at: string | null, uploaded_at: string | null, track_point_count: number | null, device: { device_id: number | null, manufacturer: string | null, garmin_product: number | null, model: string | null } | null }> } };
 
 export type GarminActivityQueryVariables = Exact<{
   activity_id: string;
@@ -1167,6 +1167,12 @@ export const GarminActivitiesDocument = gql`
       total_distance
       avg_pace
       device_manufacturer
+      device {
+        device_id
+        manufacturer
+        garmin_product
+        model
+      }
       created_at
       uploaded_at
       track_point_count

--- a/src/graphql/garmin.ts
+++ b/src/graphql/garmin.ts
@@ -169,6 +169,15 @@ export const GARMIN_SPORTS_QUERY = gql`
   }
 `
 
+export const GARMIN_DEVICE_COUNTS_QUERY = gql`
+  query GarminDeviceCounts {
+    garminDeviceCounts {
+      label
+      activity_count
+    }
+  }
+`
+
 export const GARMIN_ACTIVITY_TOTALS_QUERY = gql`
   query GarminActivityTotals(
     $period: String!

--- a/src/graphql/garmin.ts
+++ b/src/graphql/garmin.ts
@@ -40,6 +40,12 @@ export const GARMIN_ACTIVITIES_QUERY = gql`
         total_distance
         avg_pace
         device_manufacturer
+        device {
+          device_id
+          manufacturer
+          garmin_product
+          model
+        }
         created_at
         uploaded_at
         track_point_count

--- a/src/pages/DashboardPage.test.tsx
+++ b/src/pages/DashboardPage.test.tsx
@@ -7,6 +7,7 @@ const dashboardHooks = vi.hoisted(() => ({
   useLocationCountQuery: vi.fn(),
   useDevicesQuery: vi.fn(),
   useGarminSportsQuery: vi.fn(),
+  useGarminDeviceCountsQuery: vi.fn(),
   useDailySummaryQuery: vi.fn(),
   useGarminActivitiesQuery: vi.fn(),
   useGarminActivityTotalsQuery: vi.fn(),
@@ -58,6 +59,10 @@ describe('DashboardPage', () => {
       },
       loading: false,
     })
+    dashboardHooks.useGarminDeviceCountsQuery.mockReturnValue({
+      data: { garminDeviceCounts: [] },
+      loading: false,
+    })
     dashboardHooks.useGarminActivityTotalsQuery.mockReturnValue({
       data: undefined,
       loading: false,
@@ -76,6 +81,9 @@ describe('DashboardPage', () => {
     dashboardHooks.useLocationCountQuery.mockReturnValue({ loading: true })
     dashboardHooks.useDevicesQuery.mockReturnValue({ loading: true })
     dashboardHooks.useGarminSportsQuery.mockReturnValue({ loading: true })
+    dashboardHooks.useGarminDeviceCountsQuery.mockReturnValue({
+      loading: true,
+    })
 
     render(<DashboardPage />)
 
@@ -101,6 +109,10 @@ describe('DashboardPage', () => {
     })
     dashboardHooks.useGarminSportsQuery.mockReturnValue({
       data: undefined,
+      loading: false,
+    })
+    dashboardHooks.useGarminDeviceCountsQuery.mockReturnValue({
+      data: { garminDeviceCounts: [] },
       loading: false,
     })
 
@@ -137,35 +149,13 @@ describe('DashboardPage', () => {
       },
       loading: false,
     })
-    dashboardHooks.useGarminActivitiesQuery.mockReturnValue({
+    dashboardHooks.useGarminDeviceCountsQuery.mockReturnValue({
       data: {
-        garminActivities: {
-          total: 4,
-          limit: 1000,
-          offset: 0,
-          items: [
-            {
-              activity_id: '1',
-              sport: 'cycling',
-              device: { model: 'Edge 540 Solar' },
-            },
-            {
-              activity_id: '2',
-              sport: 'cycling',
-              device: { model: 'Edge 540 Solar' },
-            },
-            {
-              activity_id: '3',
-              sport: 'running',
-              device: { model: 'Forerunner 955' },
-            },
-            {
-              activity_id: '4',
-              sport: 'running',
-              device: null,
-            },
-          ],
-        },
+        garminDeviceCounts: [
+          { label: 'Edge 540 Solar', activity_count: 2 },
+          { label: 'Forerunner 955', activity_count: 1 },
+          { label: 'Manual', activity_count: 1 },
+        ],
       },
       loading: false,
     })

--- a/src/pages/DashboardPage.test.tsx
+++ b/src/pages/DashboardPage.test.tsx
@@ -48,7 +48,14 @@ describe('DashboardPage', () => {
       loading: false,
     })
     dashboardHooks.useGarminActivitiesQuery.mockReturnValue({
-      data: undefined,
+      data: {
+        garminActivities: {
+          total: 0,
+          limit: 1000,
+          offset: 0,
+          items: [],
+        },
+      },
       loading: false,
     })
     dashboardHooks.useGarminActivityTotalsQuery.mockReturnValue({
@@ -130,6 +137,38 @@ describe('DashboardPage', () => {
       },
       loading: false,
     })
+    dashboardHooks.useGarminActivitiesQuery.mockReturnValue({
+      data: {
+        garminActivities: {
+          total: 4,
+          limit: 1000,
+          offset: 0,
+          items: [
+            {
+              activity_id: '1',
+              sport: 'cycling',
+              device: { model: 'Edge 540 Solar' },
+            },
+            {
+              activity_id: '2',
+              sport: 'cycling',
+              device: { model: 'Edge 540 Solar' },
+            },
+            {
+              activity_id: '3',
+              sport: 'running',
+              device: { model: 'Forerunner 955' },
+            },
+            {
+              activity_id: '4',
+              sport: 'running',
+              device: null,
+            },
+          ],
+        },
+      },
+      loading: false,
+    })
 
     render(<DashboardPage />)
 
@@ -139,5 +178,9 @@ describe('DashboardPage', () => {
     expect(screen.getByText('v1.2.3')).toBeInTheDocument()
     expect(screen.getByText('running')).toBeInTheDocument()
     expect(screen.getByText('cycling')).toBeInTheDocument()
+    expect(screen.getByText('Devices')).toBeInTheDocument()
+    expect(screen.getByText('Edge 540 Solar')).toBeInTheDocument()
+    expect(screen.getByText('Forerunner 955')).toBeInTheDocument()
+    expect(screen.getByText('Manual')).toBeInTheDocument()
   })
 })

--- a/src/pages/DashboardPage.test.tsx
+++ b/src/pages/DashboardPage.test.tsx
@@ -90,6 +90,32 @@ describe('DashboardPage', () => {
     expect(screen.getByText('Loading dashboard...')).toBeInTheDocument()
   })
 
+  it('keeps loading while a dashboard metric query has no data yet', () => {
+    dashboardHooks.useHealthQuery.mockReturnValue({
+      data: { health: { status: 'healthy', version: '1.0.0' } },
+      loading: false,
+    })
+    dashboardHooks.useLocationCountQuery.mockReturnValue({
+      data: { locationCount: { count: 4321 } },
+      loading: false,
+      error: undefined,
+      refetch: vi.fn(),
+    })
+    dashboardHooks.useGarminSportsQuery.mockReturnValue({
+      data: undefined,
+      loading: true,
+    })
+    dashboardHooks.useGarminDeviceCountsQuery.mockReturnValue({
+      data: { garminDeviceCounts: [] },
+      loading: false,
+    })
+
+    render(<DashboardPage />)
+
+    expect(screen.getByText('Loading dashboard...')).toBeInTheDocument()
+    expect(screen.queryByText('4,321')).not.toBeInTheDocument()
+  })
+
   it('shows an error state and retries the count query', async () => {
     const user = userEvent.setup()
     const refetch = vi.fn()

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -29,14 +29,20 @@ export function DashboardPage() {
   const { data: deviceCountsData, loading: deviceCountsLoading } =
     useGarminDeviceCountsQuery()
 
-  if (countLoading && sportsLoading && healthLoading && deviceCountsLoading) {
-    return <LoadingState message="Loading dashboard..." />
-  }
-
   if (countError) {
     return (
       <ErrorState message={countError.message} onRetry={() => refetchCount()} />
     )
+  }
+
+  const initialDashboardLoading =
+    (healthLoading && !healthData) ||
+    (countLoading && !countData) ||
+    (sportsLoading && !sportsData) ||
+    (deviceCountsLoading && !deviceCountsData)
+
+  if (initialDashboardLoading) {
+    return <LoadingState message="Loading dashboard..." />
   }
 
   const totalLocations = countData?.locationCount?.count ?? 0

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -1,8 +1,14 @@
+import { useEffect, useMemo, useState } from 'react'
 import {
+  GarminActivitiesDocument,
+  type GarminActivitiesQuery,
+  type GarminActivitiesQueryVariables,
   useHealthQuery,
   useLocationCountQuery,
+  useGarminActivitiesQuery,
   useGarminSportsQuery,
 } from '@/__generated__/graphql'
+import { useApolloClient } from '@apollo/client/react'
 import { MapPin, Activity, Heart } from 'lucide-react'
 import { StatsCard } from '@/components/shared/StatsCard'
 import { LoadingState } from '@/components/shared/LoadingState'
@@ -14,7 +20,18 @@ import { GarminActivityHeatmap } from '@/components/dashboard/GarminActivityHeat
 import { GarminActivityTotals } from '@/components/dashboard/GarminActivityTotals'
 import { CyclingInFocus } from '@/components/dashboard/CyclingInFocus'
 
+const GARMIN_ACTIVITY_PAGE_SIZE = 1000
+const MANUAL_DEVICE_LABEL = 'Manual'
+
+type GarminActivityRow =
+  GarminActivitiesQuery['garminActivities']['items'][number]
+
+function getActivityDeviceLabel(activity: GarminActivityRow): string {
+  return activity.device?.model?.trim() || MANUAL_DEVICE_LABEL
+}
+
 export function DashboardPage() {
+  const apolloClient = useApolloClient()
   const { data: healthData, loading: healthLoading } = useHealthQuery()
   const {
     data: countData,
@@ -23,6 +40,97 @@ export function DashboardPage() {
     refetch: refetchCount,
   } = useLocationCountQuery()
   const { data: sportsData, loading: sportsLoading } = useGarminSportsQuery()
+  const { data: deviceActivityData } = useGarminActivitiesQuery({
+    variables: {
+      limit: GARMIN_ACTIVITY_PAGE_SIZE,
+      offset: 0,
+      sort: 'start_time',
+      order: 'desc',
+    },
+  })
+  const [extraDeviceActivities, setExtraDeviceActivities] = useState<{
+    total: number
+    items: GarminActivityRow[]
+  } | null>(null)
+
+  useEffect(() => {
+    const firstPage = deviceActivityData?.garminActivities
+    if (!firstPage || firstPage.total <= firstPage.items.length) {
+      return
+    }
+
+    let cancelled = false
+    const fetchRemainingActivities = async () => {
+      const offsets: number[] = []
+      for (
+        let offset = GARMIN_ACTIVITY_PAGE_SIZE;
+        offset < firstPage.total;
+        offset += GARMIN_ACTIVITY_PAGE_SIZE
+      ) {
+        offsets.push(offset)
+      }
+
+      const results = await Promise.all(
+        offsets.map((offset) =>
+          apolloClient.query<
+            GarminActivitiesQuery,
+            GarminActivitiesQueryVariables
+          >({
+            query: GarminActivitiesDocument,
+            variables: {
+              limit: GARMIN_ACTIVITY_PAGE_SIZE,
+              offset,
+              sort: 'start_time',
+              order: 'desc',
+            },
+            fetchPolicy: 'cache-first',
+          }),
+        ),
+      )
+
+      if (cancelled) return
+      setExtraDeviceActivities({
+        total: firstPage.total,
+        items: results.flatMap(
+          (result) => result.data?.garminActivities.items ?? [],
+        ),
+      })
+    }
+
+    void fetchRemainingActivities()
+
+    return () => {
+      cancelled = true
+    }
+  }, [apolloClient, deviceActivityData])
+
+  const deviceMetrics = useMemo(() => {
+    const firstPage = deviceActivityData?.garminActivities
+    const needsExtraPages =
+      firstPage && firstPage.total > firstPage.items.length
+    const extraActivities =
+      firstPage && extraDeviceActivities?.total === firstPage.total
+        ? extraDeviceActivities.items
+        : []
+    if (needsExtraPages && extraActivities.length === 0) {
+      return []
+    }
+    const activities = [...(firstPage?.items ?? []), ...extraActivities]
+    const counts = new Map<string, number>()
+
+    activities.forEach((activity) => {
+      const label = getActivityDeviceLabel(activity)
+      counts.set(label, (counts.get(label) ?? 0) + 1)
+    })
+
+    return Array.from(counts.entries())
+      .map(([label, count]) => ({ label, count }))
+      .sort((a, b) => {
+        if (a.label === MANUAL_DEVICE_LABEL) return 1
+        if (b.label === MANUAL_DEVICE_LABEL) return -1
+        return b.count - a.count || a.label.localeCompare(b.label)
+      })
+  }, [deviceActivityData, extraDeviceActivities])
 
   if (countLoading && sportsLoading && healthLoading) {
     return <LoadingState message="Loading dashboard..." />
@@ -41,6 +149,12 @@ export function DashboardPage() {
       (sum: number, s: { activity_count: number }) => sum + s.activity_count,
       0,
     ) ?? 0
+  const physicalDeviceMetrics = deviceMetrics.filter(
+    (metric) => metric.label !== MANUAL_DEVICE_LABEL,
+  )
+  const manualDeviceMetric = deviceMetrics.find(
+    (metric) => metric.label === MANUAL_DEVICE_LABEL,
+  )
 
   return (
     <div className="space-y-6">
@@ -75,13 +189,16 @@ export function DashboardPage() {
       <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
         <CyclingInFocus />
 
-        <Card>
+        <Card data-testid="garmin-sports-card">
           <CardHeader>
             <CardTitle>Garmin Sports</CardTitle>
           </CardHeader>
-          <CardContent>
+          <CardContent className="space-y-4">
             {sportsData?.garminSports?.length ? (
               <div className="space-y-2">
+                <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                  Sports
+                </p>
                 {sportsData.garminSports.map(
                   (s: { sport: string; activity_count: number }) => (
                     <div
@@ -99,6 +216,34 @@ export function DashboardPage() {
                 No activities found
               </p>
             )}
+            {deviceMetrics.length ? (
+              <div className="space-y-2 border-t pt-3">
+                <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                  Devices
+                </p>
+                {physicalDeviceMetrics.map((device) => (
+                  <div
+                    key={device.label}
+                    data-testid="garmin-device-row"
+                    className="flex items-center justify-between gap-3"
+                  >
+                    <span className="truncate text-sm">{device.label}</span>
+                    <Badge variant="outline">{device.count}</Badge>
+                  </div>
+                ))}
+                {manualDeviceMetric ? (
+                  <div
+                    data-testid="garmin-manual-row"
+                    className="flex items-center justify-between gap-3"
+                  >
+                    <span className="truncate text-sm">
+                      {manualDeviceMetric.label}
+                    </span>
+                    <Badge variant="outline">{manualDeviceMetric.count}</Badge>
+                  </div>
+                ) : null}
+              </div>
+            ) : null}
           </CardContent>
         </Card>
 

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -1,14 +1,9 @@
-import { useEffect, useMemo, useState } from 'react'
 import {
-  GarminActivitiesDocument,
-  type GarminActivitiesQuery,
-  type GarminActivitiesQueryVariables,
   useHealthQuery,
   useLocationCountQuery,
-  useGarminActivitiesQuery,
+  useGarminDeviceCountsQuery,
   useGarminSportsQuery,
 } from '@/__generated__/graphql'
-import { useApolloClient } from '@apollo/client/react'
 import { MapPin, Activity, Heart } from 'lucide-react'
 import { StatsCard } from '@/components/shared/StatsCard'
 import { LoadingState } from '@/components/shared/LoadingState'
@@ -20,18 +15,9 @@ import { GarminActivityHeatmap } from '@/components/dashboard/GarminActivityHeat
 import { GarminActivityTotals } from '@/components/dashboard/GarminActivityTotals'
 import { CyclingInFocus } from '@/components/dashboard/CyclingInFocus'
 
-const GARMIN_ACTIVITY_PAGE_SIZE = 1000
 const MANUAL_DEVICE_LABEL = 'Manual'
 
-type GarminActivityRow =
-  GarminActivitiesQuery['garminActivities']['items'][number]
-
-function getActivityDeviceLabel(activity: GarminActivityRow): string {
-  return activity.device?.model?.trim() || MANUAL_DEVICE_LABEL
-}
-
 export function DashboardPage() {
-  const apolloClient = useApolloClient()
   const { data: healthData, loading: healthLoading } = useHealthQuery()
   const {
     data: countData,
@@ -40,99 +26,10 @@ export function DashboardPage() {
     refetch: refetchCount,
   } = useLocationCountQuery()
   const { data: sportsData, loading: sportsLoading } = useGarminSportsQuery()
-  const { data: deviceActivityData } = useGarminActivitiesQuery({
-    variables: {
-      limit: GARMIN_ACTIVITY_PAGE_SIZE,
-      offset: 0,
-      sort: 'start_time',
-      order: 'desc',
-    },
-  })
-  const [extraDeviceActivities, setExtraDeviceActivities] = useState<{
-    total: number
-    items: GarminActivityRow[]
-  } | null>(null)
+  const { data: deviceCountsData, loading: deviceCountsLoading } =
+    useGarminDeviceCountsQuery()
 
-  useEffect(() => {
-    const firstPage = deviceActivityData?.garminActivities
-    if (!firstPage || firstPage.total <= firstPage.items.length) {
-      return
-    }
-
-    let cancelled = false
-    const fetchRemainingActivities = async () => {
-      const offsets: number[] = []
-      for (
-        let offset = GARMIN_ACTIVITY_PAGE_SIZE;
-        offset < firstPage.total;
-        offset += GARMIN_ACTIVITY_PAGE_SIZE
-      ) {
-        offsets.push(offset)
-      }
-
-      const results = await Promise.all(
-        offsets.map((offset) =>
-          apolloClient.query<
-            GarminActivitiesQuery,
-            GarminActivitiesQueryVariables
-          >({
-            query: GarminActivitiesDocument,
-            variables: {
-              limit: GARMIN_ACTIVITY_PAGE_SIZE,
-              offset,
-              sort: 'start_time',
-              order: 'desc',
-            },
-            fetchPolicy: 'cache-first',
-          }),
-        ),
-      )
-
-      if (cancelled) return
-      setExtraDeviceActivities({
-        total: firstPage.total,
-        items: results.flatMap(
-          (result) => result.data?.garminActivities.items ?? [],
-        ),
-      })
-    }
-
-    void fetchRemainingActivities()
-
-    return () => {
-      cancelled = true
-    }
-  }, [apolloClient, deviceActivityData])
-
-  const deviceMetrics = useMemo(() => {
-    const firstPage = deviceActivityData?.garminActivities
-    const needsExtraPages =
-      firstPage && firstPage.total > firstPage.items.length
-    const extraActivities =
-      firstPage && extraDeviceActivities?.total === firstPage.total
-        ? extraDeviceActivities.items
-        : []
-    if (needsExtraPages && extraActivities.length === 0) {
-      return []
-    }
-    const activities = [...(firstPage?.items ?? []), ...extraActivities]
-    const counts = new Map<string, number>()
-
-    activities.forEach((activity) => {
-      const label = getActivityDeviceLabel(activity)
-      counts.set(label, (counts.get(label) ?? 0) + 1)
-    })
-
-    return Array.from(counts.entries())
-      .map(([label, count]) => ({ label, count }))
-      .sort((a, b) => {
-        if (a.label === MANUAL_DEVICE_LABEL) return 1
-        if (b.label === MANUAL_DEVICE_LABEL) return -1
-        return b.count - a.count || a.label.localeCompare(b.label)
-      })
-  }, [deviceActivityData, extraDeviceActivities])
-
-  if (countLoading && sportsLoading && healthLoading) {
+  if (countLoading && sportsLoading && healthLoading && deviceCountsLoading) {
     return <LoadingState message="Loading dashboard..." />
   }
 
@@ -149,6 +46,7 @@ export function DashboardPage() {
       (sum: number, s: { activity_count: number }) => sum + s.activity_count,
       0,
     ) ?? 0
+  const deviceMetrics = deviceCountsData?.garminDeviceCounts ?? []
   const physicalDeviceMetrics = deviceMetrics.filter(
     (metric) => metric.label !== MANUAL_DEVICE_LABEL,
   )
@@ -228,7 +126,7 @@ export function DashboardPage() {
                     className="flex items-center justify-between gap-3"
                   >
                     <span className="truncate text-sm">{device.label}</span>
-                    <Badge variant="outline">{device.count}</Badge>
+                    <Badge variant="outline">{device.activity_count}</Badge>
                   </div>
                 ))}
                 {manualDeviceMetric ? (
@@ -239,7 +137,9 @@ export function DashboardPage() {
                     <span className="truncate text-sm">
                       {manualDeviceMetric.label}
                     </span>
-                    <Badge variant="outline">{manualDeviceMetric.count}</Badge>
+                    <Badge variant="outline">
+                      {manualDeviceMetric.activity_count}
+                    </Badge>
                   </div>
                 ) : null}
               </div>


### PR DESCRIPTION
## Summary

- Use the Gateway `garminDeviceCounts` aggregate query on the dashboard Garmin Sports tile.
- Render physical Garmin device rows plus a `Manual` row for activities without device metadata.
- Remove dashboard-side Garmin activity pagination and client-side device aggregation.
- Add Playwright coverage and screenshots for the updated tile.

## Root Cause / Context

The original UI-only implementation had to page through Garmin activities and group device models in the browser. Now that API and Gateway expose a lightweight aggregate, the dashboard can fetch the small device-count result directly.

## Validation

- `npm run test:run -- src/pages/DashboardPage.test.tsx`
- `npm run type-check`
- `npm run lint`
- `npm run build`
- `BASE_URL=http://localhost:5173 npx playwright test e2e/dashboard-garmin-sports.spec.ts`
- Live Gateway `garminDeviceCounts` query validated against `https://gateway.lab.informationcart.com/`

Playwright screenshot artifacts were generated locally under `e2e/screenshots/dashboard-garmin-sports/`.
