### PR TITLE
[codex] treat zero heart rate as unavailable

### DIFF
--- a/src/components/garmin/ActivityStatsPanel.test.tsx
+++ b/src/components/garmin/ActivityStatsPanel.test.tsx
@@ -63,6 +63,24 @@ describe('ActivityStatsPanel', () => {
     expect(minHeartRateLabel.nextElementSibling).toHaveTextContent('—')
   })
 
+  it('hides heart-rate sections when only sentinel heart-rate values are present', () => {
+    render(
+      <ActivityStatsPanel
+        activity={{
+          avg_heart_rate: 0,
+          max_heart_rate: -1,
+          min_heart_rate: 0,
+          hr_available: true,
+        }}
+      />,
+    )
+
+    expect(screen.queryByText('Heart Rate')).not.toBeInTheDocument()
+    expect(screen.queryByText('Training Effect')).not.toBeInTheDocument()
+    expect(screen.queryByText('Respiration')).not.toBeInTheDocument()
+    expect(screen.queryByText('Intensity Minutes')).not.toBeInTheDocument()
+  })
+
   it('hides HR-dependent sections when hr data is unavailable', () => {
     render(
       <ActivityStatsPanel

--- a/src/components/garmin/ActivityStatsPanel.test.tsx
+++ b/src/components/garmin/ActivityStatsPanel.test.tsx
@@ -46,6 +46,23 @@ describe('ActivityStatsPanel', () => {
     expect(totalStrokesLabel.nextElementSibling).toHaveTextContent('—')
   })
 
+  it('treats zero heart-rate values as unavailable', () => {
+    render(
+      <ActivityStatsPanel
+        activity={{
+          avg_heart_rate: 113,
+          max_heart_rate: 136,
+          min_heart_rate: 0,
+        }}
+      />,
+    )
+
+    expect(screen.getByText('113 bpm')).toBeInTheDocument()
+    expect(screen.getByText('136 bpm')).toBeInTheDocument()
+    const minHeartRateLabel = screen.getByText('Min Heart Rate')
+    expect(minHeartRateLabel.nextElementSibling).toHaveTextContent('—')
+  })
+
   it('hides HR-dependent sections when hr data is unavailable', () => {
     render(
       <ActivityStatsPanel

--- a/src/components/garmin/ActivityStatsPanel.tsx
+++ b/src/components/garmin/ActivityStatsPanel.tsx
@@ -75,7 +75,11 @@ function fmt(
 }
 
 function formatHeartRate(value: number | null | undefined): string {
-  return value != null && value > 0 ? `${value} bpm` : '—'
+  return isValidHeartRate(value) ? `${value} bpm` : '—'
+}
+
+function isValidHeartRate(value: number | null | undefined): value is number {
+  return value != null && value > 0
 }
 
 function HeartRateZoneBreakdown({
@@ -148,10 +152,11 @@ export function ActivityStatsPanel({
   heartRateZonePoints = [],
 }: ActivityStatsPanelProps) {
   const hrAvailable =
-    a.hr_available ??
-    (formatHeartRate(a.avg_heart_rate) !== '—' ||
-      formatHeartRate(a.max_heart_rate) !== '—' ||
-      formatHeartRate(a.min_heart_rate) !== '—')
+    a.hr_available === false
+      ? false
+      : isValidHeartRate(a.avg_heart_rate) ||
+        isValidHeartRate(a.max_heart_rate) ||
+        isValidHeartRate(a.min_heart_rate)
   const heartRateZoneSummaries = useMemo(
     () => (hrAvailable ? buildHeartRateZoneSummaries(heartRateZonePoints) : []),
     [heartRateZonePoints, hrAvailable],

--- a/src/components/garmin/ActivityStatsPanel.tsx
+++ b/src/components/garmin/ActivityStatsPanel.tsx
@@ -74,6 +74,10 @@ function fmt(
   return `${val.toFixed(decimals)} ${unit}`
 }
 
+function formatHeartRate(value: number | null | undefined): string {
+  return value != null && value > 0 ? `${value} bpm` : '—'
+}
+
 function HeartRateZoneBreakdown({
   summaries,
 }: {
@@ -144,7 +148,10 @@ export function ActivityStatsPanel({
   heartRateZonePoints = [],
 }: ActivityStatsPanelProps) {
   const hrAvailable =
-    a.hr_available ?? (a.avg_heart_rate != null || a.max_heart_rate != null)
+    a.hr_available ??
+    (formatHeartRate(a.avg_heart_rate) !== '—' ||
+      formatHeartRate(a.max_heart_rate) !== '—' ||
+      formatHeartRate(a.min_heart_rate) !== '—')
   const heartRateZoneSummaries = useMemo(
     () => (hrAvailable ? buildHeartRateZoneSummaries(heartRateZonePoints) : []),
     [heartRateZonePoints, hrAvailable],
@@ -229,18 +236,15 @@ export function ActivityStatsPanel({
             rows: [
               {
                 label: 'Avg Heart Rate',
-                value:
-                  a.avg_heart_rate != null ? `${a.avg_heart_rate} bpm` : '—',
+                value: formatHeartRate(a.avg_heart_rate),
               },
               {
                 label: 'Max Heart Rate',
-                value:
-                  a.max_heart_rate != null ? `${a.max_heart_rate} bpm` : '—',
+                value: formatHeartRate(a.max_heart_rate),
               },
               {
                 label: 'Min Heart Rate',
-                value:
-                  a.min_heart_rate != null ? `${a.min_heart_rate} bpm` : '—',
+                value: formatHeartRate(a.min_heart_rate),
               },
             ],
           } satisfies StatSection,


### PR DESCRIPTION
## Summary

- Treat zero and negative heart-rate values as unavailable in the Garmin stats panel.
- Keep the heart-rate section hidden when only sentinel HR values are present.
- Add a regression test for a `0` minimum heart rate rendering as `—`.

## Validation

- npm run test:run -- ActivityStatsPanel
- npm run type-check
- npm run lint:all
