### PR TITLE
[codex] Fix climb map dropdown stacking

### DIFF
--- a/src/components/garmin/ClimbDetailsPanel.tsx
+++ b/src/components/garmin/ClimbDetailsPanel.tsx
@@ -643,7 +643,7 @@ function ClimbSegmentMap({ points }: { points: ClimbMapPoint[] }) {
             >
               <SelectValue />
             </SelectTrigger>
-            <SelectContent className="z-[2000]">
+            <SelectContent>
               {availableMetrics.map((option) => (
                 <SelectItem key={option.value} value={option.value}>
                   {option.label}

--- a/src/components/garmin/ClimbDetailsPanel.tsx
+++ b/src/components/garmin/ClimbDetailsPanel.tsx
@@ -643,7 +643,7 @@ function ClimbSegmentMap({ points }: { points: ClimbMapPoint[] }) {
             >
               <SelectValue />
             </SelectTrigger>
-            <SelectContent>
+            <SelectContent className="z-[2000]">
               {availableMetrics.map((option) => (
                 <SelectItem key={option.value} value={option.value}>
                   {option.label}
@@ -660,7 +660,7 @@ function ClimbSegmentMap({ points }: { points: ClimbMapPoint[] }) {
       <div
         ref={mapRef}
         data-testid="climb-segment-map"
-        className="h-[320px] w-full overflow-hidden rounded-md"
+        className="relative z-0 h-[320px] w-full overflow-hidden rounded-md"
       />
       <div className="flex flex-wrap items-center justify-center gap-x-5 gap-y-2 text-xs font-semibold text-muted-foreground">
         {activeMetric.legend.map((item) => (


### PR DESCRIPTION
## Summary
- Fix the Garmin climb map metric dropdown stacking above Leaflet map panes and controls.
- Add an explicit base stacking context to the climb segment map container.

## Why
The Radix select content used the default select layer, while Leaflet panes and controls can render above surrounding UI. This caused the "Color route by" dropdown to appear underneath the map.

## Validation
- npm run test:run -- src/components/garmin/ClimbDetailsPanel.test.tsx
- npm run lint:all
- npm run type-check
- npm run build

Follow-up to #254.
