### PR TITLE
[codex] add Garmin heart rate zone summaries

### DIFF
--- a/src/components/garmin/ActivityStatsPanel.test.tsx
+++ b/src/components/garmin/ActivityStatsPanel.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from '@testing-library/react'
 import { describe, expect, it } from 'vitest'
 import { ActivityStatsPanel } from './ActivityStatsPanel'
+import { buildHeartRateZoneSummaries } from './heartRateZoneSummary'
 
 describe('ActivityStatsPanel', () => {
   it('renders converted metrics across activity sections', () => {
@@ -106,5 +107,136 @@ describe('ActivityStatsPanel', () => {
     expect(screen.getByText('30 min')).toBeInTheDocument()
     // No x2 badge when vigorous minutes are absent.
     expect(screen.queryByText('x2')).not.toBeInTheDocument()
+  })
+
+  it('renders heart-rate zone time totals when zoned chart points are available', () => {
+    render(
+      <ActivityStatsPanel
+        activity={{
+          avg_heart_rate: 145,
+          max_heart_rate: 176,
+          hr_available: true,
+        }}
+        heartRateZonePoints={[
+          {
+            timestamp: '2026-03-14T09:00:00Z',
+            heart_rate: 118,
+            hr_zone: 2,
+          },
+          {
+            timestamp: '2026-03-14T09:10:00Z',
+            heart_rate: 135,
+            hr_zone: 2,
+          },
+          {
+            timestamp: '2026-03-14T09:20:00Z',
+            heart_rate: 158,
+            hr_zone: 4,
+          },
+          {
+            timestamp: '2026-03-14T09:30:00Z',
+            heart_rate: 148,
+            hr_zone: 3,
+          },
+          {
+            timestamp: '2026-03-14T09:40:00Z',
+            heart_rate: 149,
+            hr_zone: 3,
+          },
+        ]}
+      />,
+    )
+
+    expect(screen.getByTestId('heart-rate-zone-breakdown')).toBeInTheDocument()
+    expect(screen.getByText('Zone 4')).toBeInTheDocument()
+    expect(screen.getByText(/158 bpm/)).toBeInTheDocument()
+    expect(screen.getByText(/148 - 149 bpm/)).toBeInTheDocument()
+    expect(screen.getByLabelText('Zone 2: 20:00 (50%)')).toBeInTheDocument()
+    expect(screen.getByLabelText('Zone 4: 10:00 (25%)')).toBeInTheDocument()
+    expect(screen.getByLabelText('Zone 3: 10:00 (25%)')).toBeInTheDocument()
+  })
+
+  it('does not render heart-rate zone totals without valid zone durations', () => {
+    render(
+      <ActivityStatsPanel
+        activity={{ avg_heart_rate: 145, hr_available: true }}
+        heartRateZonePoints={[
+          { timestamp: '2026-03-14T09:00:00Z', heart_rate: 118 },
+          { timestamp: '2026-03-14T09:10:00Z', heart_rate: 135 },
+        ]}
+      />,
+    )
+
+    expect(
+      screen.queryByTestId('heart-rate-zone-breakdown'),
+    ).not.toBeInTheDocument()
+  })
+
+  it('builds heart-rate zone summaries from consecutive timestamp deltas', () => {
+    expect(
+      buildHeartRateZoneSummaries([
+        {
+          timestamp: '2026-03-14T09:00:00Z',
+          heart_rate: 100,
+          hr_zone: 1,
+        },
+        {
+          timestamp: '2026-03-14T09:05:00Z',
+          heart_rate: 120,
+          hr_zone: 2,
+        },
+        {
+          timestamp: '2026-03-14T09:15:00Z',
+          heart_rate: 130,
+          hr_zone: 2,
+        },
+        {
+          timestamp: '2026-03-14T09:15:00Z',
+          heart_rate: 170,
+          hr_zone: 5,
+        },
+        {
+          timestamp: '2026-03-14T09:20:00Z',
+          heart_rate: 180,
+          hr_zone: 8,
+        },
+      ]),
+    ).toEqual([
+      {
+        zone: 5,
+        seconds: 300,
+        percent: 25,
+        minHeartRate: 170,
+        maxHeartRate: 170,
+      },
+      {
+        zone: 4,
+        seconds: 0,
+        percent: 0,
+        minHeartRate: null,
+        maxHeartRate: null,
+      },
+      {
+        zone: 3,
+        seconds: 0,
+        percent: 0,
+        minHeartRate: null,
+        maxHeartRate: null,
+      },
+      {
+        zone: 2,
+        seconds: 600,
+        percent: 50,
+        minHeartRate: 120,
+        maxHeartRate: 130,
+      },
+      {
+        zone: 1,
+        seconds: 300,
+        percent: 25,
+        minHeartRate: 100,
+        maxHeartRate: 100,
+      },
+    ])
   })
 })

--- a/src/components/garmin/ActivityStatsPanel.tsx
+++ b/src/components/garmin/ActivityStatsPanel.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from 'react'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import {
   kmToMi,
@@ -144,8 +145,10 @@ export function ActivityStatsPanel({
 }: ActivityStatsPanelProps) {
   const hrAvailable =
     a.hr_available ?? (a.avg_heart_rate != null || a.max_heart_rate != null)
-  const heartRateZoneSummaries =
-    buildHeartRateZoneSummaries(heartRateZonePoints)
+  const heartRateZoneSummaries = useMemo(
+    () => (hrAvailable ? buildHeartRateZoneSummaries(heartRateZonePoints) : []),
+    [heartRateZonePoints, hrAvailable],
+  )
 
   const sections: StatSection[] = [
     {

--- a/src/components/garmin/ActivityStatsPanel.tsx
+++ b/src/components/garmin/ActivityStatsPanel.tsx
@@ -7,6 +7,12 @@ import {
   formatDuration,
   formatPace,
 } from '@/lib/units'
+import type { ActivityChartTrackPoint } from './ActivityChartData'
+import { ZONE_COLORS } from './heartRateZones'
+import {
+  buildHeartRateZoneSummaries,
+  type HeartRateZoneSummary,
+} from './heartRateZoneSummary'
 
 interface ActivityStatsPanelProps {
   activity: {
@@ -44,6 +50,7 @@ interface ActivityStatsPanelProps {
     max_temperature_c?: number | null
     avg_pace?: number | null
   }
+  heartRateZonePoints?: ActivityChartTrackPoint[]
 }
 
 interface StatRow {
@@ -66,9 +73,79 @@ function fmt(
   return `${val.toFixed(decimals)} ${unit}`
 }
 
-export function ActivityStatsPanel({ activity: a }: ActivityStatsPanelProps) {
+function HeartRateZoneBreakdown({
+  summaries,
+}: {
+  summaries: HeartRateZoneSummary[]
+}) {
+  const hasZoneTime = summaries.some((summary) => summary.seconds > 0)
+  if (!hasZoneTime) return null
+
+  return (
+    <Card data-testid="heart-rate-zone-breakdown" className="lg:col-span-3">
+      <CardHeader className="pb-2">
+        <CardTitle className="text-sm font-semibold">
+          Heart Rate Zones
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {summaries.map((summary) => {
+          const observedRange =
+            summary.minHeartRate != null && summary.maxHeartRate != null
+              ? summary.minHeartRate === summary.maxHeartRate
+                ? `${summary.minHeartRate} bpm`
+                : `${summary.minHeartRate} - ${summary.maxHeartRate} bpm`
+              : null
+
+          return (
+            <div
+              className="grid gap-2 text-sm sm:grid-cols-[minmax(10rem,16rem)_1fr_auto]"
+              key={summary.zone}
+            >
+              <div>
+                <span className="font-semibold">Zone {summary.zone}</span>
+                {observedRange && (
+                  <span className="text-muted-foreground">
+                    {' '}
+                    · {observedRange}
+                  </span>
+                )}
+              </div>
+              <div
+                aria-label={`Zone ${summary.zone}: ${formatDuration(summary.seconds)} (${summary.percent}%)`}
+                className="h-6 overflow-hidden rounded-sm bg-muted"
+                role="img"
+              >
+                <div
+                  className="h-full"
+                  style={{
+                    backgroundColor: ZONE_COLORS[summary.zone],
+                    width: `${summary.percent}%`,
+                  }}
+                />
+              </div>
+              <div className="flex min-w-24 justify-end gap-3 font-medium tabular-nums">
+                <span>{formatDuration(summary.seconds)}</span>
+                <span className="w-9 text-right text-muted-foreground">
+                  {summary.percent}%
+                </span>
+              </div>
+            </div>
+          )
+        })}
+      </CardContent>
+    </Card>
+  )
+}
+
+export function ActivityStatsPanel({
+  activity: a,
+  heartRateZonePoints = [],
+}: ActivityStatsPanelProps) {
   const hrAvailable =
     a.hr_available ?? (a.avg_heart_rate != null || a.max_heart_rate != null)
+  const heartRateZoneSummaries =
+    buildHeartRateZoneSummaries(heartRateZonePoints)
 
   const sections: StatSection[] = [
     {
@@ -345,6 +422,9 @@ export function ActivityStatsPanel({ activity: a }: ActivityStatsPanelProps) {
 
   return (
     <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+      {hrAvailable && (
+        <HeartRateZoneBreakdown summaries={heartRateZoneSummaries} />
+      )}
       {sections.map((section) => (
         <Card key={section.title}>
           <CardHeader className="pb-2">

--- a/src/components/garmin/heartRateZoneSummary.ts
+++ b/src/components/garmin/heartRateZoneSummary.ts
@@ -1,0 +1,66 @@
+import type { ActivityChartTrackPoint } from './ActivityChartData'
+
+export interface HeartRateZoneSummary {
+  zone: number
+  seconds: number
+  percent: number
+  minHeartRate: number | null
+  maxHeartRate: number | null
+}
+
+function validZone(value: number | null | undefined): number | null {
+  return value != null && Number.isInteger(value) && value >= 1 && value <= 5
+    ? value
+    : null
+}
+
+export function buildHeartRateZoneSummaries(
+  points: ActivityChartTrackPoint[],
+): HeartRateZoneSummary[] {
+  const zoneSeconds = new Map<number, number>()
+  const zoneHeartRates = new Map<number, number[]>()
+  let totalSeconds = 0
+
+  for (const point of points) {
+    const zone = validZone(point.hr_zone)
+    if (zone == null || point.heart_rate == null) continue
+
+    zoneHeartRates.set(zone, [
+      ...(zoneHeartRates.get(zone) ?? []),
+      point.heart_rate,
+    ])
+  }
+
+  for (let index = 0; index < points.length - 1; index += 1) {
+    const point = points[index]
+    const nextPoint = points[index + 1]
+    const zone = validZone(point.hr_zone)
+    if (zone == null) continue
+
+    const startMs = new Date(point.timestamp).getTime()
+    const endMs = new Date(nextPoint.timestamp).getTime()
+    if (
+      !Number.isFinite(startMs) ||
+      !Number.isFinite(endMs) ||
+      endMs <= startMs
+    )
+      continue
+
+    const seconds = (endMs - startMs) / 1000
+    zoneSeconds.set(zone, (zoneSeconds.get(zone) ?? 0) + seconds)
+    totalSeconds += seconds
+  }
+
+  return [5, 4, 3, 2, 1].map((zone) => {
+    const seconds = zoneSeconds.get(zone) ?? 0
+    const heartRates = zoneHeartRates.get(zone) ?? []
+    return {
+      zone,
+      seconds,
+      percent:
+        totalSeconds > 0 ? Math.round((seconds / totalSeconds) * 100) : 0,
+      minHeartRate: heartRates.length > 0 ? Math.min(...heartRates) : null,
+      maxHeartRate: heartRates.length > 0 ? Math.max(...heartRates) : null,
+    }
+  })
+}

--- a/src/components/garmin/heartRateZoneSummary.ts
+++ b/src/components/garmin/heartRateZoneSummary.ts
@@ -25,10 +25,12 @@ export function buildHeartRateZoneSummaries(
     const zone = validZone(point.hr_zone)
     if (zone == null || point.heart_rate == null) continue
 
-    zoneHeartRates.set(zone, [
-      ...(zoneHeartRates.get(zone) ?? []),
-      point.heart_rate,
-    ])
+    const heartRates = zoneHeartRates.get(zone)
+    if (heartRates) {
+      heartRates.push(point.heart_rate)
+    } else {
+      zoneHeartRates.set(zone, [point.heart_rate])
+    }
   }
 
   for (let index = 0; index < points.length - 1; index += 1) {

--- a/src/pages/GarminDetailPage.tsx
+++ b/src/pages/GarminDetailPage.tsx
@@ -442,7 +442,10 @@ export function GarminDetailPage() {
         </TabsList>
 
         <TabsContent value="stats" className="space-y-4">
-          <ActivityStatsPanel activity={{ ...a, hr_available: hasHrData }} />
+          <ActivityStatsPanel
+            activity={{ ...a, hr_available: hasHrData }}
+            heartRateZonePoints={chartPoints}
+          />
         </TabsContent>
 
         <TabsContent value="charts" className="space-y-4">


### PR DESCRIPTION
## Summary

- Add Garmin heart-rate zone time summaries to the activity stats panel.
- Pass chart track points from the Garmin detail page into the stats panel.
- Cover zone rendering and summary calculation with focused tests.

## Validation

- npm run test:run -- ActivityStatsPanel
- npm run type-check
- npm run lint:all
