### PR TITLE
[codex] Add climb map metric overlays

### DIFF
--- a/src/components/garmin/ActivityChartData.ts
+++ b/src/components/garmin/ActivityChartData.ts
@@ -9,6 +9,7 @@ export interface ActivityChartTrackPoint {
   hr_zone?: number | null
   respiration_rate?: number | null
   cadence?: number | null
+  temperature_c?: number | null
   latitude?: number | null
   longitude?: number | null
 }

--- a/src/components/garmin/ClimbDetailsPanel.test.tsx
+++ b/src/components/garmin/ClimbDetailsPanel.test.tsx
@@ -18,6 +18,10 @@ const leafletMocks = vi.hoisted(() => {
     bindTooltip: vi.fn().mockReturnThis(),
     addTo: vi.fn().mockReturnThis(),
   }
+  const routeLayer = {
+    addTo: vi.fn().mockReturnThis(),
+    clearLayers: vi.fn(),
+  }
   const marker = {
     bindPopup: vi.fn().mockReturnThis(),
     addTo: vi.fn().mockReturnThis(),
@@ -30,10 +34,12 @@ const leafletMocks = vi.hoisted(() => {
   return {
     mapInstance,
     layer,
+    routeLayer,
     marker,
     bounds,
     map: vi.fn(() => mapInstance),
     tileLayer: vi.fn(() => layer),
+    layerGroup: vi.fn(() => routeLayer),
     polyline: vi.fn(() => layer),
     circleMarker: vi.fn(() => marker),
     latLngBounds: vi.fn(() => bounds),
@@ -44,6 +50,7 @@ vi.mock('leaflet', () => ({
   default: {
     map: leafletMocks.map,
     tileLayer: leafletMocks.tileLayer,
+    layerGroup: leafletMocks.layerGroup,
     polyline: leafletMocks.polyline,
     circleMarker: leafletMocks.circleMarker,
     latLngBounds: leafletMocks.latLngBounds,
@@ -54,6 +61,9 @@ describe('ClimbDetailsPanel', () => {
   beforeEach(() => {
     leafletMocks.map.mockClear()
     leafletMocks.tileLayer.mockClear()
+    leafletMocks.layerGroup.mockClear()
+    leafletMocks.routeLayer.addTo.mockClear()
+    leafletMocks.routeLayer.clearLayers.mockClear()
     leafletMocks.polyline.mockClear()
     leafletMocks.layer.bindTooltip.mockClear()
     leafletMocks.layer.addTo.mockClear()
@@ -109,10 +119,42 @@ describe('ClimbDetailsPanel', () => {
     expect(leafletMocks.layer.bindTooltip).toHaveBeenCalledWith(
       expect.stringContaining('Grade'),
     )
+    expect(leafletMocks.routeLayer.clearLayers).toHaveBeenCalledTimes(1)
     expect(leafletMocks.circleMarker).toHaveBeenCalledTimes(2)
     expect(
       screen.getByRole('combobox', { name: 'Color climb map route by metric' }),
     ).toBeInTheDocument()
+    expect(screen.getByTestId('climb-map-metric-control')).toHaveAttribute(
+      'data-available-metrics',
+      expect.stringContaining('heart-rate'),
+    )
+  })
+
+  it('hides sensor overlay options when older climb points lack sensor data', async () => {
+    render(
+      <ClimbDetailsPanel
+        climb={mockClimb()}
+        climbIndex={0}
+        totalClimbs={1}
+        chartPoints={mockChartPointsWithoutSensorMetrics()}
+        onPrevious={vi.fn()}
+        onNext={vi.fn()}
+        canPrevious={false}
+        canNext={false}
+      />,
+    )
+
+    await waitFor(() => expect(leafletMocks.map).toHaveBeenCalledTimes(1))
+    expect(screen.getByTestId('climb-map-metric-control')).toHaveAttribute(
+      'data-available-metrics',
+      'route grade',
+    )
+    expect(
+      screen.queryByRole('option', { name: 'Heart rate' }),
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole('option', { name: 'Respiration' }),
+    ).not.toBeInTheDocument()
   })
 
   it('filters chart points to the selected climb time window', () => {
@@ -328,5 +370,15 @@ function mockChartPointsWithoutCoordinates(): ActivityChartTrackPoint[] {
     ...point,
     latitude: null,
     longitude: null,
+  }))
+}
+
+function mockChartPointsWithoutSensorMetrics(): ActivityChartTrackPoint[] {
+  return mockChartPoints().map((point) => ({
+    timestamp: point.timestamp,
+    altitude: point.altitude,
+    distance_from_start_km: point.distance_from_start_km,
+    latitude: point.latitude,
+    longitude: point.longitude,
   }))
 }

--- a/src/components/garmin/ClimbDetailsPanel.test.tsx
+++ b/src/components/garmin/ClimbDetailsPanel.test.tsx
@@ -15,6 +15,7 @@ const leafletMocks = vi.hoisted(() => {
     remove: vi.fn(),
   }
   const layer = {
+    bindTooltip: vi.fn().mockReturnThis(),
     addTo: vi.fn().mockReturnThis(),
   }
   const marker = {
@@ -54,6 +55,8 @@ describe('ClimbDetailsPanel', () => {
     leafletMocks.map.mockClear()
     leafletMocks.tileLayer.mockClear()
     leafletMocks.polyline.mockClear()
+    leafletMocks.layer.bindTooltip.mockClear()
+    leafletMocks.layer.addTo.mockClear()
     leafletMocks.circleMarker.mockClear()
     leafletMocks.latLngBounds.mockClear()
     leafletMocks.mapInstance.setView.mockClear()
@@ -93,11 +96,23 @@ describe('ClimbDetailsPanel', () => {
       [
         [40.1, -73.1],
         [40.2, -73.2],
+      ],
+      expect.objectContaining({ color: '#22c55e' }),
+    )
+    expect(leafletMocks.polyline).toHaveBeenCalledWith(
+      [
+        [40.2, -73.2],
         [40.3, -73.3],
       ],
-      expect.objectContaining({ color: '#2563eb' }),
+      expect.objectContaining({ color: '#22c55e' }),
+    )
+    expect(leafletMocks.layer.bindTooltip).toHaveBeenCalledWith(
+      expect.stringContaining('Grade'),
     )
     expect(leafletMocks.circleMarker).toHaveBeenCalledTimes(2)
+    expect(
+      screen.getByRole('combobox', { name: 'Color climb map route by metric' }),
+    ).toBeInTheDocument()
   })
 
   it('filters chart points to the selected climb time window', () => {
@@ -268,6 +283,11 @@ function mockChartPoints(): ActivityChartTrackPoint[] {
       distance_from_start_km: 19.5,
       latitude: 40.1,
       longitude: -73.1,
+      speed_kmh: 14,
+      heart_rate: 128,
+      hr_zone: 2,
+      respiration_rate: 22,
+      temperature_c: 18,
     },
     {
       timestamp: '2026-03-14T09:07:00Z',
@@ -275,6 +295,11 @@ function mockChartPoints(): ActivityChartTrackPoint[] {
       distance_from_start_km: 19.75,
       latitude: 40.2,
       longitude: -73.2,
+      speed_kmh: 16,
+      heart_rate: 142,
+      hr_zone: 3,
+      respiration_rate: 24,
+      temperature_c: 19,
     },
     {
       timestamp: '2026-03-14T09:10:00Z',
@@ -282,6 +307,11 @@ function mockChartPoints(): ActivityChartTrackPoint[] {
       distance_from_start_km: 20,
       latitude: 40.3,
       longitude: -73.3,
+      speed_kmh: 17,
+      heart_rate: 151,
+      hr_zone: 3,
+      respiration_rate: 26,
+      temperature_c: 20,
     },
     {
       timestamp: '2026-03-14T09:11:00Z',

--- a/src/components/garmin/ClimbDetailsPanel.tsx
+++ b/src/components/garmin/ClimbDetailsPanel.tsx
@@ -63,6 +63,7 @@ interface ClimbMapPoint {
 }
 
 type ClimbMapMetric =
+  | 'route'
   | 'grade'
   | 'heart-rate-zone'
   | 'heart-rate'
@@ -178,21 +179,42 @@ function valueToBucketColor(
   )
 }
 
-function segmentGrade(point: ClimbMapPoint, nextPoint: ClimbMapPoint): number {
+function finiteNumber(value: number | null): value is number {
+  return value != null && Number.isFinite(value)
+}
+
+function segmentGrade(
+  point: ClimbMapPoint,
+  nextPoint: ClimbMapPoint,
+): number | null {
+  if (!hasSegmentGrade(point, nextPoint)) return null
+
+  const altitude = point.altitude as number
+  const nextAltitude = nextPoint.altitude as number
+  const distanceFromStartKm = point.distanceFromStartKm as number
+  const nextDistanceFromStartKm = nextPoint.distanceFromStartKm as number
+  const distanceMeters = (nextDistanceFromStartKm - distanceFromStartKm) * 1000
+  return ((nextAltitude - altitude) / distanceMeters) * 100
+}
+
+function hasSegmentGrade(point: ClimbMapPoint, nextPoint: ClimbMapPoint) {
   if (
-    point.altitude == null ||
-    nextPoint.altitude == null ||
-    point.distanceFromStartKm == null ||
-    nextPoint.distanceFromStartKm == null
+    !finiteNumber(point.altitude) ||
+    !finiteNumber(nextPoint.altitude) ||
+    !finiteNumber(point.distanceFromStartKm) ||
+    !finiteNumber(nextPoint.distanceFromStartKm)
   ) {
-    return 0
+    return false
   }
 
-  const distanceMeters =
-    (nextPoint.distanceFromStartKm - point.distanceFromStartKm) * 1000
-  if (distanceMeters <= 0) return 0
+  return nextPoint.distanceFromStartKm > point.distanceFromStartKm
+}
 
-  return ((nextPoint.altitude - point.altitude) / distanceMeters) * 100
+function hasGradeSegments(points: ClimbMapPoint[]): boolean {
+  return points.some((point, index) => {
+    const nextPoint = points[index + 1]
+    return nextPoint != null && hasSegmentGrade(point, nextPoint)
+  })
 }
 
 function formatMetric(value: number | null, suffix: string): string {
@@ -203,13 +225,25 @@ function formatMetric(value: number | null, suffix: string): string {
 
 const METRIC_OPTIONS: ClimbMapMetricOption[] = [
   {
+    value: 'route',
+    label: 'Route',
+    available: (points) => points.length >= 2,
+    color: () => '#2563eb',
+    tooltip: () => 'Climb segment',
+    legend: [{ label: 'Route', color: '#2563eb' }],
+  },
+  {
     value: 'grade',
     label: 'Grade',
-    available: (points) => points.length >= 2,
-    color: (point, nextPoint) =>
-      getGradeBucket(segmentGrade(point, nextPoint)).color,
-    tooltip: (point, nextPoint) =>
-      `Grade ${segmentGrade(point, nextPoint).toFixed(1)}%`,
+    available: hasGradeSegments,
+    color: (point, nextPoint) => {
+      const grade = segmentGrade(point, nextPoint)
+      return grade == null ? '#6b7280' : getGradeBucket(grade).color
+    },
+    tooltip: (point, nextPoint) => {
+      const grade = segmentGrade(point, nextPoint)
+      return grade == null ? 'Grade -' : `Grade ${grade.toFixed(1)}%`
+    },
     legend: GRADE_BUCKETS.map((bucket) => ({
       label: bucket.label,
       color: bucket.color,
@@ -481,6 +515,7 @@ function ClimbElevationGradeChart({ points }: { points: ClimbGraphPoint[] }) {
 function ClimbSegmentMap({ points }: { points: ClimbMapPoint[] }) {
   const mapRef = useRef<HTMLDivElement>(null)
   const mapInstanceRef = useRef<L.Map | null>(null)
+  const routeLayerRef = useRef<L.LayerGroup | null>(null)
   const [selectedMetric, setSelectedMetric] = useState<ClimbMapMetric>('grade')
   const availableMetrics = useMemo(
     () => METRIC_OPTIONS.filter((option) => option.available(points)),
@@ -496,6 +531,7 @@ function ClimbSegmentMap({ points }: { points: ClimbMapPoint[] }) {
       mapInstanceRef.current.remove()
       mapInstanceRef.current = null
     }
+    routeLayerRef.current = null
 
     if (!mapRef.current || points.length < 2) return
 
@@ -510,28 +546,11 @@ function ClimbSegmentMap({ points }: { points: ClimbMapPoint[] }) {
     L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
       attribution: '&copy; OpenStreetMap contributors',
     }).addTo(map)
+    routeLayerRef.current = L.layerGroup().addTo(map)
 
     const bounds = L.latLngBounds([])
     for (const point of points) {
       bounds.extend([point.latitude, point.longitude])
-    }
-
-    for (let index = 0; index < points.length - 1; index += 1) {
-      const point = points[index]
-      const nextPoint = points[index + 1]
-      L.polyline(
-        [
-          [point.latitude, point.longitude],
-          [nextPoint.latitude, nextPoint.longitude],
-        ],
-        {
-          color: activeMetric.color(point, nextPoint),
-          weight: 5,
-          opacity: 0.9,
-        },
-      )
-        .bindTooltip(activeMetric.tooltip(point, nextPoint))
-        .addTo(map)
     }
 
     L.circleMarker([first.latitude, first.longitude], {
@@ -561,6 +580,32 @@ function ClimbSegmentMap({ points }: { points: ClimbMapPoint[] }) {
     return () => {
       map.remove()
       mapInstanceRef.current = null
+      routeLayerRef.current = null
+    }
+  }, [points])
+
+  useEffect(() => {
+    const routeLayer = routeLayerRef.current
+    if (!routeLayer || points.length < 2) return
+
+    routeLayer.clearLayers()
+
+    for (let index = 0; index < points.length - 1; index += 1) {
+      const point = points[index]
+      const nextPoint = points[index + 1]
+      L.polyline(
+        [
+          [point.latitude, point.longitude],
+          [nextPoint.latitude, nextPoint.longitude],
+        ],
+        {
+          color: activeMetric.color(point, nextPoint),
+          weight: 5,
+          opacity: 0.9,
+        },
+      )
+        .bindTooltip(activeMetric.tooltip(point, nextPoint))
+        .addTo(routeLayer)
     }
   }, [points, activeMetric])
 
@@ -573,30 +618,44 @@ function ClimbSegmentMap({ points }: { points: ClimbMapPoint[] }) {
   }
 
   return (
-    <div className="space-y-3">
+    <div
+      className="space-y-3"
+      data-testid="climb-map-metric-control"
+      data-available-metrics={availableMetrics
+        .map((option) => option.value)
+        .join(' ')}
+    >
       <div className="flex flex-wrap items-center justify-between gap-3">
         <div className="text-sm font-medium text-muted-foreground">
           Color route by
         </div>
-        <Select
-          value={activeMetric.value}
-          onValueChange={(value) => setSelectedMetric(value as ClimbMapMetric)}
-        >
-          <SelectTrigger
-            size="sm"
-            className="w-44"
-            aria-label="Color climb map route by metric"
+        {availableMetrics.length > 1 ? (
+          <Select
+            value={activeMetric.value}
+            onValueChange={(value) =>
+              setSelectedMetric(value as ClimbMapMetric)
+            }
           >
-            <SelectValue />
-          </SelectTrigger>
-          <SelectContent>
-            {availableMetrics.map((option) => (
-              <SelectItem key={option.value} value={option.value}>
-                {option.label}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
+            <SelectTrigger
+              size="sm"
+              className="w-44"
+              aria-label="Color climb map route by metric"
+            >
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {availableMetrics.map((option) => (
+                <SelectItem key={option.value} value={option.value}>
+                  {option.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        ) : (
+          <div className="rounded-md bg-muted px-3 py-1.5 text-sm font-semibold">
+            {activeMetric.label}
+          </div>
+        )}
       </div>
       <div
         ref={mapRef}

--- a/src/components/garmin/ClimbDetailsPanel.tsx
+++ b/src/components/garmin/ClimbDetailsPanel.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { ChevronLeft, ChevronRight } from 'lucide-react'
 import L from 'leaflet'
 import 'leaflet/dist/leaflet.css'
@@ -6,6 +6,13 @@ import type { GarminActivityClimbsQuery } from '@/__generated__/graphql'
 import type { ActivityChartTrackPoint } from '@/components/garmin/ActivityChartData'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
 import { formatDurationShort, metersToFeet } from '@/lib/units'
 import {
   getClimbSegmentPoints,
@@ -46,6 +53,30 @@ interface ClimbGraphPoint {
 interface ClimbMapPoint {
   latitude: number
   longitude: number
+  altitude: number | null
+  distanceFromStartKm: number | null
+  speedKmh: number | null
+  heartRate: number | null
+  heartRateZone: number | null
+  respirationRate: number | null
+  temperatureC: number | null
+}
+
+type ClimbMapMetric =
+  | 'grade'
+  | 'heart-rate-zone'
+  | 'heart-rate'
+  | 'respiration'
+  | 'speed'
+  | 'temperature'
+
+interface ClimbMapMetricOption {
+  value: ClimbMapMetric
+  label: string
+  available: (points: ClimbMapPoint[]) => boolean
+  color: (point: ClimbMapPoint, nextPoint: ClimbMapPoint) => string
+  tooltip: (point: ClimbMapPoint, nextPoint: ClimbMapPoint) => string
+  legend: Array<{ label: string; color: string }>
 }
 
 function formatDistanceMiles(meters: number | null | undefined): string {
@@ -97,6 +128,16 @@ function toMapPoints(points: ActivityChartTrackPoint[]): ClimbMapPoint[] {
     .map((point) => ({
       latitude: point.latitude as number,
       longitude: point.longitude as number,
+      altitude: point.altitude ?? null,
+      distanceFromStartKm: point.distance_from_start_km ?? null,
+      speedKmh: point.speed_kmh ?? null,
+      heartRate: point.heart_rate ?? null,
+      heartRateZone:
+        point.hr_zone != null && point.hr_zone >= 1 && point.hr_zone <= 5
+          ? point.hr_zone
+          : null,
+      respirationRate: point.respiration_rate ?? null,
+      temperatureC: point.temperature_c ?? null,
     }))
 }
 
@@ -114,6 +155,172 @@ function ClimbStat({ label, value }: { label: string; value: string }) {
     </div>
   )
 }
+
+function hasFiniteMetric<T extends keyof ClimbMapPoint>(
+  points: ClimbMapPoint[],
+  key: T,
+): boolean {
+  return points.some((point) => {
+    const value = point[key]
+    return typeof value === 'number' && Number.isFinite(value)
+  })
+}
+
+function valueToBucketColor(
+  value: number | null,
+  stops: Array<{ max: number; color: string }>,
+  fallback = '#6b7280',
+): string {
+  if (value == null || !Number.isFinite(value)) return fallback
+  return (
+    stops.find((stop) => value < stop.max)?.color ??
+    stops[stops.length - 1].color
+  )
+}
+
+function segmentGrade(point: ClimbMapPoint, nextPoint: ClimbMapPoint): number {
+  if (
+    point.altitude == null ||
+    nextPoint.altitude == null ||
+    point.distanceFromStartKm == null ||
+    nextPoint.distanceFromStartKm == null
+  ) {
+    return 0
+  }
+
+  const distanceMeters =
+    (nextPoint.distanceFromStartKm - point.distanceFromStartKm) * 1000
+  if (distanceMeters <= 0) return 0
+
+  return ((nextPoint.altitude - point.altitude) / distanceMeters) * 100
+}
+
+function formatMetric(value: number | null, suffix: string): string {
+  return value != null && Number.isFinite(value)
+    ? `${value.toFixed(0)} ${suffix}`
+    : '-'
+}
+
+const METRIC_OPTIONS: ClimbMapMetricOption[] = [
+  {
+    value: 'grade',
+    label: 'Grade',
+    available: (points) => points.length >= 2,
+    color: (point, nextPoint) =>
+      getGradeBucket(segmentGrade(point, nextPoint)).color,
+    tooltip: (point, nextPoint) =>
+      `Grade ${segmentGrade(point, nextPoint).toFixed(1)}%`,
+    legend: GRADE_BUCKETS.map((bucket) => ({
+      label: bucket.label,
+      color: bucket.color,
+    })),
+  },
+  {
+    value: 'heart-rate-zone',
+    label: 'HR zone',
+    available: (points) => hasFiniteMetric(points, 'heartRateZone'),
+    color: (point) =>
+      ['#9ca3af', '#3b82f6', '#22c55e', '#facc15', '#f97316', '#ef4444'][
+        point.heartRateZone ?? 0
+      ] ?? '#6b7280',
+    tooltip: (point) =>
+      point.heartRateZone != null
+        ? `HR zone ${point.heartRateZone}`
+        : 'HR zone -',
+    legend: [
+      { label: 'Z1', color: '#3b82f6' },
+      { label: 'Z2', color: '#22c55e' },
+      { label: 'Z3', color: '#facc15' },
+      { label: 'Z4', color: '#f97316' },
+      { label: 'Z5', color: '#ef4444' },
+    ],
+  },
+  {
+    value: 'heart-rate',
+    label: 'Heart rate',
+    available: (points) => hasFiniteMetric(points, 'heartRate'),
+    color: (point) =>
+      valueToBucketColor(point.heartRate, [
+        { max: 120, color: '#3b82f6' },
+        { max: 140, color: '#22c55e' },
+        { max: 160, color: '#facc15' },
+        { max: 175, color: '#f97316' },
+        { max: Infinity, color: '#ef4444' },
+      ]),
+    tooltip: (point) => `Heart rate ${formatMetric(point.heartRate, 'bpm')}`,
+    legend: [
+      { label: '<120', color: '#3b82f6' },
+      { label: '120-139', color: '#22c55e' },
+      { label: '140-159', color: '#facc15' },
+      { label: '160-174', color: '#f97316' },
+      { label: '175+', color: '#ef4444' },
+    ],
+  },
+  {
+    value: 'respiration',
+    label: 'Respiration',
+    available: (points) => hasFiniteMetric(points, 'respirationRate'),
+    color: (point) =>
+      valueToBucketColor(point.respirationRate, [
+        { max: 20, color: '#3b82f6' },
+        { max: 24, color: '#22c55e' },
+        { max: 28, color: '#facc15' },
+        { max: 32, color: '#f97316' },
+        { max: Infinity, color: '#ef4444' },
+      ]),
+    tooltip: (point) =>
+      `Respiration ${formatMetric(point.respirationRate, 'br/min')}`,
+    legend: [
+      { label: '<20', color: '#3b82f6' },
+      { label: '20-23', color: '#22c55e' },
+      { label: '24-27', color: '#facc15' },
+      { label: '28-31', color: '#f97316' },
+      { label: '32+', color: '#ef4444' },
+    ],
+  },
+  {
+    value: 'speed',
+    label: 'Speed',
+    available: (points) => hasFiniteMetric(points, 'speedKmh'),
+    color: (point) =>
+      valueToBucketColor(point.speedKmh, [
+        { max: 10, color: '#3b82f6' },
+        { max: 18, color: '#22c55e' },
+        { max: 26, color: '#facc15' },
+        { max: 34, color: '#f97316' },
+        { max: Infinity, color: '#ef4444' },
+      ]),
+    tooltip: (point) => `Speed ${formatMetric(point.speedKmh, 'km/h')}`,
+    legend: [
+      { label: '<10', color: '#3b82f6' },
+      { label: '10-17', color: '#22c55e' },
+      { label: '18-25', color: '#facc15' },
+      { label: '26-33', color: '#f97316' },
+      { label: '34+', color: '#ef4444' },
+    ],
+  },
+  {
+    value: 'temperature',
+    label: 'Temperature',
+    available: (points) => hasFiniteMetric(points, 'temperatureC'),
+    color: (point) =>
+      valueToBucketColor(point.temperatureC, [
+        { max: 5, color: '#2563eb' },
+        { max: 15, color: '#06b6d4' },
+        { max: 24, color: '#22c55e' },
+        { max: 30, color: '#f97316' },
+        { max: Infinity, color: '#ef4444' },
+      ]),
+    tooltip: (point) => `Temperature ${formatMetric(point.temperatureC, 'C')}`,
+    legend: [
+      { label: '<5', color: '#2563eb' },
+      { label: '5-14', color: '#06b6d4' },
+      { label: '15-23', color: '#22c55e' },
+      { label: '24-29', color: '#f97316' },
+      { label: '30+', color: '#ef4444' },
+    ],
+  },
+]
 
 function ClimbElevationGradeChart({ points }: { points: ClimbGraphPoint[] }) {
   if (points.length < 2) {
@@ -274,6 +481,15 @@ function ClimbElevationGradeChart({ points }: { points: ClimbGraphPoint[] }) {
 function ClimbSegmentMap({ points }: { points: ClimbMapPoint[] }) {
   const mapRef = useRef<HTMLDivElement>(null)
   const mapInstanceRef = useRef<L.Map | null>(null)
+  const [selectedMetric, setSelectedMetric] = useState<ClimbMapMetric>('grade')
+  const availableMetrics = useMemo(
+    () => METRIC_OPTIONS.filter((option) => option.available(points)),
+    [points],
+  )
+  const activeMetric =
+    availableMetrics.find((option) => option.value === selectedMetric) ??
+    availableMetrics[0] ??
+    METRIC_OPTIONS[0]
 
   useEffect(() => {
     if (mapInstanceRef.current) {
@@ -300,12 +516,23 @@ function ClimbSegmentMap({ points }: { points: ClimbMapPoint[] }) {
       bounds.extend([point.latitude, point.longitude])
     }
 
-    L.polyline(
-      points.map(
-        (point) => [point.latitude, point.longitude] as [number, number],
-      ),
-      { color: '#2563eb', weight: 5, opacity: 0.9 },
-    ).addTo(map)
+    for (let index = 0; index < points.length - 1; index += 1) {
+      const point = points[index]
+      const nextPoint = points[index + 1]
+      L.polyline(
+        [
+          [point.latitude, point.longitude],
+          [nextPoint.latitude, nextPoint.longitude],
+        ],
+        {
+          color: activeMetric.color(point, nextPoint),
+          weight: 5,
+          opacity: 0.9,
+        },
+      )
+        .bindTooltip(activeMetric.tooltip(point, nextPoint))
+        .addTo(map)
+    }
 
     L.circleMarker([first.latitude, first.longitude], {
       radius: 7,
@@ -335,7 +562,7 @@ function ClimbSegmentMap({ points }: { points: ClimbMapPoint[] }) {
       map.remove()
       mapInstanceRef.current = null
     }
-  }, [points])
+  }, [points, activeMetric])
 
   if (points.length < 2) {
     return (
@@ -346,11 +573,48 @@ function ClimbSegmentMap({ points }: { points: ClimbMapPoint[] }) {
   }
 
   return (
-    <div
-      ref={mapRef}
-      data-testid="climb-segment-map"
-      className="h-[320px] w-full overflow-hidden rounded-md"
-    />
+    <div className="space-y-3">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div className="text-sm font-medium text-muted-foreground">
+          Color route by
+        </div>
+        <Select
+          value={activeMetric.value}
+          onValueChange={(value) => setSelectedMetric(value as ClimbMapMetric)}
+        >
+          <SelectTrigger
+            size="sm"
+            className="w-44"
+            aria-label="Color climb map route by metric"
+          >
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {availableMetrics.map((option) => (
+              <SelectItem key={option.value} value={option.value}>
+                {option.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+      <div
+        ref={mapRef}
+        data-testid="climb-segment-map"
+        className="h-[320px] w-full overflow-hidden rounded-md"
+      />
+      <div className="flex flex-wrap items-center justify-center gap-x-5 gap-y-2 text-xs font-semibold text-muted-foreground">
+        {activeMetric.legend.map((item) => (
+          <div key={item.label} className="flex items-center gap-1.5">
+            <span
+              className="inline-block h-3 w-3 rounded-full"
+              style={{ backgroundColor: item.color }}
+            />
+            {item.label}
+          </div>
+        ))}
+      </div>
+    </div>
   )
 }
 


### PR DESCRIPTION
## Summary
- add selectable Garmin climb map route overlays for grade, HR zone, heart rate, respiration, speed, and temperature
- show only metric options that exist for the selected climb so older activities keep working
- draw climb route segments with metric-specific legends and Leaflet tooltips

## Validation
- npm run lint:all
- npm run type-check
- npm run test:run -- src/components/garmin/ClimbDetailsPanel.test.tsx
- npm run test:run

Refs #250