### PR TITLE
[codex] Add Garmin lap details route map

### DIFF
--- a/e2e/garmin-laps.spec.ts
+++ b/e2e/garmin-laps.spec.ts
@@ -31,6 +31,14 @@ test.describe('Garmin Activity Laps', () => {
       'aria-pressed',
       'true',
     )
+    await expect(page.getByTestId('activity-lap-details-panel')).toBeVisible()
+    await expect(page.getByText('Timer Time')).toBeVisible()
+    await expect(page.getByText('Distance')).toBeVisible()
+    await expect(
+      page
+        .getByTestId('activity-route-map')
+        .or(page.getByTestId('activity-lap-route-empty')),
+    ).toBeVisible()
 
     const secondLapButton = page
       .getByTestId('lap-row-2')

--- a/src/components/garmin/ActivityLapRoutePoints.ts
+++ b/src/components/garmin/ActivityLapRoutePoints.ts
@@ -1,0 +1,33 @@
+import type { ActivityChartTrackPoint } from './ActivityChartData'
+
+export interface LapRoutePoint {
+  latitude: number
+  longitude: number
+  speed_kmh?: number | null
+}
+
+type TrackPointWithCoordinates = ActivityChartTrackPoint & {
+  latitude: number
+  longitude: number
+}
+
+function hasFiniteCoordinates(
+  point: ActivityChartTrackPoint,
+): point is TrackPointWithCoordinates {
+  return (
+    point.latitude != null &&
+    point.longitude != null &&
+    Number.isFinite(point.latitude) &&
+    Number.isFinite(point.longitude)
+  )
+}
+
+export function toRoutePoints(
+  points: ActivityChartTrackPoint[],
+): LapRoutePoint[] {
+  return points.filter(hasFiniteCoordinates).map((point) => ({
+    latitude: point.latitude,
+    longitude: point.longitude,
+    speed_kmh: point.speed_kmh,
+  }))
+}

--- a/src/components/garmin/ActivityLapsTable.helpers.ts
+++ b/src/components/garmin/ActivityLapsTable.helpers.ts
@@ -1,7 +1,14 @@
+import type { ActivityChartTrackPoint } from './ActivityChartData'
+
 export interface ActivityLap {
   id: number
+  activity_id?: string
   lap_index: number
+  start_time?: string | null
+  end_time?: string | null
   duration_seconds?: number | null
+  elapsed_duration_seconds?: number | null
+  moving_duration_seconds?: number | null
   distance_meters?: number | null
   paved_distance_meters?: number | null
   unpaved_distance_meters?: number | null
@@ -9,6 +16,8 @@ export interface ActivityLap {
   avg_heart_rate?: number | null
   max_heart_rate?: number | null
   total_ascent_meters?: number | null
+  total_descent_meters?: number | null
+  calories?: number | null
 }
 
 export interface LapSummary {
@@ -86,4 +95,113 @@ export function buildLapSummary(laps: ActivityLap[]): LapSummary {
     maxHeartRate: maxHeartRates.length > 0 ? Math.max(...maxHeartRates) : null,
     totalAscentMeters: ascentMeters > 0 ? ascentMeters : null,
   }
+}
+
+function parseTimestamp(value: string | null | undefined): number | null {
+  if (!value) return null
+  const parsed = new Date(value).getTime()
+  return Number.isFinite(parsed) ? parsed : null
+}
+
+function hasValidLatLng(point: ActivityChartTrackPoint): boolean {
+  return (
+    point.latitude != null &&
+    point.longitude != null &&
+    Number.isFinite(point.latitude) &&
+    Number.isFinite(point.longitude)
+  )
+}
+
+function getPointTime(point: ActivityChartTrackPoint): number | null {
+  return parseTimestamp(point.timestamp)
+}
+
+function getPointDistanceMeters(point: ActivityChartTrackPoint): number | null {
+  if (
+    point.distance_from_start_km == null ||
+    !Number.isFinite(point.distance_from_start_km)
+  ) {
+    return null
+  }
+  return point.distance_from_start_km * 1000
+}
+
+function getEffectiveEndTime(
+  lap: ActivityLap,
+  startTime: number,
+): number | null {
+  const endTime = parseTimestamp(lap.end_time)
+  if (endTime != null && endTime > startTime) return endTime
+  if (lap.duration_seconds != null && lap.duration_seconds > 0) {
+    return startTime + lap.duration_seconds * 1000
+  }
+  return null
+}
+
+export function getLapTimeWindow(
+  lap: ActivityLap,
+): { startTime: number; endTime: number } | null {
+  const startTime = parseTimestamp(lap.start_time)
+  if (startTime == null) return null
+  const endTime = getEffectiveEndTime(lap, startTime)
+  if (endTime == null) return null
+  return { startTime, endTime }
+}
+
+function getDistanceWindow(
+  lap: ActivityLap,
+  allLaps: ActivityLap[],
+): { startMeters: number; endMeters: number } | null {
+  if (lap.distance_meters == null || lap.distance_meters <= 0) return null
+
+  const orderedLaps = [...allLaps].sort((a, b) => a.lap_index - b.lap_index)
+  let startMeters = 0
+  for (const current of orderedLaps) {
+    if (current.lap_index === lap.lap_index) {
+      return {
+        startMeters,
+        endMeters: startMeters + lap.distance_meters,
+      }
+    }
+    if (current.distance_meters == null || current.distance_meters <= 0) {
+      return null
+    }
+    startMeters += current.distance_meters
+  }
+
+  return null
+}
+
+export function getLapSegmentPoints(
+  lap: ActivityLap,
+  chartPoints: ActivityChartTrackPoint[],
+  allLaps: ActivityLap[] = [lap],
+): ActivityChartTrackPoint[] {
+  const timeWindow = getLapTimeWindow(lap)
+
+  if (timeWindow) {
+    const timeMatches = chartPoints.filter((point) => {
+      const pointTime = getPointTime(point)
+      return (
+        pointTime != null &&
+        pointTime >= timeWindow.startTime &&
+        pointTime <= timeWindow.endTime &&
+        hasValidLatLng(point)
+      )
+    })
+    if (timeMatches.length > 0) return timeMatches
+  }
+
+  const distanceWindow = getDistanceWindow(lap, allLaps)
+  if (!distanceWindow) return []
+
+  return chartPoints.filter((point) => {
+    const distanceMeters = getPointDistanceMeters(point)
+    return (
+      distanceMeters != null &&
+      distanceMeters >= distanceWindow.startMeters &&
+      distanceMeters <= distanceWindow.endMeters &&
+      hasValidLatLng(point)
+    )
+  })
 }

--- a/src/components/garmin/ActivityLapsTable.test.tsx
+++ b/src/components/garmin/ActivityLapsTable.test.tsx
@@ -1,7 +1,34 @@
 import { fireEvent, render, screen, within } from '@testing-library/react'
-import { describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { ActivityLapsTable } from './ActivityLapsTable'
-import { buildLapSummary, type ActivityLap } from './ActivityLapsTable.helpers'
+import {
+  buildLapSummary,
+  getLapSegmentPoints,
+  type ActivityLap,
+} from './ActivityLapsTable.helpers'
+
+let latestRouteMapPoints: Array<{
+  latitude: number
+  longitude: number
+  speed_kmh?: number | null
+}> = []
+
+vi.mock('./ActivityRouteMap', () => ({
+  ActivityRouteMap: ({
+    trackPoints,
+  }: {
+    trackPoints: Array<{
+      latitude: number
+      longitude: number
+      speed_kmh?: number | null
+    }>
+  }) => {
+    latestRouteMapPoints = trackPoints
+    return (
+      <div data-testid="activity-route-map">route:{trackPoints.length}</div>
+    )
+  },
+}))
 
 function lap(overrides: Partial<ActivityLap> = {}): ActivityLap {
   return {
@@ -15,11 +42,194 @@ function lap(overrides: Partial<ActivityLap> = {}): ActivityLap {
     avg_heart_rate: 120,
     max_heart_rate: 140,
     total_ascent_meters: 10,
+    total_descent_meters: 8,
+    calories: 50,
     ...overrides,
   }
 }
 
 describe('ActivityLapsTable', () => {
+  beforeEach(() => {
+    latestRouteMapPoints = []
+  })
+
+  it('filters lap segment points inclusively by lap timestamps and valid coordinates', () => {
+    const selectedLap = lap({
+      start_time: '2026-03-14T09:05:00Z',
+      end_time: '2026-03-14T09:10:00Z',
+    })
+
+    const points = getLapSegmentPoints(selectedLap, [
+      {
+        timestamp: '2026-03-14T09:04:59Z',
+        latitude: 40.69,
+        longitude: -74,
+      },
+      {
+        timestamp: '2026-03-14T09:05:00Z',
+        latitude: 40.7,
+        longitude: -74.01,
+      },
+      {
+        timestamp: '2026-03-14T09:07:30Z',
+        latitude: null,
+        longitude: -74.02,
+      },
+      {
+        timestamp: '2026-03-14T09:10:00Z',
+        latitude: 40.71,
+        longitude: -74.03,
+      },
+      {
+        timestamp: '2026-03-14T09:10:01Z',
+        latitude: 40.72,
+        longitude: -74.04,
+      },
+    ])
+
+    expect(points.map((point) => point.timestamp)).toEqual([
+      '2026-03-14T09:05:00Z',
+      '2026-03-14T09:10:00Z',
+    ])
+  })
+
+  it('returns no lap segment points when timestamps and distance fallback data are unavailable', () => {
+    expect(getLapSegmentPoints(lap(), [])).toEqual([])
+    expect(
+      getLapSegmentPoints(
+        lap({
+          start_time: 'bad',
+          end_time: '2026-03-14T09:10:00Z',
+        }),
+        [
+          {
+            timestamp: '2026-03-14T09:05:00Z',
+            latitude: 40.7,
+            longitude: -74,
+          },
+        ],
+      ),
+    ).toEqual([])
+  })
+
+  it('falls back to lap duration when the lap end timestamp is not after the start', () => {
+    const points = getLapSegmentPoints(
+      lap({
+        start_time: '2026-07-04T19:50:33Z',
+        end_time: '2026-07-04T19:50:33Z',
+        duration_seconds: 120,
+      }),
+      [
+        {
+          timestamp: '2026-07-04T19:50:33Z',
+          latitude: 40.7,
+          longitude: -74,
+        },
+        {
+          timestamp: '2026-07-04T19:51:30Z',
+          latitude: 40.71,
+          longitude: -74.01,
+        },
+        {
+          timestamp: '2026-07-04T19:53:00Z',
+          latitude: 40.72,
+          longitude: -74.02,
+        },
+      ],
+    )
+
+    expect(points.map((point) => point.timestamp)).toEqual([
+      '2026-07-04T19:50:33Z',
+      '2026-07-04T19:51:30Z',
+    ])
+  })
+
+  it('falls back to cumulative lap distance when timestamps do not produce a route segment', () => {
+    const firstLap = lap({
+      lap_index: 1,
+      distance_meters: 1000,
+      start_time: null,
+      end_time: null,
+    })
+    const secondLap = lap({
+      lap_index: 2,
+      distance_meters: 2000,
+      start_time: null,
+      end_time: null,
+    })
+
+    const points = getLapSegmentPoints(
+      secondLap,
+      [
+        {
+          timestamp: '2026-07-04T19:50:00Z',
+          latitude: 40.7,
+          longitude: -74,
+          distance_from_start_km: 0.9,
+        },
+        {
+          timestamp: '2026-07-04T19:51:00Z',
+          latitude: 40.71,
+          longitude: -74.01,
+          distance_from_start_km: 1,
+        },
+        {
+          timestamp: '2026-07-04T19:52:00Z',
+          latitude: 40.72,
+          longitude: -74.02,
+          distance_from_start_km: 2,
+        },
+        {
+          timestamp: '2026-07-04T19:53:00Z',
+          latitude: 40.73,
+          longitude: -74.03,
+          distance_from_start_km: 3,
+        },
+        {
+          timestamp: '2026-07-04T19:54:00Z',
+          latitude: 40.74,
+          longitude: -74.04,
+          distance_from_start_km: 3.1,
+        },
+      ],
+      [firstLap, secondLap],
+    )
+
+    expect(points.map((point) => point.distance_from_start_km)).toEqual([
+      1, 2, 3,
+    ])
+  })
+
+  it('does not use distance fallback when a prior lap distance is invalid', () => {
+    const firstLap = lap({
+      lap_index: 1,
+      distance_meters: null,
+      start_time: null,
+      end_time: null,
+    })
+    const secondLap = lap({
+      lap_index: 2,
+      distance_meters: 2000,
+      start_time: null,
+      end_time: null,
+    })
+
+    expect(
+      getLapSegmentPoints(
+        secondLap,
+        [
+          {
+            timestamp: '2026-07-04T19:51:00Z',
+            latitude: 40.71,
+            longitude: -74.01,
+            distance_from_start_km: 1,
+          },
+        ],
+        [firstLap, secondLap],
+      ),
+    ).toEqual([])
+  })
+
   it('builds weighted summary values', () => {
     const summary = buildLapSummary([
       lap({ lap_index: 1, duration_seconds: 100, avg_heart_rate: 120 }),
@@ -116,6 +326,168 @@ describe('ActivityLapsTable', () => {
     expect(within(second).getByRole('button', { name: '2' })).toHaveAttribute(
       'aria-pressed',
       'true',
+    )
+  })
+
+  it('renders selected lap details with recorded stats and a route map', () => {
+    render(
+      <ActivityLapsTable
+        laps={[
+          lap({
+            lap_index: 1,
+            start_time: '2026-03-14T09:05:00Z',
+            end_time: '2026-03-14T09:10:00Z',
+            duration_seconds: 300,
+            elapsed_duration_seconds: 330,
+            moving_duration_seconds: 290,
+            distance_meters: 3218.688,
+            paved_distance_meters: 1609.344,
+            unpaved_distance_meters: 1609.344,
+            avg_speed_mps: 5,
+            avg_heart_rate: 145,
+            max_heart_rate: 172,
+            total_ascent_meters: 30.48,
+            total_descent_meters: 15.24,
+            calories: 123,
+          }),
+        ]}
+        chartPoints={[
+          {
+            timestamp: '2026-03-14T09:05:00Z',
+            latitude: 40.7,
+            longitude: -74.01,
+            speed_kmh: 18,
+          },
+          {
+            timestamp: '2026-03-14T09:10:00Z',
+            latitude: 40.71,
+            longitude: -74.02,
+            speed_kmh: 20,
+          },
+        ]}
+      />,
+    )
+
+    fireEvent.click(screen.getByTestId('lap-row-1'))
+
+    const panel = screen.getByTestId('activity-lap-details-panel')
+    expect(panel).toHaveTextContent('Lap 1')
+    expect(panel).toHaveTextContent('Timer Time')
+    expect(panel).toHaveTextContent('5:00')
+    expect(panel).toHaveTextContent('Elapsed Time')
+    expect(panel).toHaveTextContent('5:30')
+    expect(panel).toHaveTextContent('Moving Time')
+    expect(panel).toHaveTextContent('4:50')
+    expect(panel).toHaveTextContent('2.00 mi')
+    expect(panel).toHaveTextContent('50%')
+    expect(panel).toHaveTextContent('11.2 mph')
+    expect(panel).toHaveTextContent('145')
+    expect(panel).toHaveTextContent('172')
+    expect(panel).toHaveTextContent('100 ft')
+    expect(panel).toHaveTextContent('50 ft')
+    expect(panel).toHaveTextContent('123 kcal')
+    expect(screen.getByTestId('activity-route-map')).toHaveTextContent(
+      'route:2',
+    )
+    expect(latestRouteMapPoints).toEqual([
+      { latitude: 40.7, longitude: -74.01, speed_kmh: 18 },
+      { latitude: 40.71, longitude: -74.02, speed_kmh: 20 },
+    ])
+  })
+
+  it('uses the effective fallback end time in the selected lap details', () => {
+    const timeFormatOptions: Intl.DateTimeFormatOptions = {
+      hour: 'numeric',
+      minute: '2-digit',
+      second: '2-digit',
+    }
+    const expectedStart = new Date('2026-07-04T19:50:33Z').toLocaleTimeString(
+      [],
+      timeFormatOptions,
+    )
+    const expectedEnd = new Date('2026-07-04T19:52:33Z').toLocaleTimeString(
+      [],
+      timeFormatOptions,
+    )
+
+    render(
+      <ActivityLapsTable
+        laps={[
+          lap({
+            lap_index: 1,
+            start_time: '2026-07-04T19:50:33Z',
+            end_time: '2026-07-04T19:50:33Z',
+            duration_seconds: 120,
+          }),
+        ]}
+        chartPoints={[
+          {
+            timestamp: '2026-07-04T19:50:33Z',
+            latitude: 40.7,
+            longitude: -74.01,
+          },
+          {
+            timestamp: '2026-07-04T19:52:00Z',
+            latitude: 40.71,
+            longitude: -74.02,
+          },
+        ]}
+      />,
+    )
+
+    fireEvent.click(screen.getByTestId('lap-row-1'))
+
+    expect(screen.getByTestId('activity-lap-details-panel')).toHaveTextContent(
+      `${expectedStart} – ${expectedEnd}`,
+    )
+  })
+
+  it('renders the route map when one lap route point is resolved', () => {
+    render(
+      <ActivityLapsTable
+        laps={[
+          lap({
+            lap_index: 1,
+            start_time: '2026-03-14T09:05:00Z',
+            end_time: '2026-03-14T09:06:00Z',
+          }),
+        ]}
+        chartPoints={[
+          {
+            timestamp: '2026-03-14T09:05:30Z',
+            latitude: 40.7,
+            longitude: -74.01,
+          },
+        ]}
+      />,
+    )
+
+    fireEvent.click(screen.getByTestId('lap-row-1'))
+
+    expect(screen.getByTestId('activity-route-map')).toHaveTextContent(
+      'route:1',
+    )
+    expect(screen.queryByTestId('activity-lap-route-empty')).toBeNull()
+  })
+
+  it('renders an empty route state when selected lap has no matching points', () => {
+    render(
+      <ActivityLapsTable
+        laps={[
+          lap({
+            lap_index: 1,
+            start_time: '2026-03-14T09:05:00Z',
+            end_time: '2026-03-14T09:10:00Z',
+          }),
+        ]}
+        chartPoints={[]}
+      />,
+    )
+
+    fireEvent.click(screen.getByTestId('lap-row-1'))
+
+    expect(screen.getByTestId('activity-lap-route-empty')).toHaveTextContent(
+      'No route points available for this lap.',
     )
   })
 

--- a/src/components/garmin/ActivityLapsTable.test.tsx
+++ b/src/components/garmin/ActivityLapsTable.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, render, screen, within } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { ActivityLapsTable } from './ActivityLapsTable'
+import { toRoutePoints } from './ActivityLapRoutePoints'
 import {
   buildLapSummary,
   getLapSegmentPoints,
@@ -393,6 +394,31 @@ describe('ActivityLapsTable', () => {
       { latitude: 40.7, longitude: -74.01, speed_kmh: 18 },
       { latitude: 40.71, longitude: -74.02, speed_kmh: 20 },
     ])
+  })
+
+  it('filters invalid coordinates before converting route points', () => {
+    expect(
+      toRoutePoints([
+        {
+          timestamp: '2026-03-14T09:05:00Z',
+          latitude: 40.7,
+          longitude: -74.01,
+          speed_kmh: 18,
+        },
+        {
+          timestamp: '2026-03-14T09:06:00Z',
+          latitude: null,
+          longitude: -74.02,
+          speed_kmh: 19,
+        },
+        {
+          timestamp: '2026-03-14T09:07:00Z',
+          latitude: 40.72,
+          longitude: Number.NaN,
+          speed_kmh: 20,
+        },
+      ]),
+    ).toEqual([{ latitude: 40.7, longitude: -74.01, speed_kmh: 18 }])
   })
 
   it('uses the effective fallback end time in the selected lap details', () => {

--- a/src/components/garmin/ActivityLapsTable.tsx
+++ b/src/components/garmin/ActivityLapsTable.tsx
@@ -11,6 +11,7 @@ import {
 import { formatDuration, metersToFeet } from '@/lib/units'
 import { cn } from '@/lib/utils'
 import type { ActivityChartTrackPoint } from './ActivityChartData'
+import { toRoutePoints } from './ActivityLapRoutePoints'
 import { ActivityRouteMap } from './ActivityRouteMap'
 import {
   buildLapSummary,
@@ -25,12 +26,6 @@ const MPS_TO_MPH = 2.2369362921
 interface ActivityLapsTableProps {
   laps: ActivityLap[]
   chartPoints?: ActivityChartTrackPoint[]
-}
-
-interface LapRoutePoint {
-  latitude: number
-  longitude: number
-  speed_kmh?: number | null
 }
 
 function formatDistanceMeters(value: number | null | undefined): string {
@@ -105,14 +100,6 @@ function LapStat({ label, value }: { label: string; value: string }) {
       <div className="mt-1 text-xs text-muted-foreground">{label}</div>
     </div>
   )
-}
-
-function toRoutePoints(points: ActivityChartTrackPoint[]): LapRoutePoint[] {
-  return points.map((point) => ({
-    latitude: point.latitude as number,
-    longitude: point.longitude as number,
-    speed_kmh: point.speed_kmh,
-  }))
 }
 
 function ActivityLapDetailsPanel({

--- a/src/components/garmin/ActivityLapsTable.tsx
+++ b/src/components/garmin/ActivityLapsTable.tsx
@@ -10,13 +10,27 @@ import {
 } from '@/components/ui/table'
 import { formatDuration, metersToFeet } from '@/lib/units'
 import { cn } from '@/lib/utils'
-import { buildLapSummary, type ActivityLap } from './ActivityLapsTable.helpers'
+import type { ActivityChartTrackPoint } from './ActivityChartData'
+import { ActivityRouteMap } from './ActivityRouteMap'
+import {
+  buildLapSummary,
+  getLapSegmentPoints,
+  getLapTimeWindow,
+  type ActivityLap,
+} from './ActivityLapsTable.helpers'
 
 const METERS_PER_MILE = 1609.344
 const MPS_TO_MPH = 2.2369362921
 
 interface ActivityLapsTableProps {
   laps: ActivityLap[]
+  chartPoints?: ActivityChartTrackPoint[]
+}
+
+interface LapRoutePoint {
+  latitude: number
+  longitude: number
+  speed_kmh?: number | null
 }
 
 function formatDistanceMeters(value: number | null | undefined): string {
@@ -38,6 +52,37 @@ function formatAscent(value: number | null | undefined): string {
   return String(Math.round(metersToFeet(value)))
 }
 
+function formatFeet(value: number | null | undefined): string {
+  if (value == null) return '—'
+  return `${Math.round(metersToFeet(value))} ft`
+}
+
+function formatMiles(value: number | null | undefined): string {
+  if (value == null) return '—'
+  return `${(value / METERS_PER_MILE).toFixed(2)} mi`
+}
+
+function formatMph(value: number | null | undefined): string {
+  if (value == null) return '—'
+  return `${(value * MPS_TO_MPH).toFixed(1)} mph`
+}
+
+function formatCalories(value: number | null | undefined): string {
+  if (value == null) return '—'
+  return `${Math.round(value)} kcal`
+}
+
+function formatTimestamp(value: string | null | undefined): string {
+  if (!value) return '—'
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return '—'
+  return date.toLocaleTimeString([], {
+    hour: 'numeric',
+    minute: '2-digit',
+    second: '2-digit',
+  })
+}
+
 function formatPercent(value: number | null | undefined): string {
   if (value == null) return '—'
   return `${Math.round(value)}%`
@@ -53,7 +98,132 @@ function surfacePercent(
   return (surfaceMeters / distanceMeters) * 100
 }
 
-export function ActivityLapsTable({ laps }: ActivityLapsTableProps) {
+function LapStat({ label, value }: { label: string; value: string }) {
+  return (
+    <div>
+      <div className="text-xl font-semibold leading-none">{value}</div>
+      <div className="mt-1 text-xs text-muted-foreground">{label}</div>
+    </div>
+  )
+}
+
+function toRoutePoints(points: ActivityChartTrackPoint[]): LapRoutePoint[] {
+  return points.map((point) => ({
+    latitude: point.latitude as number,
+    longitude: point.longitude as number,
+    speed_kmh: point.speed_kmh,
+  }))
+}
+
+function ActivityLapDetailsPanel({
+  lap,
+  laps,
+  chartPoints,
+}: {
+  lap: ActivityLap
+  laps: ActivityLap[]
+  chartPoints: ActivityChartTrackPoint[]
+}) {
+  const segmentPoints = useMemo(
+    () => getLapSegmentPoints(lap, chartPoints, laps),
+    [lap, chartPoints, laps],
+  )
+  const routePoints = useMemo(
+    () => toRoutePoints(segmentPoints),
+    [segmentPoints],
+  )
+  const timeWindow = useMemo(() => getLapTimeWindow(lap), [lap])
+
+  return (
+    <div className="space-y-4" data-testid="activity-lap-details-panel">
+      <Card>
+        <CardContent className="space-y-5 p-4">
+          <div className="flex flex-wrap items-start justify-between gap-3">
+            <div>
+              <h3 className="text-lg font-semibold">Lap {lap.lap_index}</h3>
+              <p className="text-sm text-muted-foreground">
+                {formatTimestamp(lap.start_time)} –{' '}
+                {formatTimestamp(
+                  timeWindow
+                    ? new Date(timeWindow.endTime).toISOString()
+                    : null,
+                )}
+              </p>
+            </div>
+          </div>
+
+          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+            <LapStat
+              label="Timer Time"
+              value={formatDuration(lap.duration_seconds ?? null)}
+            />
+            <LapStat
+              label="Elapsed Time"
+              value={formatDuration(lap.elapsed_duration_seconds ?? null)}
+            />
+            <LapStat
+              label="Moving Time"
+              value={formatDuration(lap.moving_duration_seconds ?? null)}
+            />
+            <LapStat
+              label="Distance"
+              value={formatMiles(lap.distance_meters)}
+            />
+            <LapStat
+              label="Paved"
+              value={formatPercent(
+                surfacePercent(lap.paved_distance_meters, lap.distance_meters),
+              )}
+            />
+            <LapStat
+              label="Unpaved"
+              value={formatPercent(
+                surfacePercent(
+                  lap.unpaved_distance_meters,
+                  lap.distance_meters,
+                ),
+              )}
+            />
+            <LapStat label="Avg Speed" value={formatMph(lap.avg_speed_mps)} />
+            <LapStat
+              label="Avg HR"
+              value={formatHeartRate(lap.avg_heart_rate)}
+            />
+            <LapStat
+              label="Max HR"
+              value={formatHeartRate(lap.max_heart_rate)}
+            />
+            <LapStat
+              label="Ascent"
+              value={formatFeet(lap.total_ascent_meters)}
+            />
+            <LapStat
+              label="Descent"
+              value={formatFeet(lap.total_descent_meters)}
+            />
+            <LapStat label="Calories" value={formatCalories(lap.calories)} />
+          </div>
+        </CardContent>
+      </Card>
+
+      {routePoints.length > 0 ? (
+        <ActivityRouteMap trackPoints={routePoints} />
+      ) : (
+        <div
+          className="flex h-[320px] items-center justify-center rounded-md border border-dashed text-sm text-muted-foreground"
+          data-testid="activity-lap-route-empty"
+        >
+          No route points available for this lap.
+        </div>
+      )}
+    </div>
+  )
+}
+
+export function ActivityLapsTable({
+  laps,
+  chartPoints = [],
+}: ActivityLapsTableProps) {
   const [selectedLapIndex, setSelectedLapIndex] = useState<number | null>(null)
   const orderedLaps = useMemo(
     () => [...laps].sort((a, b) => a.lap_index - b.lap_index),
@@ -70,6 +240,10 @@ export function ActivityLapsTable({ laps }: ActivityLapsTableProps) {
     }, [])
   }, [orderedLaps])
   const summary = useMemo(() => buildLapSummary(orderedLaps), [orderedLaps])
+  const selectedLap =
+    selectedLapIndex == null
+      ? null
+      : (orderedLaps.find((lap) => lap.lap_index === selectedLapIndex) ?? null)
 
   if (orderedLaps.length === 0) {
     return (
@@ -80,128 +254,137 @@ export function ActivityLapsTable({ laps }: ActivityLapsTableProps) {
   }
 
   return (
-    <Card data-testid="activity-laps-table">
-      <CardContent className="p-0">
-        <div className="overflow-x-auto">
-          <Table className="min-w-[920px] text-sm">
-            <TableHeader>
-              <TableRow>
-                <TableHead>Laps</TableHead>
-                <TableHead>Time</TableHead>
-                <TableHead>Cumulative Time</TableHead>
-                <TableHead className="text-right">Distance</TableHead>
-                <TableHead className="text-right">Paved</TableHead>
-                <TableHead className="text-right">Unpaved</TableHead>
-                <TableHead className="text-right">Avg Speed</TableHead>
-                <TableHead className="text-right">Avg HR</TableHead>
-                <TableHead className="text-right">Max HR</TableHead>
-                <TableHead className="text-right">Total Ascent</TableHead>
-              </TableRow>
-            </TableHeader>
-            <TableBody>
-              {rows.map(({ lap, cumulativeSeconds }) => {
-                const selected = selectedLapIndex === lap.lap_index
+    <div className="space-y-4">
+      <Card data-testid="activity-laps-table">
+        <CardContent className="p-0">
+          <div className="overflow-x-auto">
+            <Table className="min-w-[920px] text-sm">
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Laps</TableHead>
+                  <TableHead>Time</TableHead>
+                  <TableHead>Cumulative Time</TableHead>
+                  <TableHead className="text-right">Distance</TableHead>
+                  <TableHead className="text-right">Paved</TableHead>
+                  <TableHead className="text-right">Unpaved</TableHead>
+                  <TableHead className="text-right">Avg Speed</TableHead>
+                  <TableHead className="text-right">Avg HR</TableHead>
+                  <TableHead className="text-right">Max HR</TableHead>
+                  <TableHead className="text-right">Total Ascent</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {rows.map(({ lap, cumulativeSeconds }) => {
+                  const selected = selectedLapIndex === lap.lap_index
 
-                return (
-                  <TableRow
-                    key={lap.id}
-                    data-selected={selected}
-                    data-testid={`lap-row-${lap.lap_index}`}
-                    className={cn(
-                      'cursor-pointer',
-                      selected
-                        ? 'bg-blue-100 hover:bg-blue-100 dark:bg-blue-950/40'
-                        : '',
-                    )}
-                    onClick={() => setSelectedLapIndex(lap.lap_index)}
-                  >
-                    <TableCell className="font-medium">
-                      <button
-                        type="button"
-                        aria-pressed={selected}
-                        className="rounded-sm px-1 text-left font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-                        onClick={(event) => {
-                          event.stopPropagation()
-                          setSelectedLapIndex(lap.lap_index)
-                        }}
-                      >
-                        {lap.lap_index}
-                      </button>
-                    </TableCell>
-                    <TableCell>
-                      {formatDuration(lap.duration_seconds ?? null)}
-                    </TableCell>
-                    <TableCell>{formatDuration(cumulativeSeconds)}</TableCell>
-                    <TableCell className="text-right tabular-nums">
-                      {formatDistanceMeters(lap.distance_meters)}
-                    </TableCell>
-                    <TableCell className="text-right tabular-nums">
-                      {formatPercent(
-                        surfacePercent(
-                          lap.paved_distance_meters,
-                          lap.distance_meters,
-                        ),
+                  return (
+                    <TableRow
+                      key={lap.id}
+                      data-selected={selected}
+                      data-testid={`lap-row-${lap.lap_index}`}
+                      className={cn(
+                        'cursor-pointer',
+                        selected
+                          ? 'bg-blue-100 hover:bg-blue-100 dark:bg-blue-950/40'
+                          : '',
                       )}
-                    </TableCell>
-                    <TableCell className="text-right tabular-nums">
-                      {formatPercent(
-                        surfacePercent(
-                          lap.unpaved_distance_meters,
-                          lap.distance_meters,
-                        ),
-                      )}
-                    </TableCell>
-                    <TableCell className="text-right tabular-nums">
-                      {formatSpeedMps(lap.avg_speed_mps)}
-                    </TableCell>
-                    <TableCell className="text-right tabular-nums">
-                      {formatHeartRate(lap.avg_heart_rate)}
-                    </TableCell>
-                    <TableCell className="text-right tabular-nums">
-                      {formatHeartRate(lap.max_heart_rate)}
-                    </TableCell>
-                    <TableCell className="text-right tabular-nums">
-                      {formatAscent(lap.total_ascent_meters)}
-                    </TableCell>
-                  </TableRow>
-                )
-              })}
-            </TableBody>
-            <tfoot>
-              <tr className="border-t font-semibold">
-                <td className="p-2">Summary</td>
-                <td className="p-2">
-                  {formatDuration(summary.durationSeconds)}
-                </td>
-                <td className="p-2">
-                  {formatDuration(summary.durationSeconds)}
-                </td>
-                <td className="p-2 text-right tabular-nums">
-                  {formatDistanceMeters(summary.distanceMeters)}
-                </td>
-                <td className="p-2 text-right tabular-nums">
-                  {formatPercent(summary.pavedPercent)}
-                </td>
-                <td className="p-2 text-right tabular-nums">
-                  {formatPercent(summary.unpavedPercent)}
-                </td>
-                <td className="p-2 text-right tabular-nums">
-                  {formatSpeedMps(summary.avgSpeedMps)}
-                </td>
-                <td className="p-2 text-right tabular-nums">
-                  {formatHeartRate(summary.avgHeartRate)}
-                </td>
-                <td className="p-2 text-right tabular-nums">
-                  {formatHeartRate(summary.maxHeartRate)}
-                </td>
-                <td className="p-2 text-right tabular-nums">
-                  {formatAscent(summary.totalAscentMeters)}
-                </td>
-              </tr>
-            </tfoot>
-          </Table>
-        </div>
-      </CardContent>
-    </Card>
+                      onClick={() => setSelectedLapIndex(lap.lap_index)}
+                    >
+                      <TableCell className="font-medium">
+                        <button
+                          type="button"
+                          aria-pressed={selected}
+                          className="rounded-sm px-1 text-left font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                          onClick={(event) => {
+                            event.stopPropagation()
+                            setSelectedLapIndex(lap.lap_index)
+                          }}
+                        >
+                          {lap.lap_index}
+                        </button>
+                      </TableCell>
+                      <TableCell>
+                        {formatDuration(lap.duration_seconds ?? null)}
+                      </TableCell>
+                      <TableCell>{formatDuration(cumulativeSeconds)}</TableCell>
+                      <TableCell className="text-right tabular-nums">
+                        {formatDistanceMeters(lap.distance_meters)}
+                      </TableCell>
+                      <TableCell className="text-right tabular-nums">
+                        {formatPercent(
+                          surfacePercent(
+                            lap.paved_distance_meters,
+                            lap.distance_meters,
+                          ),
+                        )}
+                      </TableCell>
+                      <TableCell className="text-right tabular-nums">
+                        {formatPercent(
+                          surfacePercent(
+                            lap.unpaved_distance_meters,
+                            lap.distance_meters,
+                          ),
+                        )}
+                      </TableCell>
+                      <TableCell className="text-right tabular-nums">
+                        {formatSpeedMps(lap.avg_speed_mps)}
+                      </TableCell>
+                      <TableCell className="text-right tabular-nums">
+                        {formatHeartRate(lap.avg_heart_rate)}
+                      </TableCell>
+                      <TableCell className="text-right tabular-nums">
+                        {formatHeartRate(lap.max_heart_rate)}
+                      </TableCell>
+                      <TableCell className="text-right tabular-nums">
+                        {formatAscent(lap.total_ascent_meters)}
+                      </TableCell>
+                    </TableRow>
+                  )
+                })}
+              </TableBody>
+              <tfoot>
+                <tr className="border-t font-semibold">
+                  <td className="p-2">Summary</td>
+                  <td className="p-2">
+                    {formatDuration(summary.durationSeconds)}
+                  </td>
+                  <td className="p-2">
+                    {formatDuration(summary.durationSeconds)}
+                  </td>
+                  <td className="p-2 text-right tabular-nums">
+                    {formatDistanceMeters(summary.distanceMeters)}
+                  </td>
+                  <td className="p-2 text-right tabular-nums">
+                    {formatPercent(summary.pavedPercent)}
+                  </td>
+                  <td className="p-2 text-right tabular-nums">
+                    {formatPercent(summary.unpavedPercent)}
+                  </td>
+                  <td className="p-2 text-right tabular-nums">
+                    {formatSpeedMps(summary.avgSpeedMps)}
+                  </td>
+                  <td className="p-2 text-right tabular-nums">
+                    {formatHeartRate(summary.avgHeartRate)}
+                  </td>
+                  <td className="p-2 text-right tabular-nums">
+                    {formatHeartRate(summary.maxHeartRate)}
+                  </td>
+                  <td className="p-2 text-right tabular-nums">
+                    {formatAscent(summary.totalAscentMeters)}
+                  </td>
+                </tr>
+              </tfoot>
+            </Table>
+          </div>
+        </CardContent>
+      </Card>
+      {selectedLap && (
+        <ActivityLapDetailsPanel
+          lap={selectedLap}
+          laps={orderedLaps}
+          chartPoints={chartPoints}
+        />
+      )}
+    </div>
   )
 }

--- a/src/pages/GarminDetailPage.test.tsx
+++ b/src/pages/GarminDetailPage.test.tsx
@@ -157,8 +157,16 @@ vi.mock('@/components/garmin/ActivityStatsPanel', () => ({
 }))
 
 vi.mock('@/components/garmin/ActivityLapsTable', () => ({
-  ActivityLapsTable: ({ laps }: { laps: unknown[] }) => (
-    <div data-testid="activity-laps-table">laps:{laps.length}</div>
+  ActivityLapsTable: ({
+    laps,
+    chartPoints,
+  }: {
+    laps: unknown[]
+    chartPoints?: unknown[]
+  }) => (
+    <div data-testid="activity-laps-table">
+      laps:{laps.length} chart-points:{chartPoints?.length ?? 0}
+    </div>
   ),
 }))
 
@@ -355,7 +363,15 @@ describe('GarminDetailPage', () => {
     garminDetailHooks.useGarminChartDataQuery.mockReturnValue({
       loading: false,
       error: undefined,
-      data: { garminChartData: [] },
+      data: {
+        garminChartData: [
+          {
+            timestamp: '2026-03-14T09:00:00Z',
+            latitude: 40.7,
+            longitude: -74,
+          },
+        ],
+      },
     })
     garminDetailHooks.useGarminActivityLapsQuery.mockReturnValue({
       loading: false,
@@ -380,7 +396,7 @@ describe('GarminDetailPage', () => {
       skip: false,
     })
     expect(screen.getByTestId('activity-laps-table')).toHaveTextContent(
-      'laps:1',
+      'laps:1 chart-points:1',
     )
   })
 

--- a/src/pages/GarminDetailPage.tsx
+++ b/src/pages/GarminDetailPage.tsx
@@ -705,7 +705,10 @@ export function GarminDetailPage() {
             <ErrorState message={`Laps failed: ${lapsError.message}`} />
           )}
           {!lapsLoading && !lapsError && (
-            <ActivityLapsTable laps={lapsData?.garminActivityLaps ?? []} />
+            <ActivityLapsTable
+              laps={lapsData?.garminActivityLaps ?? []}
+              chartPoints={chartPoints}
+            />
           )}
         </TabsContent>
 


### PR DESCRIPTION
## Summary

Refs #274

This expands the Garmin Activity Laps tab so selected laps show detailed recorded stats and a route map for the selected segment.

Changes include:
- Inline selected-lap details panel below the laps table.
- Recorded lap stats for timer/elapsed/moving time, distance, paved/unpaved %, speed, heart rate, ascent/descent, calories, and start/end time.
- Route segment rendering using existing chart track points and `ActivityRouteMap`.
- Robust lap route segmentation that falls back from lap `end_time` to `start_time + duration_seconds`, then to cumulative lap distance when timestamps cannot resolve enough GPS points.
- Unit/page/e2e coverage for lap selection, details, route segmentation, and empty route state.

## Root Cause / Context

The initial lap route approach used lap `start_time` and `end_time` directly. Some Garmin lap rows return invalid `end_time` values, including values equal to the activity start, so timestamp-only filtering can produce zero or one route point even when the activity has full GPS data.

## Validation

- `npm run test:run -- src/components/garmin/ActivityLapsTable.test.tsx src/pages/GarminDetailPage.test.tsx`
- `npm run type-check`
- `npm run lint:all`
- `npm run build`

Build passed with existing Vite chunk-size/deprecation warnings only.