### PR TITLE
[codex] Add Garmin activity laps tab

### DIFF
--- a/e2e/garmin-laps.spec.ts
+++ b/e2e/garmin-laps.spec.ts
@@ -1,0 +1,68 @@
+import { test, expect } from '@playwright/test'
+import fs from 'fs'
+import path from 'path'
+
+const SCREENSHOT_DIR = path.join('e2e', 'screenshots', 'garmin-laps')
+const ACTIVITY_ID =
+  process.env.PLAYWRIGHT_GARMIN_LAPS_ACTIVITY_ID ?? '9965963574'
+
+fs.mkdirSync(SCREENSHOT_DIR, { recursive: true })
+
+test.describe('Garmin Activity Laps', () => {
+  test('renders laps table, selection, summary, and existing tabs', async ({
+    page,
+  }) => {
+    await page.goto(`/garmin/${ACTIVITY_ID}`)
+
+    await expect(page.getByTestId('garmin-detail-tabs')).toBeVisible({
+      timeout: 20_000,
+    })
+    await page.getByTestId('garmin-tab-laps').click()
+
+    const table = page.getByTestId('activity-laps-table')
+    await expect(table).toBeVisible({ timeout: 20_000 })
+    await expect(table.getByText('Summary')).toBeVisible()
+
+    const firstLap = page.getByTestId('lap-row-1')
+    await expect(firstLap).toBeVisible()
+    await firstLap.click()
+    await expect(firstLap).toHaveAttribute('data-selected', 'true')
+    await expect(firstLap.getByRole('button', { name: '1' })).toHaveAttribute(
+      'aria-pressed',
+      'true',
+    )
+
+    const secondLapButton = page
+      .getByTestId('lap-row-2')
+      .getByRole('button', { name: '2' })
+    await secondLapButton.focus()
+    await page.keyboard.press('Enter')
+    await expect(page.getByTestId('lap-row-2')).toHaveAttribute(
+      'data-selected',
+      'true',
+    )
+
+    await table.screenshot({
+      path: path.join(SCREENSHOT_DIR, 'laps-table-selected.png'),
+    })
+    await page.screenshot({
+      path: path.join(SCREENSHOT_DIR, 'laps-page.png'),
+      fullPage: true,
+    })
+
+    await page.getByTestId('garmin-tab-stats').click()
+    await expect(page.getByRole('tab', { name: 'Stats' })).toHaveAttribute(
+      'aria-selected',
+      'true',
+    )
+    await expect(page.getByText('Heart Rate Zones')).toBeVisible()
+
+    await page.getByTestId('garmin-tab-charts').click()
+    await expect(page.getByTestId('chart-elevation')).toBeVisible({
+      timeout: 20_000,
+    })
+
+    await page.getByTestId('garmin-tab-climbs').click()
+    await expect(page.getByTestId('garmin-tab-climbs')).toBeVisible()
+  })
+})

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@fontsource-variable/geist": "^5.2.8",
         "@newrelic/browser-agent": "^1.314.0",
         "@radix-ui/react-slot": "^1.3.0",
-        "@stuartshay/otel-graphql-types": "1.0.95",
+        "@stuartshay/otel-graphql-types": "1.0.445",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "date-fns": "^4.1.0",
@@ -6487,9 +6487,9 @@
       "license": "MIT"
     },
     "node_modules/@stuartshay/otel-graphql-types": {
-      "version": "1.0.95",
-      "resolved": "https://registry.npmjs.org/@stuartshay/otel-graphql-types/-/otel-graphql-types-1.0.95.tgz",
-      "integrity": "sha512-/ybSKz3OAuhBQ5/Mh4w9JOzDLedrwJra5dO3lzSrDkIbMGhpcpVaULEWxqvTo6eyCnBRs/HL+vmxB/O6la4Iww==",
+      "version": "1.0.445",
+      "resolved": "https://registry.npmjs.org/@stuartshay/otel-graphql-types/-/otel-graphql-types-1.0.445.tgz",
+      "integrity": "sha512-nIOxlMGKe7HPwlXB8+/Df9prV10nw2pW/0MXg+gr5800bgcBqEXzO9qAqUR0bwWHREE3C+DI4PsjCN9vZOERTg==",
       "license": "MIT"
     },
     "node_modules/@tailwindcss/node": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@fontsource-variable/geist": "^5.2.8",
     "@newrelic/browser-agent": "^1.314.0",
     "@radix-ui/react-slot": "^1.3.0",
-    "@stuartshay/otel-graphql-types": "1.0.95",
+    "@stuartshay/otel-graphql-types": "1.0.445",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "date-fns": "^4.1.0",

--- a/src/__generated__/graphql.ts
+++ b/src/__generated__/graphql.ts
@@ -312,6 +312,49 @@ export type GarminActivityConnection = {
   total: Scalars['Int']['output'];
 };
 
+/** Garmin-native or derived activity lap row. */
+export type GarminActivityLap = {
+  __typename?: 'GarminActivityLap';
+  /** Parent Garmin activity identifier */
+  activity_id: Scalars['String']['output'];
+  /** Average lap heart rate in bpm */
+  avg_heart_rate?: Maybe<Scalars['Int']['output']>;
+  /** Average lap speed in meters per second */
+  avg_speed_mps?: Maybe<Scalars['Float']['output']>;
+  /** Calories recorded for this lap */
+  calories?: Maybe<Scalars['Float']['output']>;
+  /** UTC timestamp when the row was inserted */
+  created_at?: Maybe<Scalars['String']['output']>;
+  /** Lap distance in meters */
+  distance_meters?: Maybe<Scalars['Float']['output']>;
+  /** Lap timer duration in seconds */
+  duration_seconds?: Maybe<Scalars['Float']['output']>;
+  /** Lap elapsed duration in seconds */
+  elapsed_duration_seconds?: Maybe<Scalars['Float']['output']>;
+  /** UTC lap end time */
+  end_time?: Maybe<Scalars['String']['output']>;
+  /** Unique lap row identifier */
+  id: Scalars['Float']['output'];
+  /** One-based lap order within the activity */
+  lap_index: Scalars['Int']['output'];
+  /** Maximum lap heart rate in bpm */
+  max_heart_rate?: Maybe<Scalars['Int']['output']>;
+  /** Lap moving duration in seconds */
+  moving_duration_seconds?: Maybe<Scalars['Float']['output']>;
+  /** Lap paved distance in meters */
+  paved_distance_meters?: Maybe<Scalars['Float']['output']>;
+  /** UTC lap start time */
+  start_time?: Maybe<Scalars['String']['output']>;
+  /** Lap elevation gain in meters */
+  total_ascent_meters?: Maybe<Scalars['Float']['output']>;
+  /** Lap elevation loss in meters */
+  total_descent_meters?: Maybe<Scalars['Float']['output']>;
+  /** Lap unpaved distance in meters */
+  unpaved_distance_meters?: Maybe<Scalars['Float']['output']>;
+  /** UTC timestamp when the row was last updated */
+  updated_at?: Maybe<Scalars['String']['output']>;
+};
+
 /** Aggregated Garmin activity totals for a single time bucket (week, month, or year). */
 export type GarminActivityTotal = {
   __typename?: 'GarminActivityTotal';
@@ -760,6 +803,8 @@ export type Query = {
   garminActivityAddresses: Array<GarminActivityAddress>;
   /** Retrieve Garmin-native ClimbPro typed splits for a Garmin activity. */
   garminActivityClimbs: Array<GarminActivityClimb>;
+  /** Retrieve Garmin-native or derived laps for a Garmin activity. */
+  garminActivityLaps: Array<GarminActivityLap>;
   /** Aggregate Garmin activity totals grouped by week, month, or year. */
   garminActivityTotals: Array<GarminActivityTotal>;
   /** Retrieve chart-optimised track points for a Garmin activity. */
@@ -837,6 +882,11 @@ export type QueryGarminActivityAddressesArgs = {
 
 
 export type QueryGarminActivityClimbsArgs = {
+  activity_id: Scalars['String']['input'];
+};
+
+
+export type QueryGarminActivityLapsArgs = {
   activity_id: Scalars['String']['input'];
 };
 
@@ -1089,6 +1139,13 @@ export type GarminActivityClimbsQueryVariables = Exact<{
 
 
 export type GarminActivityClimbsQuery = { garminActivityClimbs: Array<{ id: number, activity_id: string, source_split_index: number, message_index: number | null, climb_type: string | null, start_time: string | null, end_time: string | null, duration_seconds: number | null, elapsed_duration_seconds: number | null, moving_duration_seconds: number | null, distance_meters: number | null, elevation_gain_meters: number | null, elevation_loss_meters: number | null, start_elevation_meters: number | null, average_grade_percent: number | null, max_grade_percent: number | null, average_speed_mps: number | null, max_speed_mps: number | null, start_latitude: number | null, start_longitude: number | null, end_latitude: number | null, end_longitude: number | null, climb_pro_difficulty: string | null }> };
+
+export type GarminActivityLapsQueryVariables = Exact<{
+  activity_id: string;
+}>;
+
+
+export type GarminActivityLapsQuery = { garminActivityLaps: Array<{ id: number, activity_id: string, lap_index: number, start_time: string | null, end_time: string | null, duration_seconds: number | null, elapsed_duration_seconds: number | null, moving_duration_seconds: number | null, distance_meters: number | null, paved_distance_meters: number | null, unpaved_distance_meters: number | null, avg_speed_mps: number | null, avg_heart_rate: number | null, max_heart_rate: number | null, total_ascent_meters: number | null, total_descent_meters: number | null, calories: number | null, created_at: string | null, updated_at: string | null }> };
 
 export type TriggerGarminSyncMutationVariables = Exact<{
   window_hours?: number | null | undefined;
@@ -1795,6 +1852,67 @@ export type GarminActivityClimbsQueryHookResult = ReturnType<typeof useGarminAct
 export type GarminActivityClimbsLazyQueryHookResult = ReturnType<typeof useGarminActivityClimbsLazyQuery>;
 export type GarminActivityClimbsSuspenseQueryHookResult = ReturnType<typeof useGarminActivityClimbsSuspenseQuery>;
 export type GarminActivityClimbsQueryResult = ApolloReactCommon.QueryResult<GarminActivityClimbsQuery, GarminActivityClimbsQueryVariables>;
+export const GarminActivityLapsDocument = gql`
+    query GarminActivityLaps($activity_id: String!) {
+  garminActivityLaps(activity_id: $activity_id) {
+    id
+    activity_id
+    lap_index
+    start_time
+    end_time
+    duration_seconds
+    elapsed_duration_seconds
+    moving_duration_seconds
+    distance_meters
+    paved_distance_meters
+    unpaved_distance_meters
+    avg_speed_mps
+    avg_heart_rate
+    max_heart_rate
+    total_ascent_meters
+    total_descent_meters
+    calories
+    created_at
+    updated_at
+  }
+}
+    `;
+
+/**
+ * __useGarminActivityLapsQuery__
+ *
+ * To run a query within a React component, call `useGarminActivityLapsQuery` and pass it any options that fit your needs.
+ * When your component renders, `useGarminActivityLapsQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useGarminActivityLapsQuery({
+ *   variables: {
+ *      activity_id: // value for 'activity_id'
+ *   },
+ * });
+ */
+export function useGarminActivityLapsQuery(baseOptions: ApolloReactHooks.QueryHookOptions<GarminActivityLapsQuery, GarminActivityLapsQueryVariables> & ({ variables: GarminActivityLapsQueryVariables; skip?: boolean; } | { skip: boolean; }) ) {
+        const options = {...defaultOptions, ...baseOptions}
+        return ApolloReactHooks.useQuery<GarminActivityLapsQuery, GarminActivityLapsQueryVariables>(GarminActivityLapsDocument, options);
+      }
+export function useGarminActivityLapsLazyQuery(baseOptions?: ApolloReactHooks.LazyQueryHookOptions<GarminActivityLapsQuery, GarminActivityLapsQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return ApolloReactHooks.useLazyQuery<GarminActivityLapsQuery, GarminActivityLapsQueryVariables>(GarminActivityLapsDocument, options);
+        }
+// @ts-ignore
+export function useGarminActivityLapsSuspenseQuery(baseOptions?: ApolloReactHooks.SuspenseQueryHookOptions<GarminActivityLapsQuery, GarminActivityLapsQueryVariables>): ApolloReactHooks.UseSuspenseQueryResult<GarminActivityLapsQuery, GarminActivityLapsQueryVariables>;
+export function useGarminActivityLapsSuspenseQuery(baseOptions?: ApolloReactHooks.SkipToken | ApolloReactHooks.SuspenseQueryHookOptions<GarminActivityLapsQuery, GarminActivityLapsQueryVariables>): ApolloReactHooks.UseSuspenseQueryResult<GarminActivityLapsQuery | undefined, GarminActivityLapsQueryVariables>;
+export function useGarminActivityLapsSuspenseQuery(baseOptions?: ApolloReactHooks.SkipToken | ApolloReactHooks.SuspenseQueryHookOptions<GarminActivityLapsQuery, GarminActivityLapsQueryVariables>) {
+          const options = baseOptions === ApolloReactHooks.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
+          return ApolloReactHooks.useSuspenseQuery<GarminActivityLapsQuery, GarminActivityLapsQueryVariables>(GarminActivityLapsDocument, options);
+        }
+export type GarminActivityLapsQueryHookResult = ReturnType<typeof useGarminActivityLapsQuery>;
+export type GarminActivityLapsLazyQueryHookResult = ReturnType<typeof useGarminActivityLapsLazyQuery>;
+export type GarminActivityLapsSuspenseQueryHookResult = ReturnType<typeof useGarminActivityLapsSuspenseQuery>;
+export type GarminActivityLapsQueryResult = ApolloReactCommon.QueryResult<GarminActivityLapsQuery, GarminActivityLapsQueryVariables>;
 export const TriggerGarminSyncDocument = gql`
     mutation TriggerGarminSync($window_hours: Int, $lookback: Int) {
   triggerGarminSync(window_hours: $window_hours, lookback: $lookback) {

--- a/src/components/garmin/ActivityLapsTable.helpers.ts
+++ b/src/components/garmin/ActivityLapsTable.helpers.ts
@@ -1,0 +1,89 @@
+export interface ActivityLap {
+  id: number
+  lap_index: number
+  duration_seconds?: number | null
+  distance_meters?: number | null
+  paved_distance_meters?: number | null
+  unpaved_distance_meters?: number | null
+  avg_speed_mps?: number | null
+  avg_heart_rate?: number | null
+  max_heart_rate?: number | null
+  total_ascent_meters?: number | null
+}
+
+export interface LapSummary {
+  durationSeconds: number | null
+  distanceMeters: number | null
+  pavedPercent: number | null
+  unpavedPercent: number | null
+  avgSpeedMps: number | null
+  avgHeartRate: number | null
+  maxHeartRate: number | null
+  totalAscentMeters: number | null
+}
+
+function lapWeight(lap: ActivityLap): number {
+  if (lap.duration_seconds != null && lap.duration_seconds > 0) {
+    return lap.duration_seconds
+  }
+  if (lap.distance_meters != null && lap.distance_meters > 0) {
+    return lap.distance_meters
+  }
+  return 1
+}
+
+export function buildLapSummary(laps: ActivityLap[]): LapSummary {
+  const durationSeconds = laps.reduce(
+    (sum, lap) => sum + (lap.duration_seconds ?? 0),
+    0,
+  )
+  const distanceMeters = laps.reduce(
+    (sum, lap) => sum + (lap.distance_meters ?? 0),
+    0,
+  )
+  const pavedMeters = laps.reduce(
+    (sum, lap) => sum + (lap.paved_distance_meters ?? 0),
+    0,
+  )
+  const unpavedMeters = laps.reduce(
+    (sum, lap) => sum + (lap.unpaved_distance_meters ?? 0),
+    0,
+  )
+  const ascentMeters = laps.reduce(
+    (sum, lap) => sum + (lap.total_ascent_meters ?? 0),
+    0,
+  )
+  const heartRateWeight = laps.reduce(
+    (sum, lap) =>
+      lap.avg_heart_rate != null && lap.avg_heart_rate > 0
+        ? sum + lapWeight(lap)
+        : sum,
+    0,
+  )
+  const avgHeartRate =
+    heartRateWeight > 0
+      ? laps.reduce((sum, lap) => {
+          if (lap.avg_heart_rate == null || lap.avg_heart_rate <= 0) return sum
+          return sum + lap.avg_heart_rate * lapWeight(lap)
+        }, 0) / heartRateWeight
+      : null
+  const maxHeartRates = laps
+    .map((lap) => lap.max_heart_rate)
+    .filter((value): value is number => value != null && value > 0)
+
+  return {
+    durationSeconds: durationSeconds > 0 ? durationSeconds : null,
+    distanceMeters: distanceMeters > 0 ? distanceMeters : null,
+    pavedPercent:
+      distanceMeters > 0 ? (pavedMeters / distanceMeters) * 100 : null,
+    unpavedPercent:
+      distanceMeters > 0 ? (unpavedMeters / distanceMeters) * 100 : null,
+    avgSpeedMps:
+      distanceMeters > 0 && durationSeconds > 0
+        ? distanceMeters / durationSeconds
+        : null,
+    avgHeartRate,
+    maxHeartRate: maxHeartRates.length > 0 ? Math.max(...maxHeartRates) : null,
+    totalAscentMeters: ascentMeters > 0 ? ascentMeters : null,
+  }
+}

--- a/src/components/garmin/ActivityLapsTable.test.tsx
+++ b/src/components/garmin/ActivityLapsTable.test.tsx
@@ -1,0 +1,129 @@
+import { fireEvent, render, screen, within } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import { ActivityLapsTable } from './ActivityLapsTable'
+import { buildLapSummary, type ActivityLap } from './ActivityLapsTable.helpers'
+
+function lap(overrides: Partial<ActivityLap> = {}): ActivityLap {
+  return {
+    id: overrides.lap_index ?? 1,
+    lap_index: 1,
+    duration_seconds: 60,
+    distance_meters: 1609.344,
+    paved_distance_meters: 1609.344,
+    unpaved_distance_meters: 0,
+    avg_speed_mps: 4,
+    avg_heart_rate: 120,
+    max_heart_rate: 140,
+    total_ascent_meters: 10,
+    ...overrides,
+  }
+}
+
+describe('ActivityLapsTable', () => {
+  it('builds weighted summary values', () => {
+    const summary = buildLapSummary([
+      lap({ lap_index: 1, duration_seconds: 100, avg_heart_rate: 120 }),
+      lap({ lap_index: 2, duration_seconds: 200, avg_heart_rate: 150 }),
+    ])
+
+    expect(summary.durationSeconds).toBe(300)
+    expect(summary.distanceMeters).toBeCloseTo(3218.688)
+    expect(summary.avgSpeedMps).toBeCloseTo(10.72896)
+    expect(summary.avgHeartRate).toBe(140)
+    expect(summary.maxHeartRate).toBe(140)
+  })
+
+  it('preserves zero summary percentages and ignores unavailable heart rate values', () => {
+    const summary = buildLapSummary([
+      lap({
+        lap_index: 1,
+        distance_meters: 1000,
+        paved_distance_meters: 0,
+        unpaved_distance_meters: 1000,
+        avg_heart_rate: 0,
+      }),
+      lap({
+        lap_index: 2,
+        distance_meters: 1000,
+        paved_distance_meters: 0,
+        unpaved_distance_meters: 1000,
+        avg_heart_rate: null,
+      }),
+    ])
+
+    expect(summary.pavedPercent).toBe(0)
+    expect(summary.unpavedPercent).toBe(100)
+    expect(summary.avgHeartRate).toBeNull()
+  })
+
+  it('falls back to distance weighting when heart-rate laps have zero duration', () => {
+    const summary = buildLapSummary([
+      lap({
+        lap_index: 1,
+        duration_seconds: 0,
+        distance_meters: 1000,
+        avg_heart_rate: 120,
+      }),
+      lap({
+        lap_index: 2,
+        duration_seconds: 0,
+        distance_meters: 3000,
+        avg_heart_rate: 160,
+      }),
+    ])
+
+    expect(summary.avgHeartRate).toBe(150)
+  })
+
+  it('renders laps in lap order with cumulative time and summary', () => {
+    render(
+      <ActivityLapsTable
+        laps={[
+          lap({ id: 2, lap_index: 2, duration_seconds: 90 }),
+          lap({ id: 1, lap_index: 1, duration_seconds: 60 }),
+        ]}
+      />,
+    )
+
+    const rows = screen.getAllByTestId(/lap-row-/)
+    const firstCells = within(rows[0]).getAllByRole('cell')
+    const secondCells = within(rows[1]).getAllByRole('cell')
+    expect(firstCells[0]).toHaveTextContent('1')
+    expect(firstCells[1]).toHaveTextContent('1:00')
+    expect(firstCells[2]).toHaveTextContent('1:00')
+    expect(secondCells[0]).toHaveTextContent('2')
+    expect(secondCells[1]).toHaveTextContent('1:30')
+    expect(secondCells[2]).toHaveTextContent('2:30')
+    expect(screen.getByText('Summary')).toBeInTheDocument()
+    expect(screen.getAllByText('2.00')[0]).toBeInTheDocument()
+  })
+
+  it('supports selecting rows with click and keyboard', () => {
+    render(
+      <ActivityLapsTable
+        laps={[lap({ lap_index: 1 }), lap({ lap_index: 2 })]}
+      />,
+    )
+
+    const first = screen.getByTestId('lap-row-1')
+    const second = screen.getByTestId('lap-row-2')
+
+    fireEvent.click(first)
+    expect(first).toHaveAttribute('data-selected', 'true')
+
+    fireEvent.click(within(second).getByRole('button', { name: '2' }))
+    expect(second).toHaveAttribute('data-selected', 'true')
+    expect(within(second).getByRole('button', { name: '2' })).toHaveAttribute(
+      'aria-pressed',
+      'true',
+    )
+  })
+
+  it('renders an empty state when no laps are available', () => {
+    render(<ActivityLapsTable laps={[]} />)
+
+    expect(
+      screen.getByText('No laps found for this activity.'),
+    ).toBeInTheDocument()
+  })
+})

--- a/src/components/garmin/ActivityLapsTable.tsx
+++ b/src/components/garmin/ActivityLapsTable.tsx
@@ -1,0 +1,207 @@
+import { useMemo, useState } from 'react'
+import { Card, CardContent } from '@/components/ui/card'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table'
+import { formatDuration, metersToFeet } from '@/lib/units'
+import { cn } from '@/lib/utils'
+import { buildLapSummary, type ActivityLap } from './ActivityLapsTable.helpers'
+
+const METERS_PER_MILE = 1609.344
+const MPS_TO_MPH = 2.2369362921
+
+interface ActivityLapsTableProps {
+  laps: ActivityLap[]
+}
+
+function formatDistanceMeters(value: number | null | undefined): string {
+  if (value == null) return '—'
+  return (value / METERS_PER_MILE).toFixed(2)
+}
+
+function formatSpeedMps(value: number | null | undefined): string {
+  if (value == null) return '—'
+  return (value * MPS_TO_MPH).toFixed(1)
+}
+
+function formatHeartRate(value: number | null | undefined): string {
+  return value != null && value > 0 ? String(Math.round(value)) : '—'
+}
+
+function formatAscent(value: number | null | undefined): string {
+  if (value == null) return '—'
+  return String(Math.round(metersToFeet(value)))
+}
+
+function formatPercent(value: number | null | undefined): string {
+  if (value == null) return '—'
+  return `${Math.round(value)}%`
+}
+
+function surfacePercent(
+  surfaceMeters: number | null | undefined,
+  distanceMeters: number | null | undefined,
+): number | null {
+  if (surfaceMeters == null || distanceMeters == null || distanceMeters <= 0) {
+    return null
+  }
+  return (surfaceMeters / distanceMeters) * 100
+}
+
+export function ActivityLapsTable({ laps }: ActivityLapsTableProps) {
+  const [selectedLapIndex, setSelectedLapIndex] = useState<number | null>(null)
+  const orderedLaps = useMemo(
+    () => [...laps].sort((a, b) => a.lap_index - b.lap_index),
+    [laps],
+  )
+  const rows = useMemo(() => {
+    return orderedLaps.reduce<
+      Array<{ lap: ActivityLap; cumulativeSeconds: number }>
+    >((acc, lap) => {
+      const cumulativeSeconds =
+        (acc.at(-1)?.cumulativeSeconds ?? 0) + (lap.duration_seconds ?? 0)
+      acc.push({ lap, cumulativeSeconds })
+      return acc
+    }, [])
+  }, [orderedLaps])
+  const summary = useMemo(() => buildLapSummary(orderedLaps), [orderedLaps])
+
+  if (orderedLaps.length === 0) {
+    return (
+      <div className="rounded-md border border-dashed p-6 text-sm text-muted-foreground">
+        No laps found for this activity.
+      </div>
+    )
+  }
+
+  return (
+    <Card data-testid="activity-laps-table">
+      <CardContent className="p-0">
+        <div className="overflow-x-auto">
+          <Table className="min-w-[920px] text-sm">
+            <TableHeader>
+              <TableRow>
+                <TableHead>Laps</TableHead>
+                <TableHead>Time</TableHead>
+                <TableHead>Cumulative Time</TableHead>
+                <TableHead className="text-right">Distance</TableHead>
+                <TableHead className="text-right">Paved</TableHead>
+                <TableHead className="text-right">Unpaved</TableHead>
+                <TableHead className="text-right">Avg Speed</TableHead>
+                <TableHead className="text-right">Avg HR</TableHead>
+                <TableHead className="text-right">Max HR</TableHead>
+                <TableHead className="text-right">Total Ascent</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {rows.map(({ lap, cumulativeSeconds }) => {
+                const selected = selectedLapIndex === lap.lap_index
+
+                return (
+                  <TableRow
+                    key={lap.id}
+                    data-selected={selected}
+                    data-testid={`lap-row-${lap.lap_index}`}
+                    className={cn(
+                      'cursor-pointer',
+                      selected
+                        ? 'bg-blue-100 hover:bg-blue-100 dark:bg-blue-950/40'
+                        : '',
+                    )}
+                    onClick={() => setSelectedLapIndex(lap.lap_index)}
+                  >
+                    <TableCell className="font-medium">
+                      <button
+                        type="button"
+                        aria-pressed={selected}
+                        className="rounded-sm px-1 text-left font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                        onClick={(event) => {
+                          event.stopPropagation()
+                          setSelectedLapIndex(lap.lap_index)
+                        }}
+                      >
+                        {lap.lap_index}
+                      </button>
+                    </TableCell>
+                    <TableCell>
+                      {formatDuration(lap.duration_seconds ?? null)}
+                    </TableCell>
+                    <TableCell>{formatDuration(cumulativeSeconds)}</TableCell>
+                    <TableCell className="text-right tabular-nums">
+                      {formatDistanceMeters(lap.distance_meters)}
+                    </TableCell>
+                    <TableCell className="text-right tabular-nums">
+                      {formatPercent(
+                        surfacePercent(
+                          lap.paved_distance_meters,
+                          lap.distance_meters,
+                        ),
+                      )}
+                    </TableCell>
+                    <TableCell className="text-right tabular-nums">
+                      {formatPercent(
+                        surfacePercent(
+                          lap.unpaved_distance_meters,
+                          lap.distance_meters,
+                        ),
+                      )}
+                    </TableCell>
+                    <TableCell className="text-right tabular-nums">
+                      {formatSpeedMps(lap.avg_speed_mps)}
+                    </TableCell>
+                    <TableCell className="text-right tabular-nums">
+                      {formatHeartRate(lap.avg_heart_rate)}
+                    </TableCell>
+                    <TableCell className="text-right tabular-nums">
+                      {formatHeartRate(lap.max_heart_rate)}
+                    </TableCell>
+                    <TableCell className="text-right tabular-nums">
+                      {formatAscent(lap.total_ascent_meters)}
+                    </TableCell>
+                  </TableRow>
+                )
+              })}
+            </TableBody>
+            <tfoot>
+              <tr className="border-t font-semibold">
+                <td className="p-2">Summary</td>
+                <td className="p-2">
+                  {formatDuration(summary.durationSeconds)}
+                </td>
+                <td className="p-2">
+                  {formatDuration(summary.durationSeconds)}
+                </td>
+                <td className="p-2 text-right tabular-nums">
+                  {formatDistanceMeters(summary.distanceMeters)}
+                </td>
+                <td className="p-2 text-right tabular-nums">
+                  {formatPercent(summary.pavedPercent)}
+                </td>
+                <td className="p-2 text-right tabular-nums">
+                  {formatPercent(summary.unpavedPercent)}
+                </td>
+                <td className="p-2 text-right tabular-nums">
+                  {formatSpeedMps(summary.avgSpeedMps)}
+                </td>
+                <td className="p-2 text-right tabular-nums">
+                  {formatHeartRate(summary.avgHeartRate)}
+                </td>
+                <td className="p-2 text-right tabular-nums">
+                  {formatHeartRate(summary.maxHeartRate)}
+                </td>
+                <td className="p-2 text-right tabular-nums">
+                  {formatAscent(summary.totalAscentMeters)}
+                </td>
+              </tr>
+            </tfoot>
+          </Table>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}

--- a/src/graphql/garmin.ts
+++ b/src/graphql/garmin.ts
@@ -249,6 +249,32 @@ export const GARMIN_ACTIVITY_CLIMBS_QUERY = gql`
   }
 `
 
+export const GARMIN_ACTIVITY_LAPS_QUERY = gql`
+  query GarminActivityLaps($activity_id: String!) {
+    garminActivityLaps(activity_id: $activity_id) {
+      id
+      activity_id
+      lap_index
+      start_time
+      end_time
+      duration_seconds
+      elapsed_duration_seconds
+      moving_duration_seconds
+      distance_meters
+      paved_distance_meters
+      unpaved_distance_meters
+      avg_speed_mps
+      avg_heart_rate
+      max_heart_rate
+      total_ascent_meters
+      total_descent_meters
+      calories
+      created_at
+      updated_at
+    }
+  }
+`
+
 export const TRIGGER_GARMIN_SYNC_MUTATION = gql`
   mutation TriggerGarminSync($window_hours: Int, $lookback: Int) {
     triggerGarminSync(window_hours: $window_hours, lookback: $lookback) {

--- a/src/pages/GarminDetailPage.test.tsx
+++ b/src/pages/GarminDetailPage.test.tsx
@@ -9,6 +9,7 @@ const garminDetailHooks = vi.hoisted(() => ({
   useGarminTrackPointsQuery: vi.fn(),
   useGarminChartDataQuery: vi.fn(),
   useGarminActivityClimbsQuery: vi.fn(),
+  useGarminActivityLapsQuery: vi.fn(),
   useGarminExportPointsLazyQuery: vi.fn(),
 }))
 const toastMocks = vi.hoisted(() => ({
@@ -155,6 +156,12 @@ vi.mock('@/components/garmin/ActivityStatsPanel', () => ({
   ),
 }))
 
+vi.mock('@/components/garmin/ActivityLapsTable', () => ({
+  ActivityLapsTable: ({ laps }: { laps: unknown[] }) => (
+    <div data-testid="activity-laps-table">laps:{laps.length}</div>
+  ),
+}))
+
 import { GarminDetailPage } from './GarminDetailPage'
 
 describe('GarminDetailPage', () => {
@@ -163,6 +170,7 @@ describe('GarminDetailPage', () => {
     garminDetailHooks.useGarminTrackPointsQuery.mockReset()
     garminDetailHooks.useGarminChartDataQuery.mockReset()
     garminDetailHooks.useGarminActivityClimbsQuery.mockReset()
+    garminDetailHooks.useGarminActivityLapsQuery.mockReset()
     garminDetailHooks.useGarminExportPointsLazyQuery.mockReset()
     toastMocks.error.mockReset()
     toastMocks.warning.mockReset()
@@ -175,6 +183,11 @@ describe('GarminDetailPage', () => {
     garminDetailHooks.useGarminActivityClimbsQuery.mockReturnValue({
       loading: false,
       data: { garminActivityClimbs: [] },
+      error: undefined,
+    })
+    garminDetailHooks.useGarminActivityLapsQuery.mockReturnValue({
+      loading: false,
+      data: { garminActivityLaps: [] },
       error: undefined,
     })
   })
@@ -334,6 +347,41 @@ describe('GarminDetailPage', () => {
     expect(
       screen.getByText('No Garmin ClimbPro climbs found for this activity.'),
     ).toBeInTheDocument()
+  })
+
+  it('renders the Laps tab with activity laps', async () => {
+    const user = userEvent.setup()
+    mockLoadedActivity()
+    garminDetailHooks.useGarminChartDataQuery.mockReturnValue({
+      loading: false,
+      error: undefined,
+      data: { garminChartData: [] },
+    })
+    garminDetailHooks.useGarminActivityLapsQuery.mockReturnValue({
+      loading: false,
+      error: undefined,
+      data: {
+        garminActivityLaps: [
+          {
+            id: 1,
+            lap_index: 1,
+            duration_seconds: 60,
+            distance_meters: 1609.344,
+          },
+        ],
+      },
+    })
+
+    renderPage()
+    await user.click(screen.getByTestId('garmin-tab-laps'))
+
+    expect(garminDetailHooks.useGarminActivityLapsQuery).toHaveBeenCalledWith({
+      variables: { activity_id: '42' },
+      skip: false,
+    })
+    expect(screen.getByTestId('activity-laps-table')).toHaveTextContent(
+      'laps:1',
+    )
   })
 
   it('renders ClimbPro rows and auto-selects the first climb', async () => {

--- a/src/pages/GarminDetailPage.tsx
+++ b/src/pages/GarminDetailPage.tsx
@@ -7,6 +7,7 @@ import {
   useGarminTrackPointsQuery,
   useGarminChartDataQuery,
   useGarminActivityClimbsQuery,
+  useGarminActivityLapsQuery,
   useGarminExportPointsLazyQuery,
   type GarminActivityClimbsQuery,
 } from '@/__generated__/graphql'
@@ -29,6 +30,7 @@ import { ClimbDetailsPanel } from '@/components/garmin/ClimbDetailsPanel'
 import { SavedPointsList } from '@/components/garmin/SavedPointsList'
 import { SegmentAnalysis } from '@/components/garmin/SegmentAnalysis'
 import { ActivityStatsPanel } from '@/components/garmin/ActivityStatsPanel'
+import { ActivityLapsTable } from '@/components/garmin/ActivityLapsTable'
 import { Button } from '@/components/ui/button'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import {
@@ -542,6 +544,14 @@ export function GarminDetailPage() {
     variables: { activity_id: activityId ?? '' },
     skip: !activityId,
   })
+  const {
+    data: lapsData,
+    loading: lapsLoading,
+    error: lapsError,
+  } = useGarminActivityLapsQuery({
+    variables: { activity_id: activityId ?? '' },
+    skip: !activityId,
+  })
   // Resolve map clicks against the *full-resolution* track series (not the
   // downsampled chart series) so the selected point is the true nearest
   // location, then convert it into the chart/display shape using the same
@@ -671,6 +681,9 @@ export function GarminDetailPage() {
           <TabsTrigger value="stats" data-testid="garmin-tab-stats">
             Stats
           </TabsTrigger>
+          <TabsTrigger value="laps" data-testid="garmin-tab-laps">
+            Laps
+          </TabsTrigger>
           <TabsTrigger value="charts" data-testid="garmin-tab-charts">
             Charts
           </TabsTrigger>
@@ -684,6 +697,16 @@ export function GarminDetailPage() {
             activity={{ ...a, hr_available: hasHrData }}
             heartRateZonePoints={chartPoints}
           />
+        </TabsContent>
+
+        <TabsContent value="laps" className="space-y-4">
+          {lapsLoading && <LoadingState message="Loading laps..." />}
+          {lapsError && (
+            <ErrorState message={`Laps failed: ${lapsError.message}`} />
+          )}
+          {!lapsLoading && !lapsError && (
+            <ActivityLapsTable laps={lapsData?.garminActivityLaps ?? []} />
+          )}
         </TabsContent>
 
         <TabsContent value="charts" className="space-y-4">


### PR DESCRIPTION
## Summary
- add `GARMIN_ACTIVITY_LAPS_QUERY` and generated Apollo hooks for `garminActivityLaps`
- add a Garmin-style `ActivityLapsTable` with lap ordering, horizontal overflow, row selection, and summary calculations
- insert the `Laps` tab after `Stats` and before `Charts` on Garmin activity detail pages
- bump `@stuartshay/otel-graphql-types` to `1.0.445` so the UI has the deployed laps schema
- add component/page tests and a targeted Playwright spec for the Laps tab

Refs #263.

## Validation
- `npm run lint:all`
- `npm run type-check`
- `npm run test:run`
- `npm run build`
- `BASE_URL=http://127.0.0.1:5174 PLAYWRIGHT_GARMIN_LAPS_ACTIVITY_ID=23459431656 npx playwright test e2e/garmin-laps.spec.ts`

## Notes
- Playwright generated local screenshots under `e2e/screenshots/garmin-laps/`; that directory is gitignored by the repo.
- This PR intentionally does not close the issue. The issue should remain open until the UI is deployed and validated live.
