### PR TITLE
[codex] Fix dashboard activity tooltip rows

### DIFF
--- a/src/components/dashboard/CyclingInFocus.test.tsx
+++ b/src/components/dashboard/CyclingInFocus.test.tsx
@@ -135,6 +135,43 @@ describe('CyclingInFocus', () => {
     expect(jun18?.distance_mi).toBeCloseTo(31.07, 1)
   })
 
+  it('keeps same-day rides as separate tooltip activities while aggregating the bar', () => {
+    mockActivities([
+      {
+        activity_id: 'a1',
+        sport: 'cycling',
+        start_time: '2026-06-20T08:00:00',
+        distance_km: 25.77,
+        duration_seconds: 6480,
+      },
+      {
+        activity_id: 'a2',
+        sport: 'cycling',
+        start_time: '2026-06-20T14:00:00',
+        distance_km: 18.56,
+        duration_seconds: 5040,
+      },
+    ])
+
+    render(<CyclingInFocus />)
+
+    const jun20 = latestBarChartData.find((d) => d.date === '2026-06-20')
+    expect(jun20?.count).toBe(2)
+    expect(jun20?.distance_mi).toBeCloseTo(27.55, 1)
+    expect(jun20?.activities).toEqual([
+      expect.objectContaining({
+        activity_id: 'a1',
+        distance_km: 25.77,
+        duration_seconds: 6480,
+      }),
+      expect.objectContaining({
+        activity_id: 'a2',
+        distance_km: 18.56,
+        duration_seconds: 5040,
+      }),
+    ])
+  })
+
   it('uses unique date keys for the chart axis while rendering one-letter ticks', () => {
     mockActivities(SAMPLE_ITEMS)
 

--- a/src/components/dashboard/CyclingInFocus.tsx
+++ b/src/components/dashboard/CyclingInFocus.tsx
@@ -13,7 +13,11 @@ import { useGarminActivitiesQuery } from '@/__generated__/graphql'
 import { Card, CardContent } from '@/components/ui/card'
 import { ErrorState } from '@/components/shared/ErrorState'
 import { cn } from '@/lib/utils'
-import { formatDuration, formatDurationShort, kmToMi } from '@/lib/units'
+import { formatDuration, kmToMi } from '@/lib/units'
+import {
+  GarminActivitiesTable,
+  type GarminActivityTableRow,
+} from './GarminActivitiesTable'
 
 const SPORT = 'cycling'
 const BAR_COLOR = '#2563eb'
@@ -35,6 +39,8 @@ interface DayBucket {
   duration_seconds: number
   /** Number of rides completed that day. */
   count: number
+  /** Individual rides for the day, used by the tooltip detail table. */
+  activities: GarminActivityTableRow[]
 }
 
 // Recharts tooltip styled to match the Garmin Activity heatmap day popover.
@@ -62,32 +68,7 @@ function ActivityTooltip({
         </p>
       </div>
       {day.count > 0 ? (
-        <table className="w-full text-xs">
-          <thead>
-            <tr className="border-b">
-              <th className="px-3 py-1 text-left font-medium text-muted-foreground">
-                Sport
-              </th>
-              <th className="px-2 py-1 text-right font-medium text-muted-foreground">
-                Distance
-              </th>
-              <th className="px-3 py-1 text-right font-medium text-muted-foreground">
-                Duration
-              </th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <td className="px-3 py-1">Cycling</td>
-              <td className="px-2 py-1 text-right tabular-nums">
-                {day.distance_mi.toFixed(2)} mi
-              </td>
-              <td className="px-3 py-1 text-right tabular-nums">
-                {formatDurationShort(day.duration_seconds)}
-              </td>
-            </tr>
-          </tbody>
-        </table>
+        <GarminActivitiesTable activities={day.activities} distanceUnit="mi" />
       ) : (
         <p className="px-3 py-2 text-[11px] text-muted-foreground">
           No activities.
@@ -141,6 +122,7 @@ export function CyclingInFocus() {
         distance_mi: 0,
         duration_seconds: 0,
         count: 0,
+        activities: [],
       })
     }
     const byDate = new Map(buckets.map((bucket) => [bucket.date, bucket]))
@@ -156,6 +138,12 @@ export function CyclingInFocus() {
       bucket.distance_mi += kmToMi(km)
       bucket.duration_seconds += dur
       bucket.count += 1
+      bucket.activities.push({
+        activity_id: activity.activity_id,
+        sport: activity.sport,
+        distance_km: activity.distance_km,
+        duration_seconds: activity.duration_seconds,
+      })
       totalKm += km
       seconds += dur
     }

--- a/src/components/dashboard/GarminActivitiesTable.tsx
+++ b/src/components/dashboard/GarminActivitiesTable.tsx
@@ -1,0 +1,85 @@
+import { Link } from 'react-router-dom'
+
+import { formatDurationShort, kmToMi } from '@/lib/units'
+
+export interface GarminActivityTableRow {
+  activity_id: string
+  sport: string
+  distance_km?: number | null
+  duration_seconds?: number | null
+}
+
+interface GarminActivitiesTableProps {
+  activities: GarminActivityTableRow[]
+  distanceUnit?: 'km' | 'mi'
+  linkSport?: boolean
+  onSportClick?: () => void
+  rowTestId?: string
+  sportLinkTestId?: string
+}
+
+function formatDistance(
+  distanceKm: number | null | undefined,
+  unit: 'km' | 'mi',
+) {
+  if (distanceKm == null) return '—'
+  const value = unit === 'mi' ? kmToMi(distanceKm) : distanceKm
+  return `${value.toFixed(2)} ${unit}`
+}
+
+export function GarminActivitiesTable({
+  activities,
+  distanceUnit = 'km',
+  linkSport = false,
+  onSportClick,
+  rowTestId = 'garmin-activity-table-row',
+  sportLinkTestId = 'garmin-activity-table-sport-link',
+}: GarminActivitiesTableProps) {
+  return (
+    <table className="w-full text-xs">
+      <thead className="sticky top-0 bg-popover">
+        <tr className="border-b">
+          <th className="px-3 py-1 text-left font-medium text-muted-foreground">
+            Sport
+          </th>
+          <th className="px-2 py-1 text-right font-medium text-muted-foreground">
+            Distance
+          </th>
+          <th className="px-3 py-1 text-right font-medium text-muted-foreground">
+            Duration
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        {activities.map((activity) => (
+          <tr
+            key={activity.activity_id}
+            className="border-b last:border-b-0 hover:bg-muted/50"
+            data-testid={rowTestId}
+          >
+            <td className="px-3 py-1">
+              {linkSport ? (
+                <Link
+                  to={`/garmin/${activity.activity_id}`}
+                  onClick={onSportClick}
+                  className="font-medium capitalize text-primary hover:underline"
+                  data-testid={sportLinkTestId}
+                >
+                  {activity.sport}
+                </Link>
+              ) : (
+                <span className="font-medium capitalize">{activity.sport}</span>
+              )}
+            </td>
+            <td className="px-2 py-1 text-right tabular-nums">
+              {formatDistance(activity.distance_km, distanceUnit)}
+            </td>
+            <td className="px-3 py-1 text-right tabular-nums">
+              {formatDurationShort(activity.duration_seconds)}
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  )
+}

--- a/src/components/dashboard/GarminDayActivitiesPopover.test.tsx
+++ b/src/components/dashboard/GarminDayActivitiesPopover.test.tsx
@@ -84,7 +84,7 @@ describe('GarminDayActivitiesPopover', () => {
 
     const { onOpenChange } = renderPopover()
 
-    expect(screen.getByText('42.20 km')).toBeInTheDocument()
+    expect(screen.getByText('26.22 mi')).toBeInTheDocument()
     expect(screen.getByText('1h 2m')).toBeInTheDocument()
 
     const link = screen.getByTestId('garmin-day-popover-sport-link')

--- a/src/components/dashboard/GarminDayActivitiesPopover.tsx
+++ b/src/components/dashboard/GarminDayActivitiesPopover.tsx
@@ -1,10 +1,9 @@
-import { Link } from 'react-router-dom'
 import { Loader2 } from 'lucide-react'
 import { format } from 'date-fns'
 
 import { useGarminActivitiesQuery } from '@/__generated__/graphql'
 import { Popover, PopoverAnchor, PopoverContent } from '@/components/ui/popover'
-import { formatDurationShort } from '@/lib/units'
+import { GarminActivitiesTable } from './GarminActivitiesTable'
 
 interface GarminDayActivitiesPopoverProps {
   date: string | null
@@ -95,49 +94,14 @@ export function GarminDayActivitiesPopover({
             className="max-h-72 overflow-y-auto"
             data-testid="garmin-day-popover-list"
           >
-            <table className="w-full text-xs">
-              <thead className="sticky top-0 bg-popover">
-                <tr className="border-b">
-                  <th className="px-3 py-1 text-left font-medium text-muted-foreground">
-                    Sport
-                  </th>
-                  <th className="px-2 py-1 text-right font-medium text-muted-foreground">
-                    Distance
-                  </th>
-                  <th className="px-3 py-1 text-right font-medium text-muted-foreground">
-                    Duration
-                  </th>
-                </tr>
-              </thead>
-              <tbody>
-                {activities.map((a) => (
-                  <tr
-                    key={a.activity_id}
-                    className="border-b last:border-b-0 hover:bg-muted/50"
-                    data-testid="garmin-day-popover-row"
-                  >
-                    <td className="px-3 py-1">
-                      <Link
-                        to={`/garmin/${a.activity_id}`}
-                        onClick={() => onOpenChange(false)}
-                        className="font-medium capitalize text-primary hover:underline"
-                        data-testid="garmin-day-popover-sport-link"
-                      >
-                        {a.sport}
-                      </Link>
-                    </td>
-                    <td className="px-2 py-1 text-right tabular-nums">
-                      {a.distance_km != null
-                        ? `${a.distance_km.toFixed(2)} km`
-                        : '—'}
-                    </td>
-                    <td className="px-3 py-1 text-right tabular-nums">
-                      {formatDurationShort(a.duration_seconds)}
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
+            <GarminActivitiesTable
+              activities={activities}
+              distanceUnit="mi"
+              linkSport
+              onSportClick={() => onOpenChange(false)}
+              rowTestId="garmin-day-popover-row"
+              sportLinkTestId="garmin-day-popover-sport-link"
+            />
           </div>
         )}
       </PopoverContent>


### PR DESCRIPTION
## Summary

Refs #268

This fixes the dashboard activity detail behavior for Garmin activity days:

- Cycling in Focus now keeps same-day rides as separate tooltip rows while preserving aggregated daily bars and weekly totals.
- Heatmap day activity popover now displays distance in miles to match the cycling widget.
- Shared the repeated dashboard activity table rendering through `GarminActivitiesTable`.

## Root Cause

The cycling widget bucketed activities by day and only kept aggregate distance/duration/count values, so the tooltip could only render one combined row for days with multiple rides. The heatmap popover had its own duplicate table rendering and formatted raw API distance in kilometers.

## Validation

- `npm run test:run -- src/components/dashboard/CyclingInFocus.test.tsx src/components/dashboard/GarminDayActivitiesPopover.test.tsx`
- `npm run type-check`
- `npm run lint:all`
- `npm run build`

Build completed with existing Vite chunk-size/deprecation warnings only.