### PR TITLE
[codex] Annotate Garmin exports with climb markers

### DIFF
--- a/src/pages/GarminDetailPage.test.tsx
+++ b/src/pages/GarminDetailPage.test.tsx
@@ -804,6 +804,14 @@ describe('GarminDetailPage', () => {
     })
   }
 
+  function mockLoadedClimbs(climbs: ReturnType<typeof mockClimb>[]) {
+    garminDetailHooks.useGarminActivityClimbsQuery.mockReturnValue({
+      loading: false,
+      data: { garminActivityClimbs: climbs },
+      error: undefined,
+    })
+  }
+
   function mockClimb(
     overrides: Partial<{
       id: number
@@ -880,6 +888,13 @@ describe('GarminDetailPage', () => {
   it('clicking Export CSV calls the lazy query and triggers a CSV download', async () => {
     const user = userEvent.setup()
     mockLoadedActivity()
+    mockLoadedClimbs([
+      mockClimb({
+        id: 7,
+        start_time: '2026-03-14T08:59:00Z',
+        end_time: '2026-03-14T09:01:00Z',
+      }),
+    ])
 
     const fetchExport = vi.fn().mockResolvedValue({
       data: {
@@ -916,10 +931,10 @@ describe('GarminDetailPage', () => {
 
     const csvText = exportedBlob ? await exportedBlob.text() : ''
     expect(csvText).toContain(
-      'heart_rate,hr_zone,respiration_rate,cadence,temperature_c,surface_type,effort_level,created_at',
+      'heart_rate,hr_zone,respiration_rate,cadence,temperature_c,is_climb_point,climb_id,climb_index,climb_label,climb_type,climb_difficulty,surface_type,effort_level,created_at',
     )
     expect(csvText).toContain(
-      '135,3,22,80,18,paved,steady,2026-03-14T10:00:00Z',
+      '135,3,22,80,18,true,7,1,Climb 1,CLIMB_PRO_CYCLING_CLIMB,NONE,paved,steady,2026-03-14T10:00:00Z',
     )
 
     vi.unstubAllGlobals()
@@ -929,6 +944,13 @@ describe('GarminDetailPage', () => {
   it('clicking Export GeoJSON calls the lazy query and triggers a GeoJSON download', async () => {
     const user = userEvent.setup()
     mockLoadedActivity()
+    mockLoadedClimbs([
+      mockClimb({
+        id: 7,
+        start_time: '2026-03-14T08:59:00Z',
+        end_time: '2026-03-14T09:01:00Z',
+      }),
+    ])
 
     const fetchExport = vi.fn().mockResolvedValue({
       data: {
@@ -968,6 +990,12 @@ describe('GarminDetailPage', () => {
     expect(geojson.features[0].properties).toMatchObject({
       hr_zone: 3,
       respiration_rate: 22,
+      is_climb_point: true,
+      climb_id: 7,
+      climb_index: 1,
+      climb_label: 'Climb 1',
+      climb_type: 'CLIMB_PRO_CYCLING_CLIMB',
+      climb_difficulty: 'NONE',
       surface_type: 'paved',
       effort_level: 'steady',
       created_at: '2026-03-14T10:00:00Z',

--- a/src/pages/GarminDetailPage.test.tsx
+++ b/src/pages/GarminDetailPage.test.tsx
@@ -941,6 +941,43 @@ describe('GarminDetailPage', () => {
     vi.restoreAllMocks()
   })
 
+  it('exports empty climb marker fields in CSV when an activity has no climbs', async () => {
+    const user = userEvent.setup()
+    mockLoadedActivity()
+
+    const fetchExport = vi.fn().mockResolvedValue({
+      data: {
+        garminTrackPoints: { total: 1, items: mockExportPoints() },
+      },
+    })
+    garminDetailHooks.useGarminExportPointsLazyQuery.mockReturnValue([
+      fetchExport,
+      { loading: false },
+    ])
+
+    let exportedBlob: Blob | undefined
+    const createObjectURL = vi.fn((blob: Blob) => {
+      exportedBlob = blob
+      return 'blob:test'
+    })
+    const revokeObjectURL = vi.fn()
+    const clickSpy = vi.fn()
+    vi.stubGlobal('URL', { createObjectURL, revokeObjectURL })
+    vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(clickSpy)
+
+    renderPage()
+    await user.click(screen.getByTestId('garmin-tab-charts'))
+    await user.click(screen.getByRole('button', { name: /Export CSV/i }))
+
+    const csvText = exportedBlob ? await exportedBlob.text() : ''
+    expect(csvText).toContain(
+      '135,3,22,80,18,false,,,,,,paved,steady,2026-03-14T10:00:00Z',
+    )
+
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+  })
+
   it('clicking Export GeoJSON calls the lazy query and triggers a GeoJSON download', async () => {
     const user = userEvent.setup()
     mockLoadedActivity()
@@ -999,6 +1036,56 @@ describe('GarminDetailPage', () => {
       surface_type: 'paved',
       effort_level: 'steady',
       created_at: '2026-03-14T10:00:00Z',
+    })
+
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+  })
+
+  it('exports empty climb marker properties in GeoJSON for points outside climbs', async () => {
+    const user = userEvent.setup()
+    mockLoadedActivity()
+    mockLoadedClimbs([
+      mockClimb({
+        id: 7,
+        start_time: '2026-03-14T09:05:00Z',
+        end_time: '2026-03-14T09:10:00Z',
+      }),
+    ])
+
+    const fetchExport = vi.fn().mockResolvedValue({
+      data: {
+        garminTrackPoints: { total: 1, items: mockExportPoints() },
+      },
+    })
+    garminDetailHooks.useGarminExportPointsLazyQuery.mockReturnValue([
+      fetchExport,
+      { loading: false },
+    ])
+
+    let exportedBlob: Blob | undefined
+    const createObjectURL = vi.fn((blob: Blob) => {
+      exportedBlob = blob
+      return 'blob:test'
+    })
+    const revokeObjectURL = vi.fn()
+    const clickSpy = vi.fn()
+    vi.stubGlobal('URL', { createObjectURL, revokeObjectURL })
+    vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(clickSpy)
+
+    renderPage()
+    await user.click(screen.getByTestId('garmin-tab-charts'))
+    await user.click(screen.getByRole('button', { name: /Export GeoJSON/i }))
+
+    if (!exportedBlob) throw new Error('Expected export blob to be created')
+    const geojson = JSON.parse(await exportedBlob.text())
+    expect(geojson.features[0].properties).toMatchObject({
+      is_climb_point: false,
+      climb_id: null,
+      climb_index: null,
+      climb_label: null,
+      climb_type: null,
+      climb_difficulty: null,
     })
 
     vi.unstubAllGlobals()

--- a/src/pages/GarminDetailPage.tsx
+++ b/src/pages/GarminDetailPage.tsx
@@ -118,6 +118,59 @@ function formatPercent(value: number | null | undefined): string {
   return value != null ? `${value.toFixed(2)} %` : '—'
 }
 
+interface ClimbExportMarker {
+  isClimbPoint: boolean
+  climbId: number | null
+  climbIndex: number | null
+  climbLabel: string | null
+  climbType: string | null
+  climbDifficulty: string | null
+}
+
+function parseTimestamp(value: string | null | undefined): number | null {
+  if (!value) return null
+  const timestamp = new Date(value).getTime()
+  return Number.isFinite(timestamp) ? timestamp : null
+}
+
+function getClimbExportMarker(
+  timestamp: string,
+  climbs: ActivityClimb[],
+): ClimbExportMarker {
+  const pointTime = parseTimestamp(timestamp)
+  if (pointTime == null) {
+    return {
+      isClimbPoint: false,
+      climbId: null,
+      climbIndex: null,
+      climbLabel: null,
+      climbType: null,
+      climbDifficulty: null,
+    }
+  }
+
+  const climbIndex = climbs.findIndex((climb) => {
+    const startTime = parseTimestamp(climb.start_time)
+    const endTime = parseTimestamp(climb.end_time)
+    return (
+      startTime != null &&
+      endTime != null &&
+      pointTime >= startTime &&
+      pointTime <= endTime
+    )
+  })
+  const climb = climbIndex >= 0 ? climbs[climbIndex] : null
+
+  return {
+    isClimbPoint: climb != null,
+    climbId: climb?.id ?? null,
+    climbIndex: climb != null ? climbIndex + 1 : null,
+    climbLabel: climb != null ? `Climb ${climbIndex + 1}` : null,
+    climbType: climb?.climb_type ?? null,
+    climbDifficulty: climb?.climb_pro_difficulty ?? null,
+  }
+}
+
 function ActivityClimbsTable({
   climbs,
   selectedClimbId,
@@ -248,6 +301,7 @@ export function GarminDetailPage() {
     null,
   )
   const exportInFlightRef = useRef(false)
+  const mainClimbsRef = useRef<ActivityClimb[]>([])
   const isExporting = activeExport !== null
 
   async function handleExport(format: 'csv' | 'geojson') {
@@ -284,6 +338,12 @@ export function GarminDetailPage() {
       }
 
       const points = allPoints
+      const climbMarkers = new Map(
+        points.map((point) => [
+          point.id,
+          getClimbExportMarker(point.timestamp, mainClimbsRef.current),
+        ]),
+      )
       if (points.length === 0) {
         toast.warning('No track points found for this activity', {
           description: 'Exporting an empty file.',
@@ -305,6 +365,12 @@ export function GarminDetailPage() {
           'respiration_rate',
           'cadence',
           'temperature_c',
+          'is_climb_point',
+          'climb_id',
+          'climb_index',
+          'climb_label',
+          'climb_type',
+          'climb_difficulty',
           'surface_type',
           'effort_level',
           'created_at',
@@ -321,8 +387,9 @@ export function GarminDetailPage() {
           'postalcode',
           'geocoded_at',
         ]
-        const rows = points.map((p) =>
-          [
+        const rows = points.map((p) => {
+          const marker = climbMarkers.get(p.id)
+          return [
             p.activity_id,
             p.id,
             p.timestamp,
@@ -336,6 +403,12 @@ export function GarminDetailPage() {
             p.respiration_rate,
             p.cadence,
             p.temperature_c,
+            marker?.isClimbPoint ?? false,
+            marker?.climbId,
+            marker?.climbIndex,
+            marker?.climbLabel,
+            marker?.climbType,
+            marker?.climbDifficulty,
             p.surface_type,
             p.effort_level,
             p.created_at,
@@ -353,8 +426,8 @@ export function GarminDetailPage() {
             p.address?.geocoded_at,
           ]
             .map(escapeCsvValue)
-            .join(','),
-        )
+            .join(',')
+        })
         const csv = [headers.join(','), ...rows].join('\n')
         triggerDownload(
           csv,
@@ -382,6 +455,12 @@ export function GarminDetailPage() {
               respiration_rate: p.respiration_rate,
               cadence: p.cadence,
               temperature_c: p.temperature_c,
+              is_climb_point: climbMarkers.get(p.id)?.isClimbPoint ?? false,
+              climb_id: climbMarkers.get(p.id)?.climbId ?? null,
+              climb_index: climbMarkers.get(p.id)?.climbIndex ?? null,
+              climb_label: climbMarkers.get(p.id)?.climbLabel ?? null,
+              climb_type: climbMarkers.get(p.id)?.climbType ?? null,
+              climb_difficulty: climbMarkers.get(p.id)?.climbDifficulty ?? null,
               surface_type: p.surface_type,
               effort_level: p.effort_level,
               created_at: p.created_at,
@@ -496,6 +575,9 @@ export function GarminDetailPage() {
       ),
     [climbsData?.garminActivityClimbs],
   )
+  useEffect(() => {
+    mainClimbsRef.current = mainClimbs
+  }, [mainClimbs])
   const effectiveSelectedClimbId =
     mainClimbs.length === 0
       ? null

--- a/src/pages/GarminDetailPage.tsx
+++ b/src/pages/GarminDetailPage.tsx
@@ -127,48 +127,59 @@ interface ClimbExportMarker {
   climbDifficulty: string | null
 }
 
+interface ClimbExportWindow extends ClimbExportMarker {
+  startTime: number
+  endTime: number
+}
+
 function parseTimestamp(value: string | null | undefined): number | null {
   if (!value) return null
   const timestamp = new Date(value).getTime()
   return Number.isFinite(timestamp) ? timestamp : null
 }
 
-function getClimbExportMarker(
-  timestamp: string,
-  climbs: ActivityClimb[],
-): ClimbExportMarker {
-  const pointTime = parseTimestamp(timestamp)
-  if (pointTime == null) {
-    return {
-      isClimbPoint: false,
-      climbId: null,
-      climbIndex: null,
-      climbLabel: null,
-      climbType: null,
-      climbDifficulty: null,
-    }
-  }
+const EMPTY_CLIMB_EXPORT_MARKER: ClimbExportMarker = {
+  isClimbPoint: false,
+  climbId: null,
+  climbIndex: null,
+  climbLabel: null,
+  climbType: null,
+  climbDifficulty: null,
+}
 
-  const climbIndex = climbs.findIndex((climb) => {
+function buildClimbExportWindows(climbs: ActivityClimb[]): ClimbExportWindow[] {
+  return climbs.flatMap((climb, index) => {
     const startTime = parseTimestamp(climb.start_time)
     const endTime = parseTimestamp(climb.end_time)
-    return (
-      startTime != null &&
-      endTime != null &&
-      pointTime >= startTime &&
-      pointTime <= endTime
-    )
-  })
-  const climb = climbIndex >= 0 ? climbs[climbIndex] : null
+    if (startTime == null || endTime == null) return []
 
-  return {
-    isClimbPoint: climb != null,
-    climbId: climb?.id ?? null,
-    climbIndex: climb != null ? climbIndex + 1 : null,
-    climbLabel: climb != null ? `Climb ${climbIndex + 1}` : null,
-    climbType: climb?.climb_type ?? null,
-    climbDifficulty: climb?.climb_pro_difficulty ?? null,
-  }
+    return [
+      {
+        startTime,
+        endTime,
+        isClimbPoint: true,
+        climbId: climb.id,
+        climbIndex: index + 1,
+        climbLabel: `Climb ${index + 1}`,
+        climbType: climb.climb_type ?? null,
+        climbDifficulty: climb.climb_pro_difficulty ?? null,
+      },
+    ]
+  })
+}
+
+function getClimbExportMarker(
+  timestamp: string,
+  climbWindows: ClimbExportWindow[],
+): ClimbExportMarker {
+  const pointTime = parseTimestamp(timestamp)
+  if (pointTime == null) return EMPTY_CLIMB_EXPORT_MARKER
+
+  return (
+    climbWindows.find(
+      (climb) => pointTime >= climb.startTime && pointTime <= climb.endTime,
+    ) ?? EMPTY_CLIMB_EXPORT_MARKER
+  )
 }
 
 function ActivityClimbsTable({
@@ -338,10 +349,11 @@ export function GarminDetailPage() {
       }
 
       const points = allPoints
+      const climbWindows = buildClimbExportWindows(mainClimbsRef.current)
       const climbMarkers = new Map(
         points.map((point) => [
           point.id,
-          getClimbExportMarker(point.timestamp, mainClimbsRef.current),
+          getClimbExportMarker(point.timestamp, climbWindows),
         ]),
       )
       if (points.length === 0) {


### PR DESCRIPTION
## Summary
- add climb marker columns to Garmin activity CSV exports
- add matching climb marker properties to GeoJSON exports
- mark exported track points that fall inside main Garmin ClimbPro climb windows with climb id/index/label/type/difficulty

## Validation
- npm run lint:all
- npm run type-check
- npm run build
- npm run test:run -- src/pages/GarminDetailPage.test.tsx
- npm run test:run
- Verified a local browser CSV download includes `is_climb_point`, `climb_id`, `climb_index`, `climb_label`, `climb_type`, and `climb_difficulty`

Refs #253