### PR TITLE
[codex] Add Garmin activity climbs tab

### DIFF
--- a/src/__generated__/graphql.ts
+++ b/src/__generated__/graphql.ts
@@ -224,6 +224,81 @@ export type GarminActivityAddress = {
   waypoint_kind: Scalars['String']['output'];
 };
 
+/** Garmin-native ClimbPro typed split for an activity. */
+export type GarminActivityClimb = {
+  __typename?: 'GarminActivityClimb';
+  /** Parent Garmin activity identifier */
+  activity_id: Scalars['String']['output'];
+  /** Average elapsed vertical speed in meters per second */
+  average_elapsed_vertical_speed_mps?: Maybe<Scalars['Float']['output']>;
+  /** Average climb grade percent */
+  average_grade_percent?: Maybe<Scalars['Float']['output']>;
+  /** Average moving speed in meters per second */
+  average_moving_speed_mps?: Maybe<Scalars['Float']['output']>;
+  /** Average speed in meters per second */
+  average_speed_mps?: Maybe<Scalars['Float']['output']>;
+  /** Average temperature in degrees C */
+  average_temperature_c?: Maybe<Scalars['Float']['output']>;
+  /** Average vertical speed in meters per second */
+  average_vertical_speed_mps?: Maybe<Scalars['Float']['output']>;
+  /** BMR calories recorded for this climb */
+  bmr_calories?: Maybe<Scalars['Float']['output']>;
+  /** Calories recorded for this climb */
+  calories?: Maybe<Scalars['Float']['output']>;
+  /** Garmin ClimbPro difficulty */
+  climb_pro_difficulty?: Maybe<Scalars['String']['output']>;
+  /** Garmin ClimbPro typed split type */
+  climb_type?: Maybe<Scalars['String']['output']>;
+  /** UTC timestamp when the row was inserted */
+  created_at?: Maybe<Scalars['String']['output']>;
+  /** Climb distance in meters */
+  distance_meters?: Maybe<Scalars['Float']['output']>;
+  /** Climb duration in seconds */
+  duration_seconds?: Maybe<Scalars['Float']['output']>;
+  /** Elapsed climb duration in seconds */
+  elapsed_duration_seconds?: Maybe<Scalars['Float']['output']>;
+  /** Climb elevation gain in meters */
+  elevation_gain_meters?: Maybe<Scalars['Float']['output']>;
+  /** Climb elevation loss in meters */
+  elevation_loss_meters?: Maybe<Scalars['Float']['output']>;
+  /** Climb end latitude */
+  end_latitude?: Maybe<Scalars['Float']['output']>;
+  /** Climb end longitude */
+  end_longitude?: Maybe<Scalars['Float']['output']>;
+  /** UTC climb end time */
+  end_time?: Maybe<Scalars['String']['output']>;
+  /** Unique climb row identifier */
+  id: Scalars['Float']['output'];
+  /** Maximum climb grade percent */
+  max_grade_percent?: Maybe<Scalars['Float']['output']>;
+  /** Maximum speed in meters per second */
+  max_speed_mps?: Maybe<Scalars['Float']['output']>;
+  /** Maximum temperature in degrees C */
+  max_temperature_c?: Maybe<Scalars['Float']['output']>;
+  /** Garmin message index */
+  message_index?: Maybe<Scalars['Int']['output']>;
+  /** Minimum temperature in degrees C */
+  min_temperature_c?: Maybe<Scalars['Float']['output']>;
+  /** Moving climb duration in seconds */
+  moving_duration_seconds?: Maybe<Scalars['Float']['output']>;
+  /** Zero-based Garmin typed split order */
+  source_split_index: Scalars['Int']['output'];
+  /** Garmin split type label when provided */
+  split_type?: Maybe<Scalars['String']['output']>;
+  /** Climb start elevation in meters */
+  start_elevation_meters?: Maybe<Scalars['Float']['output']>;
+  /** Climb start latitude */
+  start_latitude?: Maybe<Scalars['Float']['output']>;
+  /** Climb start longitude */
+  start_longitude?: Maybe<Scalars['Float']['output']>;
+  /** UTC climb start time */
+  start_time?: Maybe<Scalars['String']['output']>;
+  /** Local climb start time from Garmin */
+  start_time_local?: Maybe<Scalars['String']['output']>;
+  /** UTC timestamp when the row was last updated */
+  updated_at?: Maybe<Scalars['String']['output']>;
+};
+
 /** Paginated list of Garmin activities. */
 export type GarminActivityConnection = {
   __typename?: 'GarminActivityConnection';
@@ -683,6 +758,8 @@ export type Query = {
   garminActivity?: Maybe<GarminActivity>;
   /** Retrieve all reverse-geocoded addresses for a Garmin activity (start, mid-route waypoints, and end). */
   garminActivityAddresses: Array<GarminActivityAddress>;
+  /** Retrieve Garmin-native ClimbPro typed splits for a Garmin activity. */
+  garminActivityClimbs: Array<GarminActivityClimb>;
   /** Aggregate Garmin activity totals grouped by week, month, or year. */
   garminActivityTotals: Array<GarminActivityTotal>;
   /** Retrieve chart-optimised track points for a Garmin activity. */
@@ -755,6 +832,11 @@ export type QueryGarminActivityArgs = {
 
 
 export type QueryGarminActivityAddressesArgs = {
+  activity_id: Scalars['String']['input'];
+};
+
+
+export type QueryGarminActivityClimbsArgs = {
   activity_id: Scalars['String']['input'];
 };
 
@@ -1000,6 +1082,13 @@ export type GarminChartDataQueryVariables = Exact<{
 
 
 export type GarminChartDataQuery = { garminChartData: Array<{ timestamp: string, altitude: number | null, distance_from_start_km: number | null, speed_kmh: number | null, heart_rate: number | null, hr_zone: number | null, respiration_rate: number | null, cadence: number | null, temperature_c: number | null, latitude: number, longitude: number }> };
+
+export type GarminActivityClimbsQueryVariables = Exact<{
+  activity_id: string;
+}>;
+
+
+export type GarminActivityClimbsQuery = { garminActivityClimbs: Array<{ id: number, activity_id: string, source_split_index: number, message_index: number | null, climb_type: string | null, start_time: string | null, end_time: string | null, duration_seconds: number | null, elapsed_duration_seconds: number | null, moving_duration_seconds: number | null, distance_meters: number | null, elevation_gain_meters: number | null, elevation_loss_meters: number | null, start_elevation_meters: number | null, average_grade_percent: number | null, max_grade_percent: number | null, average_speed_mps: number | null, max_speed_mps: number | null, start_latitude: number | null, start_longitude: number | null, end_latitude: number | null, end_longitude: number | null, climb_pro_difficulty: string | null }> };
 
 export type TriggerGarminSyncMutationVariables = Exact<{
   window_hours?: number | null | undefined;
@@ -1641,6 +1730,71 @@ export type GarminChartDataQueryHookResult = ReturnType<typeof useGarminChartDat
 export type GarminChartDataLazyQueryHookResult = ReturnType<typeof useGarminChartDataLazyQuery>;
 export type GarminChartDataSuspenseQueryHookResult = ReturnType<typeof useGarminChartDataSuspenseQuery>;
 export type GarminChartDataQueryResult = ApolloReactCommon.QueryResult<GarminChartDataQuery, GarminChartDataQueryVariables>;
+export const GarminActivityClimbsDocument = gql`
+    query GarminActivityClimbs($activity_id: String!) {
+  garminActivityClimbs(activity_id: $activity_id) {
+    id
+    activity_id
+    source_split_index
+    message_index
+    climb_type
+    start_time
+    end_time
+    duration_seconds
+    elapsed_duration_seconds
+    moving_duration_seconds
+    distance_meters
+    elevation_gain_meters
+    elevation_loss_meters
+    start_elevation_meters
+    average_grade_percent
+    max_grade_percent
+    average_speed_mps
+    max_speed_mps
+    start_latitude
+    start_longitude
+    end_latitude
+    end_longitude
+    climb_pro_difficulty
+  }
+}
+    `;
+
+/**
+ * __useGarminActivityClimbsQuery__
+ *
+ * To run a query within a React component, call `useGarminActivityClimbsQuery` and pass it any options that fit your needs.
+ * When your component renders, `useGarminActivityClimbsQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useGarminActivityClimbsQuery({
+ *   variables: {
+ *      activity_id: // value for 'activity_id'
+ *   },
+ * });
+ */
+export function useGarminActivityClimbsQuery(baseOptions: ApolloReactHooks.QueryHookOptions<GarminActivityClimbsQuery, GarminActivityClimbsQueryVariables> & ({ variables: GarminActivityClimbsQueryVariables; skip?: boolean; } | { skip: boolean; }) ) {
+        const options = {...defaultOptions, ...baseOptions}
+        return ApolloReactHooks.useQuery<GarminActivityClimbsQuery, GarminActivityClimbsQueryVariables>(GarminActivityClimbsDocument, options);
+      }
+export function useGarminActivityClimbsLazyQuery(baseOptions?: ApolloReactHooks.LazyQueryHookOptions<GarminActivityClimbsQuery, GarminActivityClimbsQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return ApolloReactHooks.useLazyQuery<GarminActivityClimbsQuery, GarminActivityClimbsQueryVariables>(GarminActivityClimbsDocument, options);
+        }
+// @ts-ignore
+export function useGarminActivityClimbsSuspenseQuery(baseOptions?: ApolloReactHooks.SuspenseQueryHookOptions<GarminActivityClimbsQuery, GarminActivityClimbsQueryVariables>): ApolloReactHooks.UseSuspenseQueryResult<GarminActivityClimbsQuery, GarminActivityClimbsQueryVariables>;
+export function useGarminActivityClimbsSuspenseQuery(baseOptions?: ApolloReactHooks.SkipToken | ApolloReactHooks.SuspenseQueryHookOptions<GarminActivityClimbsQuery, GarminActivityClimbsQueryVariables>): ApolloReactHooks.UseSuspenseQueryResult<GarminActivityClimbsQuery | undefined, GarminActivityClimbsQueryVariables>;
+export function useGarminActivityClimbsSuspenseQuery(baseOptions?: ApolloReactHooks.SkipToken | ApolloReactHooks.SuspenseQueryHookOptions<GarminActivityClimbsQuery, GarminActivityClimbsQueryVariables>) {
+          const options = baseOptions === ApolloReactHooks.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
+          return ApolloReactHooks.useSuspenseQuery<GarminActivityClimbsQuery, GarminActivityClimbsQueryVariables>(GarminActivityClimbsDocument, options);
+        }
+export type GarminActivityClimbsQueryHookResult = ReturnType<typeof useGarminActivityClimbsQuery>;
+export type GarminActivityClimbsLazyQueryHookResult = ReturnType<typeof useGarminActivityClimbsLazyQuery>;
+export type GarminActivityClimbsSuspenseQueryHookResult = ReturnType<typeof useGarminActivityClimbsSuspenseQuery>;
+export type GarminActivityClimbsQueryResult = ApolloReactCommon.QueryResult<GarminActivityClimbsQuery, GarminActivityClimbsQueryVariables>;
 export const TriggerGarminSyncDocument = gql`
     mutation TriggerGarminSync($window_hours: Int, $lookback: Int) {
   triggerGarminSync(window_hours: $window_hours, lookback: $lookback) {

--- a/src/components/garmin/ActivityStatsPanel.test.tsx
+++ b/src/components/garmin/ActivityStatsPanel.test.tsx
@@ -81,6 +81,36 @@ describe('ActivityStatsPanel', () => {
     expect(screen.queryByText('Intensity Minutes')).not.toBeInTheDocument()
   })
 
+  it('shows heart-rate sections when chart points contain valid heart-rate samples', () => {
+    render(
+      <ActivityStatsPanel
+        activity={{
+          avg_heart_rate: null,
+          max_heart_rate: 0,
+          min_heart_rate: 0,
+          hr_available: true,
+        }}
+        heartRateZonePoints={[
+          {
+            timestamp: '2026-03-14T09:00:00Z',
+            heart_rate: 118,
+            hr_zone: 2,
+          },
+          {
+            timestamp: '2026-03-14T09:10:00Z',
+            heart_rate: 135,
+            hr_zone: 2,
+          },
+        ]}
+      />,
+    )
+
+    expect(screen.getByText('Heart Rate')).toBeInTheDocument()
+    const avgHeartRateLabel = screen.getByText('Avg Heart Rate')
+    expect(avgHeartRateLabel.nextElementSibling).toHaveTextContent('—')
+    expect(screen.getByTestId('heart-rate-zone-breakdown')).toBeInTheDocument()
+  })
+
   it('hides HR-dependent sections when hr data is unavailable', () => {
     render(
       <ActivityStatsPanel

--- a/src/components/garmin/ActivityStatsPanel.tsx
+++ b/src/components/garmin/ActivityStatsPanel.tsx
@@ -151,12 +151,16 @@ export function ActivityStatsPanel({
   activity: a,
   heartRateZonePoints = [],
 }: ActivityStatsPanelProps) {
+  const hasHeartRateSamples = heartRateZonePoints.some((point) =>
+    isValidHeartRate(point.heart_rate),
+  )
   const hrAvailable =
     a.hr_available === false
       ? false
       : isValidHeartRate(a.avg_heart_rate) ||
         isValidHeartRate(a.max_heart_rate) ||
-        isValidHeartRate(a.min_heart_rate)
+        isValidHeartRate(a.min_heart_rate) ||
+        hasHeartRateSamples
   const heartRateZoneSummaries = useMemo(
     () => (hrAvailable ? buildHeartRateZoneSummaries(heartRateZonePoints) : []),
     [heartRateZonePoints, hrAvailable],

--- a/src/graphql/garmin.ts
+++ b/src/graphql/garmin.ts
@@ -219,6 +219,36 @@ export const GARMIN_CHART_DATA_QUERY = gql`
   }
 `
 
+export const GARMIN_ACTIVITY_CLIMBS_QUERY = gql`
+  query GarminActivityClimbs($activity_id: String!) {
+    garminActivityClimbs(activity_id: $activity_id) {
+      id
+      activity_id
+      source_split_index
+      message_index
+      climb_type
+      start_time
+      end_time
+      duration_seconds
+      elapsed_duration_seconds
+      moving_duration_seconds
+      distance_meters
+      elevation_gain_meters
+      elevation_loss_meters
+      start_elevation_meters
+      average_grade_percent
+      max_grade_percent
+      average_speed_mps
+      max_speed_mps
+      start_latitude
+      start_longitude
+      end_latitude
+      end_longitude
+      climb_pro_difficulty
+    }
+  }
+`
+
 export const TRIGGER_GARMIN_SYNC_MUTATION = gql`
   mutation TriggerGarminSync($window_hours: Int, $lookback: Int) {
     triggerGarminSync(window_hours: $window_hours, lookback: $lookback) {

--- a/src/pages/GarminDetailPage.test.tsx
+++ b/src/pages/GarminDetailPage.test.tsx
@@ -8,6 +8,7 @@ const garminDetailHooks = vi.hoisted(() => ({
   useGarminActivityQuery: vi.fn(),
   useGarminTrackPointsQuery: vi.fn(),
   useGarminChartDataQuery: vi.fn(),
+  useGarminActivityClimbsQuery: vi.fn(),
   useGarminExportPointsLazyQuery: vi.fn(),
 }))
 const toastMocks = vi.hoisted(() => ({
@@ -121,6 +122,7 @@ describe('GarminDetailPage', () => {
     garminDetailHooks.useGarminActivityQuery.mockReset()
     garminDetailHooks.useGarminTrackPointsQuery.mockReset()
     garminDetailHooks.useGarminChartDataQuery.mockReset()
+    garminDetailHooks.useGarminActivityClimbsQuery.mockReset()
     garminDetailHooks.useGarminExportPointsLazyQuery.mockReset()
     toastMocks.error.mockReset()
     toastMocks.warning.mockReset()
@@ -130,6 +132,11 @@ describe('GarminDetailPage', () => {
       vi.fn(),
       { loading: false },
     ])
+    garminDetailHooks.useGarminActivityClimbsQuery.mockReturnValue({
+      loading: false,
+      data: { garminActivityClimbs: [] },
+      error: undefined,
+    })
   })
 
   function renderPage(

--- a/src/pages/GarminDetailPage.test.tsx
+++ b/src/pages/GarminDetailPage.test.tsx
@@ -255,6 +255,47 @@ describe('GarminDetailPage', () => {
     ).toBeInTheDocument()
   })
 
+  it('shows the Climbs tab empty state when an activity has no ClimbPro climbs', async () => {
+    const user = userEvent.setup()
+    garminDetailHooks.useGarminActivityQuery.mockReturnValue({
+      loading: false,
+      error: undefined,
+      refetch: vi.fn(),
+      data: {
+        garminActivity: {
+          sport: 'cycling',
+          sub_sport: 'road',
+          start_time: '2026-03-14T09:00:00Z',
+          device_manufacturer: 'Garmin',
+          distance_km: 32,
+          duration_seconds: 5400,
+          avg_speed_kmh: 21,
+          total_ascent_m: 220,
+        },
+      },
+    })
+    garminDetailHooks.useGarminTrackPointsQuery.mockReturnValue({
+      loading: false,
+      data: {
+        garminTrackPoints: {
+          items: [{ latitude: 40.7, longitude: -74.0 }],
+        },
+      },
+    })
+    garminDetailHooks.useGarminChartDataQuery.mockReturnValue({
+      loading: false,
+      error: undefined,
+      data: { garminChartData: [] },
+    })
+
+    renderPage()
+    await user.click(screen.getByTestId('garmin-tab-climbs'))
+
+    expect(
+      screen.getByText('No Garmin ClimbPro climbs found for this activity.'),
+    ).toBeInTheDocument()
+  })
+
   it('selects the nearest chart point when the route map is clicked', async () => {
     const user = userEvent.setup()
     garminDetailHooks.useGarminActivityQuery.mockReturnValue({

--- a/src/pages/GarminDetailPage.tsx
+++ b/src/pages/GarminDetailPage.tsx
@@ -6,7 +6,9 @@ import {
   useGarminActivityQuery,
   useGarminTrackPointsQuery,
   useGarminChartDataQuery,
+  useGarminActivityClimbsQuery,
   useGarminExportPointsLazyQuery,
+  type GarminActivityClimbsQuery,
 } from '@/__generated__/graphql'
 import { LoadingState } from '@/components/shared/LoadingState'
 import { ErrorState } from '@/components/shared/ErrorState'
@@ -28,14 +30,27 @@ import { SegmentAnalysis } from '@/components/garmin/SegmentAnalysis'
 import { ActivityStatsPanel } from '@/components/garmin/ActivityStatsPanel'
 import { Button } from '@/components/ui/button'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table'
 import { setNRCustomAttribute } from '@/lib/newrelic-browser'
 import { escapeCsvValue, triggerDownload } from '@/lib/export'
+import { formatDurationShort, metersToFeet } from '@/lib/units'
 
 /** Douglas-Peucker tolerance in degrees (~1.1 m) for PostGIS ST_Simplify */
 const SIMPLIFY_TOLERANCE = 0.00001
 /** Maximum track points fetched per page when exporting. */
 const EXPORT_PAGE_SIZE = 10000
 const EARTH_RADIUS_M = 6_371_000
+const METERS_PER_MILE = 1609.344
+const MAIN_CLIMB_TYPE = 'CLIMB_PRO_CYCLING_CLIMB'
+
+type ActivityClimb = GarminActivityClimbsQuery['garminActivityClimbs'][number]
 
 function toRadians(degrees: number): number {
   return (degrees * Math.PI) / 180
@@ -87,6 +102,69 @@ function findNearestTrackPoint(
   }
 
   return nearest
+}
+
+function formatDistanceMiles(meters: number | null | undefined): string {
+  return meters != null ? `${(meters / METERS_PER_MILE).toFixed(2)} mi` : '—'
+}
+
+function formatFeet(meters: number | null | undefined): string {
+  return meters != null ? `${metersToFeet(meters).toFixed(0)} ft` : '—'
+}
+
+function formatPercent(value: number | null | undefined): string {
+  return value != null ? `${value.toFixed(2)} %` : '—'
+}
+
+function ActivityClimbsTable({ climbs }: { climbs: ActivityClimb[] }) {
+  const mainClimbs = climbs.filter(
+    (climb) => climb.climb_type === MAIN_CLIMB_TYPE,
+  )
+
+  if (mainClimbs.length === 0) {
+    return (
+      <div className="rounded-md border border-dashed p-6 text-sm text-muted-foreground">
+        No Garmin ClimbPro climbs found for this activity.
+      </div>
+    )
+  }
+
+  return (
+    <div className="overflow-x-auto rounded-md border">
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>Climb</TableHead>
+            <TableHead>Time</TableHead>
+            <TableHead>Distance</TableHead>
+            <TableHead>Ascent</TableHead>
+            <TableHead>Grade</TableHead>
+            <TableHead>Max Grade</TableHead>
+            <TableHead>Difficulty</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {mainClimbs.map((climb, index) => (
+            <TableRow key={climb.id}>
+              <TableCell className="font-medium">Climb {index + 1}</TableCell>
+              <TableCell>
+                {formatDurationShort(climb.duration_seconds ?? null)}
+              </TableCell>
+              <TableCell>
+                {formatDistanceMiles(climb.distance_meters)}
+              </TableCell>
+              <TableCell>{formatFeet(climb.elevation_gain_meters)}</TableCell>
+              <TableCell>
+                {formatPercent(climb.average_grade_percent)}
+              </TableCell>
+              <TableCell>{formatPercent(climb.max_grade_percent)}</TableCell>
+              <TableCell>{climb.climb_pro_difficulty ?? '—'}</TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </div>
+  )
 }
 
 export function GarminDetailPage() {
@@ -339,6 +417,14 @@ export function GarminDetailPage() {
     skip: !activityId,
     fetchPolicy: 'no-cache',
   })
+  const {
+    data: climbsData,
+    loading: climbsLoading,
+    error: climbsError,
+  } = useGarminActivityClimbsQuery({
+    variables: { activity_id: activityId ?? '' },
+    skip: !activityId,
+  })
   // Resolve map clicks against the *full-resolution* track series (not the
   // downsampled chart series) so the selected point is the true nearest
   // location, then convert it into the chart/display shape using the same
@@ -385,6 +471,7 @@ export function GarminDetailPage() {
 
   const mapTrackPoints = mapTrackData?.garminTrackPoints?.items ?? []
   const chartPoints = chartData?.garminChartData ?? []
+  const climbs = climbsData?.garminActivityClimbs ?? []
   const hasHrData =
     a.avg_heart_rate != null ||
     a.max_heart_rate != null ||
@@ -438,6 +525,9 @@ export function GarminDetailPage() {
           </TabsTrigger>
           <TabsTrigger value="charts" data-testid="garmin-tab-charts">
             Charts
+          </TabsTrigger>
+          <TabsTrigger value="climbs" data-testid="garmin-tab-climbs">
+            Climbs
           </TabsTrigger>
         </TabsList>
 
@@ -534,6 +624,16 @@ export function GarminDetailPage() {
               />
               <SegmentAnalysis points={savedPoints} />
             </>
+          )}
+        </TabsContent>
+
+        <TabsContent value="climbs" className="space-y-4">
+          {climbsLoading && <LoadingState message="Loading climbs..." />}
+          {climbsError && (
+            <ErrorState message={`Climbs failed: ${climbsError.message}`} />
+          )}
+          {!climbsLoading && !climbsError && (
+            <ActivityClimbsTable climbs={climbs} />
           )}
         </TabsContent>
       </Tabs>


### PR DESCRIPTION
## Summary
- Adds GarminActivityClimbs GraphQL operation.
- Adds a Climbs tab to the Garmin Activity detail page.
- Renders Garmin-native main ClimbPro rows with time, distance, ascent, grade, max grade, and difficulty.

## Validation
- GRAPHQL_SCHEMA_PATH=../otel-data-gateway/src/schema/schema.graphql npm run codegen
- npm run lint:all
- npm run type-check
- npm run test:run
- Local UI available at http://localhost:5173/ with API/gateway dev servers running.

## Dependency
- Requires the gateway GraphQL schema/types PR before normal package-based UI codegen can use the new query.
