### PR TITLE
[codex] Add inline Garmin climb details

### DIFF
--- a/e2e/garmin-climbs.spec.ts
+++ b/e2e/garmin-climbs.spec.ts
@@ -1,0 +1,44 @@
+import { test, expect } from '@playwright/test'
+import fs from 'fs'
+import path from 'path'
+
+const SCREENSHOT_DIR = path.join('e2e', 'screenshots', 'garmin-climbs')
+const ACTIVITY_ID =
+  process.env.PLAYWRIGHT_GARMIN_CLIMB_ACTIVITY_ID ?? '23390888525'
+
+fs.mkdirSync(SCREENSHOT_DIR, { recursive: true })
+
+test.describe('Garmin Activity Climbs', () => {
+  test('renders selectable climbs with inline graph and map details', async ({
+    page,
+  }) => {
+    await page.goto(`/garmin/${ACTIVITY_ID}`)
+
+    await expect(page.getByTestId('garmin-detail-tabs')).toBeVisible({
+      timeout: 20_000,
+    })
+    await page.getByTestId('garmin-tab-climbs').click()
+
+    const firstClimb = page.getByTestId('climb-row-1')
+    const secondClimb = page.getByTestId('climb-row-2')
+    const details = page.getByTestId('climb-details-panel')
+
+    await expect(firstClimb).toBeVisible({ timeout: 20_000 })
+    await expect(secondClimb).toBeVisible({ timeout: 20_000 })
+    await expect(firstClimb).toHaveAttribute('aria-pressed', 'true')
+    await expect(details).toContainText('Climb 1 of 2')
+    await expect(page.getByTestId('climb-elevation-grade-chart')).toBeVisible()
+    await expect(page.getByTestId('climb-segment-map')).toBeVisible({
+      timeout: 20_000,
+    })
+
+    await secondClimb.click()
+    await expect(secondClimb).toHaveAttribute('aria-pressed', 'true')
+    await expect(details).toContainText('Climb 2 of 2')
+
+    await page.screenshot({
+      path: path.join(SCREENSHOT_DIR, 'climbs-inline-detail.png'),
+      fullPage: true,
+    })
+  })
+})

--- a/src/components/garmin/ClimbDetailsPanel.helpers.ts
+++ b/src/components/garmin/ClimbDetailsPanel.helpers.ts
@@ -1,0 +1,46 @@
+import type { GarminActivityClimbsQuery } from '@/__generated__/graphql'
+import type { ActivityChartTrackPoint } from '@/components/garmin/ActivityChartData'
+
+type ActivityClimb = GarminActivityClimbsQuery['garminActivityClimbs'][number]
+
+export interface GradeBucket {
+  label: string
+  color: string
+  className: string
+}
+
+export const GRADE_BUCKETS: GradeBucket[] = [
+  { label: '<3%', color: '#22c55e', className: 'bg-green-500' },
+  { label: '3-6%', color: '#facc15', className: 'bg-yellow-400' },
+  { label: '6-9%', color: '#f97316', className: 'bg-orange-500' },
+  { label: '9-12%', color: '#ef4444', className: 'bg-red-500' },
+  { label: '>12%', color: '#dc2626', className: 'bg-red-600' },
+]
+
+function parseTime(value: string | null | undefined): number | null {
+  if (!value) return null
+  const timestamp = new Date(value).getTime()
+  return Number.isFinite(timestamp) ? timestamp : null
+}
+
+export function getGradeBucket(gradePercent: number): GradeBucket {
+  if (gradePercent < 3) return GRADE_BUCKETS[0]
+  if (gradePercent < 6) return GRADE_BUCKETS[1]
+  if (gradePercent < 9) return GRADE_BUCKETS[2]
+  if (gradePercent < 12) return GRADE_BUCKETS[3]
+  return GRADE_BUCKETS[4]
+}
+
+export function getClimbSegmentPoints(
+  climb: ActivityClimb,
+  chartPoints: ActivityChartTrackPoint[],
+): ActivityChartTrackPoint[] {
+  const startTime = parseTime(climb.start_time)
+  const endTime = parseTime(climb.end_time)
+  if (startTime == null || endTime == null) return []
+
+  return chartPoints.filter((point) => {
+    const pointTime = parseTime(point.timestamp)
+    return pointTime != null && pointTime >= startTime && pointTime <= endTime
+  })
+}

--- a/src/components/garmin/ClimbDetailsPanel.test.tsx
+++ b/src/components/garmin/ClimbDetailsPanel.test.tsx
@@ -1,0 +1,268 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { ClimbDetailsPanel } from './ClimbDetailsPanel'
+import {
+  getClimbSegmentPoints,
+  getGradeBucket,
+} from './ClimbDetailsPanel.helpers'
+import type { ActivityChartTrackPoint } from './ActivityChartData'
+
+const leafletMocks = vi.hoisted(() => {
+  const mapInstance = {
+    setView: vi.fn().mockReturnThis(),
+    fitBounds: vi.fn(),
+    remove: vi.fn(),
+  }
+  const layer = {
+    addTo: vi.fn().mockReturnThis(),
+  }
+  const marker = {
+    bindPopup: vi.fn().mockReturnThis(),
+    addTo: vi.fn().mockReturnThis(),
+  }
+  const bounds = {
+    extend: vi.fn(),
+    isValid: vi.fn(() => true),
+  }
+
+  return {
+    mapInstance,
+    layer,
+    marker,
+    bounds,
+    map: vi.fn(() => mapInstance),
+    tileLayer: vi.fn(() => layer),
+    polyline: vi.fn(() => layer),
+    circleMarker: vi.fn(() => marker),
+    latLngBounds: vi.fn(() => bounds),
+  }
+})
+
+vi.mock('leaflet', () => ({
+  default: {
+    map: leafletMocks.map,
+    tileLayer: leafletMocks.tileLayer,
+    polyline: leafletMocks.polyline,
+    circleMarker: leafletMocks.circleMarker,
+    latLngBounds: leafletMocks.latLngBounds,
+  },
+}))
+
+describe('ClimbDetailsPanel', () => {
+  beforeEach(() => {
+    leafletMocks.map.mockClear()
+    leafletMocks.tileLayer.mockClear()
+    leafletMocks.polyline.mockClear()
+    leafletMocks.circleMarker.mockClear()
+    leafletMocks.latLngBounds.mockClear()
+    leafletMocks.mapInstance.setView.mockClear()
+    leafletMocks.mapInstance.fitBounds.mockClear()
+    leafletMocks.mapInstance.remove.mockClear()
+    leafletMocks.bounds.extend.mockClear()
+    leafletMocks.bounds.isValid.mockClear()
+    leafletMocks.bounds.isValid.mockReturnValue(true)
+  })
+
+  it('formats stats and renders the climb chart and map', async () => {
+    render(
+      <ClimbDetailsPanel
+        climb={mockClimb()}
+        climbIndex={0}
+        totalClimbs={2}
+        chartPoints={mockChartPoints()}
+        onPrevious={vi.fn()}
+        onNext={vi.fn()}
+        canPrevious={false}
+        canNext
+      />,
+    )
+
+    expect(screen.getByText('Climb 1 of 2')).toBeInTheDocument()
+    expect(screen.getByText('1.57%')).toBeInTheDocument()
+    expect(screen.getByText('5.76%')).toBeInTheDocument()
+    expect(screen.getByText('26 ft')).toBeInTheDocument()
+    expect(screen.getByText('0.32 mi')).toBeInTheDocument()
+    expect(screen.getByText('None')).toBeInTheDocument()
+    expect(
+      screen.getByTestId('climb-elevation-grade-chart'),
+    ).toBeInTheDocument()
+
+    await waitFor(() => expect(leafletMocks.map).toHaveBeenCalledTimes(1))
+    expect(leafletMocks.polyline).toHaveBeenCalledWith(
+      [
+        [40.1, -73.1],
+        [40.2, -73.2],
+        [40.3, -73.3],
+      ],
+      expect.objectContaining({ color: '#2563eb' }),
+    )
+    expect(leafletMocks.circleMarker).toHaveBeenCalledTimes(2)
+  })
+
+  it('filters chart points to the selected climb time window', () => {
+    const points = getClimbSegmentPoints(mockClimb(), mockChartPoints())
+
+    expect(points.map((point) => point.timestamp)).toEqual([
+      '2026-03-14T09:05:00Z',
+      '2026-03-14T09:07:00Z',
+      '2026-03-14T09:10:00Z',
+    ])
+  })
+
+  it('uses the expected grade buckets', () => {
+    expect(getGradeBucket(2.9).label).toBe('<3%')
+    expect(getGradeBucket(3).label).toBe('3-6%')
+    expect(getGradeBucket(6).label).toBe('6-9%')
+    expect(getGradeBucket(9).label).toBe('9-12%')
+    expect(getGradeBucket(12).label).toBe('>12%')
+  })
+
+  it('calls previous and next handlers and disables at boundaries', async () => {
+    const user = userEvent.setup()
+    const onPrevious = vi.fn()
+    const onNext = vi.fn()
+
+    render(
+      <ClimbDetailsPanel
+        climb={mockClimb()}
+        climbIndex={1}
+        totalClimbs={2}
+        chartPoints={mockChartPoints()}
+        onPrevious={onPrevious}
+        onNext={onNext}
+        canPrevious
+        canNext={false}
+      />,
+    )
+
+    await user.click(screen.getByRole('button', { name: 'Previous climb' }))
+    expect(onPrevious).toHaveBeenCalledTimes(1)
+    expect(screen.getByRole('button', { name: 'Next climb' })).toBeDisabled()
+  })
+
+  it('shows a chart-point empty state when the selected climb has no points', () => {
+    render(
+      <ClimbDetailsPanel
+        climb={mockClimb({
+          start_time: '2026-03-14T10:00:00Z',
+          end_time: '2026-03-14T10:05:00Z',
+        })}
+        climbIndex={0}
+        totalClimbs={1}
+        chartPoints={mockChartPoints()}
+        onPrevious={vi.fn()}
+        onNext={vi.fn()}
+        canPrevious={false}
+        canNext={false}
+      />,
+    )
+
+    expect(
+      screen.getByText('No chart points available for this climb.'),
+    ).toBeInTheDocument()
+  })
+
+  it('shows a map empty state when selected chart points have no lat/lng', () => {
+    render(
+      <ClimbDetailsPanel
+        climb={mockClimb()}
+        climbIndex={0}
+        totalClimbs={1}
+        chartPoints={mockChartPointsWithoutCoordinates()}
+        onPrevious={vi.fn()}
+        onNext={vi.fn()}
+        canPrevious={false}
+        canNext={false}
+      />,
+    )
+
+    expect(
+      screen.getByTestId('climb-elevation-grade-chart'),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText('No map points available for this climb.'),
+    ).toBeInTheDocument()
+  })
+})
+
+function mockClimb(
+  overrides: Partial<{
+    start_time: string
+    end_time: string
+  }> = {},
+) {
+  return {
+    id: 1,
+    activity_id: '42',
+    source_split_index: 0,
+    message_index: null,
+    climb_type: 'CLIMB_PRO_CYCLING_CLIMB',
+    start_time: overrides.start_time ?? '2026-03-14T09:05:00Z',
+    end_time: overrides.end_time ?? '2026-03-14T09:10:00Z',
+    duration_seconds: 122,
+    elapsed_duration_seconds: 122,
+    moving_duration_seconds: 122,
+    distance_meters: 509.6,
+    elevation_gain_meters: 8,
+    elevation_loss_meters: 0,
+    start_elevation_meters: 27,
+    average_grade_percent: 1.57,
+    max_grade_percent: 5.76,
+    average_speed_mps: 4.1,
+    max_speed_mps: 6.2,
+    start_latitude: 40.1,
+    start_longitude: -73.1,
+    end_latitude: 40.3,
+    end_longitude: -73.3,
+    climb_pro_difficulty: null,
+  }
+}
+
+function mockChartPoints(): ActivityChartTrackPoint[] {
+  return [
+    {
+      timestamp: '2026-03-14T09:04:00Z',
+      altitude: 24,
+      distance_from_start_km: 19,
+      latitude: 40,
+      longitude: -73,
+    },
+    {
+      timestamp: '2026-03-14T09:05:00Z',
+      altitude: 27,
+      distance_from_start_km: 19.5,
+      latitude: 40.1,
+      longitude: -73.1,
+    },
+    {
+      timestamp: '2026-03-14T09:07:00Z',
+      altitude: 31,
+      distance_from_start_km: 19.75,
+      latitude: 40.2,
+      longitude: -73.2,
+    },
+    {
+      timestamp: '2026-03-14T09:10:00Z',
+      altitude: 35,
+      distance_from_start_km: 20,
+      latitude: 40.3,
+      longitude: -73.3,
+    },
+    {
+      timestamp: '2026-03-14T09:11:00Z',
+      altitude: 33,
+      distance_from_start_km: 20.1,
+      latitude: 40.4,
+      longitude: -73.4,
+    },
+  ]
+}
+
+function mockChartPointsWithoutCoordinates(): ActivityChartTrackPoint[] {
+  return mockChartPoints().map((point) => ({
+    ...point,
+    latitude: null,
+    longitude: null,
+  }))
+}

--- a/src/components/garmin/ClimbDetailsPanel.test.tsx
+++ b/src/components/garmin/ClimbDetailsPanel.test.tsx
@@ -184,6 +184,40 @@ describe('ClimbDetailsPanel', () => {
       screen.getByText('No map points available for this climb.'),
     ).toBeInTheDocument()
   })
+
+  it('removes an existing climb map when the selected climb has no map points', async () => {
+    const { rerender } = render(
+      <ClimbDetailsPanel
+        climb={mockClimb()}
+        climbIndex={0}
+        totalClimbs={1}
+        chartPoints={mockChartPoints()}
+        onPrevious={vi.fn()}
+        onNext={vi.fn()}
+        canPrevious={false}
+        canNext={false}
+      />,
+    )
+    await waitFor(() => expect(leafletMocks.map).toHaveBeenCalledTimes(1))
+
+    rerender(
+      <ClimbDetailsPanel
+        climb={mockClimb()}
+        climbIndex={0}
+        totalClimbs={1}
+        chartPoints={mockChartPointsWithoutCoordinates()}
+        onPrevious={vi.fn()}
+        onNext={vi.fn()}
+        canPrevious={false}
+        canNext={false}
+      />,
+    )
+
+    expect(leafletMocks.mapInstance.remove).toHaveBeenCalledTimes(1)
+    expect(
+      screen.getByText('No map points available for this climb.'),
+    ).toBeInTheDocument()
+  })
 })
 
 function mockClimb(

--- a/src/components/garmin/ClimbDetailsPanel.tsx
+++ b/src/components/garmin/ClimbDetailsPanel.tsx
@@ -276,12 +276,12 @@ function ClimbSegmentMap({ points }: { points: ClimbMapPoint[] }) {
   const mapInstanceRef = useRef<L.Map | null>(null)
 
   useEffect(() => {
-    if (!mapRef.current || points.length < 2) return
-
     if (mapInstanceRef.current) {
       mapInstanceRef.current.remove()
       mapInstanceRef.current = null
     }
+
+    if (!mapRef.current || points.length < 2) return
 
     const first = points[0]
     const last = points[points.length - 1]

--- a/src/components/garmin/ClimbDetailsPanel.tsx
+++ b/src/components/garmin/ClimbDetailsPanel.tsx
@@ -1,0 +1,461 @@
+import { useEffect, useMemo, useRef } from 'react'
+import { ChevronLeft, ChevronRight } from 'lucide-react'
+import L from 'leaflet'
+import 'leaflet/dist/leaflet.css'
+import type { GarminActivityClimbsQuery } from '@/__generated__/graphql'
+import type { ActivityChartTrackPoint } from '@/components/garmin/ActivityChartData'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { formatDurationShort, metersToFeet } from '@/lib/units'
+import {
+  getClimbSegmentPoints,
+  getGradeBucket,
+  GRADE_BUCKETS,
+} from './ClimbDetailsPanel.helpers'
+
+const METERS_PER_MILE = 1609.344
+const FEET_PER_MILE = 5280
+const SVG_WIDTH = 900
+const SVG_HEIGHT = 260
+const CHART_PADDING = {
+  top: 18,
+  right: 24,
+  bottom: 42,
+  left: 52,
+}
+
+type ActivityClimb = GarminActivityClimbsQuery['garminActivityClimbs'][number]
+
+interface ClimbDetailsPanelProps {
+  climb: ActivityClimb
+  climbIndex: number
+  totalClimbs: number
+  chartPoints: ActivityChartTrackPoint[]
+  onPrevious: () => void
+  onNext: () => void
+  canPrevious: boolean
+  canNext: boolean
+}
+
+interface ClimbGraphPoint {
+  timestamp: string
+  distanceMiles: number
+  elevationFeet: number
+}
+
+interface ClimbMapPoint {
+  latitude: number
+  longitude: number
+}
+
+function formatDistanceMiles(meters: number | null | undefined): string {
+  return meters != null ? `${(meters / METERS_PER_MILE).toFixed(2)} mi` : '-'
+}
+
+function formatFeet(meters: number | null | undefined): string {
+  return meters != null ? `${metersToFeet(meters).toFixed(0)} ft` : '-'
+}
+
+function formatPercent(value: number | null | undefined): string {
+  return value != null ? `${value.toFixed(2)}%` : '-'
+}
+
+function formatDifficulty(value: string | null | undefined): string {
+  return value && value.trim().length > 0 ? value : 'None'
+}
+
+function toGraphPoints(points: ActivityChartTrackPoint[]): ClimbGraphPoint[] {
+  const usable = points.filter(
+    (point) =>
+      point.distance_from_start_km != null &&
+      point.altitude != null &&
+      Number.isFinite(point.distance_from_start_km) &&
+      Number.isFinite(point.altitude),
+  )
+  if (usable.length === 0) return []
+
+  const startDistanceKm = usable[0].distance_from_start_km ?? 0
+  return usable.map((point) => ({
+    timestamp: point.timestamp,
+    distanceMiles:
+      (((point.distance_from_start_km ?? startDistanceKm) - startDistanceKm) *
+        1000) /
+      METERS_PER_MILE,
+    elevationFeet: metersToFeet(point.altitude ?? 0),
+  }))
+}
+
+function toMapPoints(points: ActivityChartTrackPoint[]): ClimbMapPoint[] {
+  return points
+    .filter(
+      (point) =>
+        point.latitude != null &&
+        point.longitude != null &&
+        Number.isFinite(point.latitude) &&
+        Number.isFinite(point.longitude),
+    )
+    .map((point) => ({
+      latitude: point.latitude as number,
+      longitude: point.longitude as number,
+    }))
+}
+
+function axisTicks(min: number, max: number, count: number): number[] {
+  if (count <= 1 || min === max) return [min]
+  const step = (max - min) / (count - 1)
+  return Array.from({ length: count }, (_, index) => min + step * index)
+}
+
+function ClimbStat({ label, value }: { label: string; value: string }) {
+  return (
+    <div>
+      <div className="text-2xl font-semibold leading-none">{value}</div>
+      <div className="mt-2 text-sm text-muted-foreground">{label}</div>
+    </div>
+  )
+}
+
+function ClimbElevationGradeChart({ points }: { points: ClimbGraphPoint[] }) {
+  if (points.length < 2) {
+    return (
+      <div className="rounded-md border border-dashed p-6 text-sm text-muted-foreground">
+        No elevation and distance chart data available for this climb.
+      </div>
+    )
+  }
+
+  const minX = Math.min(...points.map((point) => point.distanceMiles))
+  const maxX = Math.max(...points.map((point) => point.distanceMiles))
+  const minElevation = Math.min(...points.map((point) => point.elevationFeet))
+  const maxElevation = Math.max(...points.map((point) => point.elevationFeet))
+  const elevationPadding = Math.max(10, (maxElevation - minElevation) * 0.15)
+  const minY = Math.max(0, minElevation - elevationPadding)
+  const maxY = maxElevation + elevationPadding
+  const chartWidth = SVG_WIDTH - CHART_PADDING.left - CHART_PADDING.right
+  const chartHeight = SVG_HEIGHT - CHART_PADDING.top - CHART_PADDING.bottom
+
+  const scaleX = (value: number) => {
+    if (maxX === minX) return CHART_PADDING.left
+    return CHART_PADDING.left + ((value - minX) / (maxX - minX)) * chartWidth
+  }
+  const scaleY = (value: number) => {
+    if (maxY === minY) return CHART_PADDING.top + chartHeight
+    return (
+      CHART_PADDING.top +
+      chartHeight -
+      ((value - minY) / (maxY - minY)) * chartHeight
+    )
+  }
+  const baselineY = CHART_PADDING.top + chartHeight
+  const xTicks = axisTicks(minX, maxX, 5)
+  const yTicks = axisTicks(minY, maxY, 4)
+  const linePath = points
+    .map((point, index) => {
+      const command = index === 0 ? 'M' : 'L'
+      return `${command} ${scaleX(point.distanceMiles).toFixed(2)} ${scaleY(
+        point.elevationFeet,
+      ).toFixed(2)}`
+    })
+    .join(' ')
+
+  return (
+    <div data-testid="climb-elevation-grade-chart">
+      <div className="h-72 w-full">
+        <svg
+          role="img"
+          aria-label="Elevation and grade over climb distance"
+          viewBox={`0 0 ${SVG_WIDTH} ${SVG_HEIGHT}`}
+          className="h-full w-full"
+          preserveAspectRatio="none"
+        >
+          {yTicks.map((tick) => {
+            const y = scaleY(tick)
+            return (
+              <g key={tick}>
+                <line
+                  x1={CHART_PADDING.left}
+                  x2={SVG_WIDTH - CHART_PADDING.right}
+                  y1={y}
+                  y2={y}
+                  stroke="hsl(var(--border))"
+                  strokeWidth="1"
+                />
+                <text
+                  x={CHART_PADDING.left - 10}
+                  y={y + 4}
+                  textAnchor="end"
+                  className="fill-muted-foreground text-xs"
+                >
+                  {tick.toFixed(0)}
+                </text>
+              </g>
+            )
+          })}
+
+          {points.slice(0, -1).map((point, index) => {
+            const next = points[index + 1]
+            const deltaDistanceFeet =
+              (next.distanceMiles - point.distanceMiles) * FEET_PER_MILE
+            const deltaElevationFeet = next.elevationFeet - point.elevationFeet
+            const grade =
+              deltaDistanceFeet > 0
+                ? (deltaElevationFeet / deltaDistanceFeet) * 100
+                : 0
+            const bucket = getGradeBucket(grade)
+            const x1 = scaleX(point.distanceMiles)
+            const x2 = scaleX(next.distanceMiles)
+            const y1 = scaleY(point.elevationFeet)
+            const y2 = scaleY(next.elevationFeet)
+            return (
+              <polygon
+                key={`${point.timestamp}-${next.timestamp}`}
+                points={`${x1},${baselineY} ${x1},${y1} ${x2},${y2} ${x2},${baselineY}`}
+                fill={bucket.color}
+                opacity="0.85"
+              />
+            )
+          })}
+
+          <path d={linePath} fill="none" stroke="#111827" strokeWidth="2" />
+          <line
+            x1={CHART_PADDING.left}
+            x2={SVG_WIDTH - CHART_PADDING.right}
+            y1={baselineY}
+            y2={baselineY}
+            stroke="#111827"
+            strokeWidth="1"
+          />
+          {xTicks.map((tick) => {
+            const x = scaleX(tick)
+            return (
+              <g key={tick}>
+                <line
+                  x1={x}
+                  x2={x}
+                  y1={baselineY}
+                  y2={baselineY + 6}
+                  stroke="#111827"
+                />
+                <text
+                  x={x}
+                  y={baselineY + 22}
+                  textAnchor="middle"
+                  className="fill-foreground text-xs"
+                >
+                  {tick.toFixed(2)}
+                </text>
+              </g>
+            )
+          })}
+          <text
+            x={CHART_PADDING.left + chartWidth / 2}
+            y={SVG_HEIGHT - 6}
+            textAnchor="middle"
+            className="fill-foreground text-xs"
+          >
+            Distance (mi)
+          </text>
+        </svg>
+      </div>
+      <div className="mt-3 flex flex-wrap items-center justify-center gap-x-8 gap-y-2 text-sm font-semibold">
+        {GRADE_BUCKETS.map((bucket) => (
+          <div key={bucket.label} className="flex items-center gap-2">
+            <span
+              className={`inline-block h-4 w-4 rounded-full ${bucket.className}`}
+            />
+            {bucket.label}
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+function ClimbSegmentMap({ points }: { points: ClimbMapPoint[] }) {
+  const mapRef = useRef<HTMLDivElement>(null)
+  const mapInstanceRef = useRef<L.Map | null>(null)
+
+  useEffect(() => {
+    if (!mapRef.current || points.length < 2) return
+
+    if (mapInstanceRef.current) {
+      mapInstanceRef.current.remove()
+      mapInstanceRef.current = null
+    }
+
+    const first = points[0]
+    const last = points[points.length - 1]
+    const map = L.map(mapRef.current).setView(
+      [first.latitude, first.longitude],
+      15,
+    )
+    mapInstanceRef.current = map
+
+    L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+      attribution: '&copy; OpenStreetMap contributors',
+    }).addTo(map)
+
+    const bounds = L.latLngBounds([])
+    for (const point of points) {
+      bounds.extend([point.latitude, point.longitude])
+    }
+
+    L.polyline(
+      points.map(
+        (point) => [point.latitude, point.longitude] as [number, number],
+      ),
+      { color: '#2563eb', weight: 5, opacity: 0.9 },
+    ).addTo(map)
+
+    L.circleMarker([first.latitude, first.longitude], {
+      radius: 7,
+      fillColor: '#22c55e',
+      color: '#fff',
+      weight: 2,
+      fillOpacity: 1,
+    })
+      .bindPopup('Climb start')
+      .addTo(map)
+
+    L.circleMarker([last.latitude, last.longitude], {
+      radius: 7,
+      fillColor: '#ef4444',
+      color: '#fff',
+      weight: 2,
+      fillOpacity: 1,
+    })
+      .bindPopup('Climb finish')
+      .addTo(map)
+
+    if (bounds.isValid()) {
+      map.fitBounds(bounds, { padding: [28, 28] })
+    }
+
+    return () => {
+      map.remove()
+      mapInstanceRef.current = null
+    }
+  }, [points])
+
+  if (points.length < 2) {
+    return (
+      <div className="flex h-[320px] items-center justify-center rounded-md border border-dashed text-sm text-muted-foreground">
+        No map points available for this climb.
+      </div>
+    )
+  }
+
+  return (
+    <div
+      ref={mapRef}
+      data-testid="climb-segment-map"
+      className="h-[320px] w-full overflow-hidden rounded-md"
+    />
+  )
+}
+
+export function ClimbDetailsPanel({
+  climb,
+  climbIndex,
+  totalClimbs,
+  chartPoints,
+  onPrevious,
+  onNext,
+  canPrevious,
+  canNext,
+}: ClimbDetailsPanelProps) {
+  const segmentPoints = useMemo(
+    () => getClimbSegmentPoints(climb, chartPoints),
+    [climb, chartPoints],
+  )
+  const graphPoints = useMemo(
+    () => toGraphPoints(segmentPoints),
+    [segmentPoints],
+  )
+  const mapPoints = useMemo(() => toMapPoints(segmentPoints), [segmentPoints])
+
+  return (
+    <Card data-testid="climb-details-panel">
+      <CardHeader className="space-y-4">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <CardTitle className="text-base">Climb Details</CardTitle>
+          <div className="flex items-center gap-2">
+            <Button
+              type="button"
+              variant="outline"
+              size="icon"
+              aria-label="Previous climb"
+              disabled={!canPrevious}
+              onClick={onPrevious}
+            >
+              <ChevronLeft className="h-4 w-4" />
+            </Button>
+            <div className="rounded-md bg-muted px-4 py-2 text-sm font-semibold">
+              Climb {climbIndex + 1} of {totalClimbs}
+            </div>
+            <Button
+              type="button"
+              variant="outline"
+              size="icon"
+              aria-label="Next climb"
+              disabled={!canNext}
+              onClick={onNext}
+            >
+              <ChevronRight className="h-4 w-4" />
+            </Button>
+          </div>
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-6">
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-6">
+          <ClimbStat
+            label="Avg Grade"
+            value={formatPercent(climb.average_grade_percent)}
+          />
+          <ClimbStat
+            label="Max Grade"
+            value={formatPercent(climb.max_grade_percent)}
+          />
+          <ClimbStat
+            label="Ascent"
+            value={formatFeet(climb.elevation_gain_meters)}
+          />
+          <ClimbStat
+            label="Distance"
+            value={formatDistanceMiles(climb.distance_meters)}
+          />
+          <ClimbStat
+            label="Time"
+            value={formatDurationShort(climb.duration_seconds ?? null)}
+          />
+          <ClimbStat
+            label="Difficulty"
+            value={formatDifficulty(climb.climb_pro_difficulty)}
+          />
+        </div>
+
+        {segmentPoints.length === 0 ? (
+          <div className="rounded-md border border-dashed p-6 text-sm text-muted-foreground">
+            No chart points available for this climb.
+          </div>
+        ) : (
+          <>
+            <section className="space-y-3" aria-labelledby="climb-chart-title">
+              <h3 id="climb-chart-title" className="text-xl font-semibold">
+                Elevation & Grade
+              </h3>
+              <ClimbElevationGradeChart points={graphPoints} />
+            </section>
+
+            <section className="space-y-3" aria-labelledby="climb-map-title">
+              <h3 id="climb-map-title" className="text-xl font-semibold">
+                Map
+              </h3>
+              <ClimbSegmentMap points={mapPoints} />
+            </section>
+          </>
+        )}
+      </CardContent>
+    </Card>
+  )
+}

--- a/src/pages/GarminDetailPage.test.tsx
+++ b/src/pages/GarminDetailPage.test.tsx
@@ -109,6 +109,46 @@ vi.mock('@/components/garmin/ActivityCharts', () => ({
   ),
 }))
 
+vi.mock('@/components/garmin/ClimbDetailsPanel', () => ({
+  ClimbDetailsPanel: ({
+    climb,
+    climbIndex,
+    totalClimbs,
+    onPrevious,
+    onNext,
+    canPrevious,
+    canNext,
+  }: {
+    climb: { id: number }
+    climbIndex: number
+    totalClimbs: number
+    onPrevious: () => void
+    onNext: () => void
+    canPrevious: boolean
+    canNext: boolean
+  }) => (
+    <div data-testid="climb-details-panel">
+      Climb {climbIndex + 1} of {totalClimbs} id:{climb.id}
+      <button
+        type="button"
+        aria-label="Previous climb"
+        disabled={!canPrevious}
+        onClick={onPrevious}
+      >
+        previous
+      </button>
+      <button
+        type="button"
+        aria-label="Next climb"
+        disabled={!canNext}
+        onClick={onNext}
+      >
+        next
+      </button>
+    </div>
+  ),
+}))
+
 vi.mock('@/components/garmin/ActivityStatsPanel', () => ({
   ActivityStatsPanel: () => (
     <div data-testid="activity-stats-panel">stats-panel</div>
@@ -294,6 +334,138 @@ describe('GarminDetailPage', () => {
     expect(
       screen.getByText('No Garmin ClimbPro climbs found for this activity.'),
     ).toBeInTheDocument()
+  })
+
+  it('renders ClimbPro rows and auto-selects the first climb', async () => {
+    const user = userEvent.setup()
+    mockLoadedActivity()
+    garminDetailHooks.useGarminChartDataQuery.mockReturnValue({
+      loading: false,
+      error: undefined,
+      data: { garminChartData: [] },
+    })
+    garminDetailHooks.useGarminActivityClimbsQuery.mockReturnValue({
+      loading: false,
+      error: undefined,
+      data: {
+        garminActivityClimbs: [
+          mockClimb({ id: 1, source_split_index: 0 }),
+          mockClimb({
+            id: 2,
+            source_split_index: 1,
+            start_time: '2026-03-14T09:20:00Z',
+            end_time: '2026-03-14T09:25:00Z',
+          }),
+          mockClimb({
+            id: 3,
+            climb_type: 'CLIMB_PRO_CYCLING_CLIMB_SECTION',
+          }),
+        ],
+      },
+    })
+
+    renderPage()
+    await user.click(screen.getByTestId('garmin-tab-climbs'))
+
+    expect(screen.getByTestId('climb-row-1')).toHaveTextContent('Climb 1')
+    expect(screen.getByTestId('climb-row-2')).toHaveTextContent('Climb 2')
+    expect(screen.queryByText('Climb 3')).not.toBeInTheDocument()
+    expect(screen.getByTestId('climb-row-1')).toHaveAttribute(
+      'aria-pressed',
+      'true',
+    )
+    expect(screen.getByTestId('climb-details-panel')).toHaveTextContent(
+      'Climb 1 of 2 id:1',
+    )
+    expect(
+      screen.getByRole('button', { name: 'Previous climb' }),
+    ).toBeDisabled()
+    expect(
+      screen.getByRole('button', { name: 'Next climb' }),
+    ).not.toBeDisabled()
+  })
+
+  it('updates the inline climb detail when another climb row is selected', async () => {
+    const user = userEvent.setup()
+    mockLoadedActivity()
+    garminDetailHooks.useGarminChartDataQuery.mockReturnValue({
+      loading: false,
+      error: undefined,
+      data: { garminChartData: [] },
+    })
+    garminDetailHooks.useGarminActivityClimbsQuery.mockReturnValue({
+      loading: false,
+      error: undefined,
+      data: {
+        garminActivityClimbs: [
+          mockClimb({ id: 1, source_split_index: 0 }),
+          mockClimb({
+            id: 2,
+            source_split_index: 1,
+            start_time: '2026-03-14T09:20:00Z',
+            end_time: '2026-03-14T09:25:00Z',
+          }),
+        ],
+      },
+    })
+
+    renderPage()
+    await user.click(screen.getByTestId('garmin-tab-climbs'))
+    await user.click(screen.getByTestId('climb-row-2'))
+
+    expect(screen.getByTestId('climb-row-1')).toHaveAttribute(
+      'aria-pressed',
+      'false',
+    )
+    expect(screen.getByTestId('climb-row-2')).toHaveAttribute(
+      'aria-pressed',
+      'true',
+    )
+    expect(screen.getByTestId('climb-details-panel')).toHaveTextContent(
+      'Climb 2 of 2 id:2',
+    )
+  })
+
+  it('changes selected climbs with previous and next controls', async () => {
+    const user = userEvent.setup()
+    mockLoadedActivity()
+    garminDetailHooks.useGarminChartDataQuery.mockReturnValue({
+      loading: false,
+      error: undefined,
+      data: { garminChartData: [] },
+    })
+    garminDetailHooks.useGarminActivityClimbsQuery.mockReturnValue({
+      loading: false,
+      error: undefined,
+      data: {
+        garminActivityClimbs: [
+          mockClimb({ id: 1, source_split_index: 0 }),
+          mockClimb({
+            id: 2,
+            source_split_index: 1,
+            start_time: '2026-03-14T09:20:00Z',
+            end_time: '2026-03-14T09:25:00Z',
+          }),
+        ],
+      },
+    })
+
+    renderPage()
+    await user.click(screen.getByTestId('garmin-tab-climbs'))
+
+    await user.click(screen.getByRole('button', { name: 'Next climb' }))
+    expect(screen.getByTestId('climb-details-panel')).toHaveTextContent(
+      'Climb 2 of 2 id:2',
+    )
+    expect(screen.getByRole('button', { name: 'Next climb' })).toBeDisabled()
+
+    await user.click(screen.getByRole('button', { name: 'Previous climb' }))
+    expect(screen.getByTestId('climb-details-panel')).toHaveTextContent(
+      'Climb 1 of 2 id:1',
+    )
+    expect(
+      screen.getByRole('button', { name: 'Previous climb' }),
+    ).toBeDisabled()
   })
 
   it('selects the nearest chart point when the route map is clicked', async () => {
@@ -630,6 +802,42 @@ describe('GarminDetailPage', () => {
       error: undefined,
       data: { garminChartData: [] },
     })
+  }
+
+  function mockClimb(
+    overrides: Partial<{
+      id: number
+      source_split_index: number
+      climb_type: string
+      start_time: string
+      end_time: string
+    }> = {},
+  ) {
+    return {
+      id: overrides.id ?? 1,
+      activity_id: '42',
+      source_split_index: overrides.source_split_index ?? 0,
+      message_index: null,
+      climb_type: overrides.climb_type ?? 'CLIMB_PRO_CYCLING_CLIMB',
+      start_time: overrides.start_time ?? '2026-03-14T09:05:00Z',
+      end_time: overrides.end_time ?? '2026-03-14T09:10:00Z',
+      duration_seconds: 300,
+      elapsed_duration_seconds: 300,
+      moving_duration_seconds: 300,
+      distance_meters: 500,
+      elevation_gain_meters: 25,
+      elevation_loss_meters: 0,
+      start_elevation_meters: 100,
+      average_grade_percent: 5,
+      max_grade_percent: 8,
+      average_speed_mps: 3,
+      max_speed_mps: 5,
+      start_latitude: 40.7,
+      start_longitude: -74,
+      end_latitude: 40.71,
+      end_longitude: -74.01,
+      climb_pro_difficulty: 'NONE',
+    }
   }
 
   function mockExportPoints() {

--- a/src/pages/GarminDetailPage.tsx
+++ b/src/pages/GarminDetailPage.tsx
@@ -503,30 +503,21 @@ export function GarminDetailPage() {
           mainClimbs.some((climb) => climb.id === selectedClimbId)
         ? selectedClimbId
         : mainClimbs[0].id
-  if (selectedClimbId !== effectiveSelectedClimbId) {
-    setSelectedClimbId(effectiveSelectedClimbId)
-  }
   const selectedClimbIndex = mainClimbs.findIndex(
     (climb) => climb.id === effectiveSelectedClimbId,
   )
   const selectedClimb =
     selectedClimbIndex >= 0 ? mainClimbs[selectedClimbIndex] : null
   const selectPreviousClimb = useCallback(() => {
-    setSelectedClimbId((current) => {
-      const currentIndex = mainClimbs.findIndex((climb) => climb.id === current)
-      if (currentIndex <= 0) return current
-      return mainClimbs[currentIndex - 1].id
-    })
-  }, [mainClimbs])
+    if (selectedClimbIndex <= 0) return
+    setSelectedClimbId(mainClimbs[selectedClimbIndex - 1].id)
+  }, [mainClimbs, selectedClimbIndex])
   const selectNextClimb = useCallback(() => {
-    setSelectedClimbId((current) => {
-      const currentIndex = mainClimbs.findIndex((climb) => climb.id === current)
-      if (currentIndex < 0 || currentIndex >= mainClimbs.length - 1) {
-        return current
-      }
-      return mainClimbs[currentIndex + 1].id
-    })
-  }, [mainClimbs])
+    if (selectedClimbIndex < 0 || selectedClimbIndex >= mainClimbs.length - 1) {
+      return
+    }
+    setSelectedClimbId(mainClimbs[selectedClimbIndex + 1].id)
+  }, [mainClimbs, selectedClimbIndex])
 
   if (loading) return <LoadingState message="Loading activity..." />
   if (error)

--- a/src/pages/GarminDetailPage.tsx
+++ b/src/pages/GarminDetailPage.tsx
@@ -25,6 +25,7 @@ import {
 import { nextSavedPointColor } from '@/components/garmin/savedPointColors'
 import { ActivityCharts } from '@/components/garmin/ActivityCharts'
 import { ActivityHoverDetails } from '@/components/garmin/ActivityHoverDetails'
+import { ClimbDetailsPanel } from '@/components/garmin/ClimbDetailsPanel'
 import { SavedPointsList } from '@/components/garmin/SavedPointsList'
 import { SegmentAnalysis } from '@/components/garmin/SegmentAnalysis'
 import { ActivityStatsPanel } from '@/components/garmin/ActivityStatsPanel'
@@ -41,6 +42,7 @@ import {
 import { setNRCustomAttribute } from '@/lib/newrelic-browser'
 import { escapeCsvValue, triggerDownload } from '@/lib/export'
 import { formatDurationShort, metersToFeet } from '@/lib/units'
+import { cn } from '@/lib/utils'
 
 /** Douglas-Peucker tolerance in degrees (~1.1 m) for PostGIS ST_Simplify */
 const SIMPLIFY_TOLERANCE = 0.00001
@@ -116,12 +118,16 @@ function formatPercent(value: number | null | undefined): string {
   return value != null ? `${value.toFixed(2)} %` : '—'
 }
 
-function ActivityClimbsTable({ climbs }: { climbs: ActivityClimb[] }) {
-  const mainClimbs = climbs.filter(
-    (climb) => climb.climb_type === MAIN_CLIMB_TYPE,
-  )
-
-  if (mainClimbs.length === 0) {
+function ActivityClimbsTable({
+  climbs,
+  selectedClimbId,
+  onSelectClimb,
+}: {
+  climbs: ActivityClimb[]
+  selectedClimbId: number | null
+  onSelectClimb: (climbId: number) => void
+}) {
+  if (climbs.length === 0) {
     return (
       <div className="rounded-md border border-dashed p-6 text-sm text-muted-foreground">
         No Garmin ClimbPro climbs found for this activity.
@@ -144,8 +150,27 @@ function ActivityClimbsTable({ climbs }: { climbs: ActivityClimb[] }) {
           </TableRow>
         </TableHeader>
         <TableBody>
-          {mainClimbs.map((climb, index) => (
-            <TableRow key={climb.id}>
+          {climbs.map((climb, index) => (
+            <TableRow
+              key={climb.id}
+              role="button"
+              tabIndex={0}
+              aria-pressed={selectedClimbId === climb.id}
+              data-testid={`climb-row-${index + 1}`}
+              className={cn(
+                'cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
+                selectedClimbId === climb.id
+                  ? 'bg-muted hover:bg-muted'
+                  : 'hover:bg-muted/50',
+              )}
+              onClick={() => onSelectClimb(climb.id)}
+              onKeyDown={(event) => {
+                if (event.key === 'Enter' || event.key === ' ') {
+                  event.preventDefault()
+                  onSelectClimb(climb.id)
+                }
+              }}
+            >
               <TableCell className="font-medium">Climb {index + 1}</TableCell>
               <TableCell>
                 {formatDurationShort(climb.duration_seconds ?? null)}
@@ -172,6 +197,7 @@ export function GarminDetailPage() {
   const location = useLocation()
   const [activePoint, setActivePoint] = useState<ChartDataPoint | null>(null)
   const [savedPoints, setSavedPoints] = useState<SavedPoint[]>([])
+  const [selectedClimbId, setSelectedClimbId] = useState<number | null>(null)
 
   // Reset hover state when switching activities so the shared details
   // panel and map marker don't briefly show stale coordinates from the
@@ -461,6 +487,46 @@ export function GarminDetailPage() {
     },
     [rawChartPoints, chartContext, addOrTogglePoint],
   )
+  const mapTrackPoints = mapTrackData?.garminTrackPoints?.items ?? []
+  const chartPoints = rawChartPoints
+  const mainClimbs = useMemo(
+    () =>
+      (climbsData?.garminActivityClimbs ?? []).filter(
+        (climb) => climb.climb_type === MAIN_CLIMB_TYPE,
+      ),
+    [climbsData?.garminActivityClimbs],
+  )
+  const effectiveSelectedClimbId =
+    mainClimbs.length === 0
+      ? null
+      : selectedClimbId != null &&
+          mainClimbs.some((climb) => climb.id === selectedClimbId)
+        ? selectedClimbId
+        : mainClimbs[0].id
+  if (selectedClimbId !== effectiveSelectedClimbId) {
+    setSelectedClimbId(effectiveSelectedClimbId)
+  }
+  const selectedClimbIndex = mainClimbs.findIndex(
+    (climb) => climb.id === effectiveSelectedClimbId,
+  )
+  const selectedClimb =
+    selectedClimbIndex >= 0 ? mainClimbs[selectedClimbIndex] : null
+  const selectPreviousClimb = useCallback(() => {
+    setSelectedClimbId((current) => {
+      const currentIndex = mainClimbs.findIndex((climb) => climb.id === current)
+      if (currentIndex <= 0) return current
+      return mainClimbs[currentIndex - 1].id
+    })
+  }, [mainClimbs])
+  const selectNextClimb = useCallback(() => {
+    setSelectedClimbId((current) => {
+      const currentIndex = mainClimbs.findIndex((climb) => climb.id === current)
+      if (currentIndex < 0 || currentIndex >= mainClimbs.length - 1) {
+        return current
+      }
+      return mainClimbs[currentIndex + 1].id
+    })
+  }, [mainClimbs])
 
   if (loading) return <LoadingState message="Loading activity..." />
   if (error)
@@ -469,9 +535,6 @@ export function GarminDetailPage() {
   const a = data?.garminActivity
   if (!a) return <ErrorState message="Activity not found" />
 
-  const mapTrackPoints = mapTrackData?.garminTrackPoints?.items ?? []
-  const chartPoints = chartData?.garminChartData ?? []
-  const climbs = climbsData?.garminActivityClimbs ?? []
   const hasHrData =
     a.avg_heart_rate != null ||
     a.max_heart_rate != null ||
@@ -633,7 +696,25 @@ export function GarminDetailPage() {
             <ErrorState message={`Climbs failed: ${climbsError.message}`} />
           )}
           {!climbsLoading && !climbsError && (
-            <ActivityClimbsTable climbs={climbs} />
+            <>
+              <ActivityClimbsTable
+                climbs={mainClimbs}
+                selectedClimbId={effectiveSelectedClimbId}
+                onSelectClimb={setSelectedClimbId}
+              />
+              {selectedClimb && (
+                <ClimbDetailsPanel
+                  climb={selectedClimb}
+                  climbIndex={selectedClimbIndex}
+                  totalClimbs={mainClimbs.length}
+                  chartPoints={chartPoints}
+                  onPrevious={selectPreviousClimb}
+                  onNext={selectNextClimb}
+                  canPrevious={selectedClimbIndex > 0}
+                  canNext={selectedClimbIndex < mainClimbs.length - 1}
+                />
+              )}
+            </>
           )}
         </TabsContent>
       </Tabs>


### PR DESCRIPTION
## Summary

Adds inline Garmin ClimbPro details to the activity detail Climbs tab.

- Makes main `CLIMB_PRO_CYCLING_CLIMB` rows selectable and auto-selects the first climb.
- Renders an inline detail panel below the table with climb stats, previous/next controls, an Elevation & Grade graph, and a focused route map.
- Uses existing `garminActivityClimbs` and `garminChartData` data only; no API, DB, agent, or backfill changes.
- Adds component, page, and Playwright coverage for the selected-climb workflow.

## Validation

- `npm run test:run -- src/components/garmin/ClimbDetailsPanel.test.tsx src/pages/GarminDetailPage.test.tsx`
- `npm run type-check`
- `npm run lint:all`
- `npm run build`
- `BASE_URL=http://localhost:5173 npx playwright test e2e/garmin-climbs.spec.ts --project=chromium --reporter=line`

## Local Smoke

- Verified `http://localhost:5173/garmin/23390888525` renders two climbs and updates the inline detail panel when selecting the second climb.
- Playwright screenshot generated locally at `e2e/screenshots/garmin-climbs/climbs-inline-detail.png`.