### PR TITLE
feat(garmin): Save as segment from a lap (create action)

### DIFF
--- a/src/__generated__/graphql.ts
+++ b/src/__generated__/graphql.ts
@@ -1283,6 +1283,8 @@ export type WithinReferenceResult = {
   total_points: Scalars['Int']['output'];
 };
 
+/** Input for creating a saved Garmin segment (e.g. from an activity lap or climb). */
+
 /** Sort direction for query results. */
 
 export type GarminActivitiesQueryVariables = Exact<{
@@ -1488,6 +1490,20 @@ export type GarminSegmentEffortsQueryVariables = Exact<{
 
 
 export type GarminSegmentEffortsQuery = { garminSegmentEfforts: { total: number, segment: { start_lat: number, start_lon: number, end_lat: number, end_lon: number, tolerance_meters: number }, items: Array<{ rank: number, activity_id: string, sport: string | null, activity_start_time: string | null, effort_start: string, effort_end: string, elapsed_seconds: number, distance_km: number | null, avg_speed_kmh: number | null, avg_heart_rate: number | null, max_heart_rate: number | null }> } };
+
+export type CreateGarminSegmentMutationVariables = Exact<{
+  input: CreateGarminSegmentInput;
+}>;
+
+
+export type CreateGarminSegmentMutation = { createGarminSegment: { id: number, name: string, sport: string | null, start_latitude: number, start_longitude: number, end_latitude: number, end_longitude: number, distance_meters: number | null, match_tolerance_meters: number, source_activity_id: string | null, source_lap_index: number | null, source_climb_index: number | null, created_at: string | null, updated_at: string | null } };
+
+export type DeleteGarminSegmentMutationVariables = Exact<{
+  id: number;
+}>;
+
+
+export type DeleteGarminSegmentMutation = { deleteGarminSegment: boolean };
 
 export type NearbyPointsQueryVariables = Exact<{
   lat: number;
@@ -3099,6 +3115,83 @@ export type GarminSegmentEffortsQueryHookResult = ReturnType<typeof useGarminSeg
 export type GarminSegmentEffortsLazyQueryHookResult = ReturnType<typeof useGarminSegmentEffortsLazyQuery>;
 export type GarminSegmentEffortsSuspenseQueryHookResult = ReturnType<typeof useGarminSegmentEffortsSuspenseQuery>;
 export type GarminSegmentEffortsQueryResult = ApolloReactCommon.QueryResult<GarminSegmentEffortsQuery, GarminSegmentEffortsQueryVariables>;
+export const CreateGarminSegmentDocument = gql`
+    mutation CreateGarminSegment($input: CreateGarminSegmentInput!) {
+  createGarminSegment(input: $input) {
+    id
+    name
+    sport
+    start_latitude
+    start_longitude
+    end_latitude
+    end_longitude
+    distance_meters
+    match_tolerance_meters
+    source_activity_id
+    source_lap_index
+    source_climb_index
+    created_at
+    updated_at
+  }
+}
+    `;
+export type CreateGarminSegmentMutationFn = ApolloReactCommon.MutationFunction<CreateGarminSegmentMutation, CreateGarminSegmentMutationVariables>;
+
+/**
+ * __useCreateGarminSegmentMutation__
+ *
+ * To run a mutation, you first call `useCreateGarminSegmentMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useCreateGarminSegmentMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [createGarminSegmentMutation, { data, loading, error }] = useCreateGarminSegmentMutation({
+ *   variables: {
+ *      input: // value for 'input'
+ *   },
+ * });
+ */
+export function useCreateGarminSegmentMutation(baseOptions?: ApolloReactHooks.MutationHookOptions<CreateGarminSegmentMutation, CreateGarminSegmentMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return ApolloReactHooks.useMutation<CreateGarminSegmentMutation, CreateGarminSegmentMutationVariables>(CreateGarminSegmentDocument, options);
+      }
+export type CreateGarminSegmentMutationHookResult = ReturnType<typeof useCreateGarminSegmentMutation>;
+export type CreateGarminSegmentMutationResult = ApolloReactCommon.MutationResult<CreateGarminSegmentMutation>;
+export type CreateGarminSegmentMutationOptions = ApolloReactCommon.BaseMutationOptions<CreateGarminSegmentMutation, CreateGarminSegmentMutationVariables>;
+export const DeleteGarminSegmentDocument = gql`
+    mutation DeleteGarminSegment($id: Int!) {
+  deleteGarminSegment(id: $id)
+}
+    `;
+export type DeleteGarminSegmentMutationFn = ApolloReactCommon.MutationFunction<DeleteGarminSegmentMutation, DeleteGarminSegmentMutationVariables>;
+
+/**
+ * __useDeleteGarminSegmentMutation__
+ *
+ * To run a mutation, you first call `useDeleteGarminSegmentMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useDeleteGarminSegmentMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [deleteGarminSegmentMutation, { data, loading, error }] = useDeleteGarminSegmentMutation({
+ *   variables: {
+ *      id: // value for 'id'
+ *   },
+ * });
+ */
+export function useDeleteGarminSegmentMutation(baseOptions?: ApolloReactHooks.MutationHookOptions<DeleteGarminSegmentMutation, DeleteGarminSegmentMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return ApolloReactHooks.useMutation<DeleteGarminSegmentMutation, DeleteGarminSegmentMutationVariables>(DeleteGarminSegmentDocument, options);
+      }
+export type DeleteGarminSegmentMutationHookResult = ReturnType<typeof useDeleteGarminSegmentMutation>;
+export type DeleteGarminSegmentMutationResult = ApolloReactCommon.MutationResult<DeleteGarminSegmentMutation>;
+export type DeleteGarminSegmentMutationOptions = ApolloReactCommon.BaseMutationOptions<DeleteGarminSegmentMutation, DeleteGarminSegmentMutationVariables>;
 export const NearbyPointsDocument = gql`
     query NearbyPoints($lat: Float!, $lon: Float!, $radius_meters: Float, $source: String, $limit: Int) {
   nearbyPoints(

--- a/src/components/garmin/ActivityLapsTable.test.tsx
+++ b/src/components/garmin/ActivityLapsTable.test.tsx
@@ -31,6 +31,12 @@ vi.mock('./ActivityRouteMap', () => ({
   },
 }))
 
+vi.mock('./SaveSegmentPopover', () => ({
+  SaveSegmentPopover: () => (
+    <div data-testid="save-segment-trigger">save-segment</div>
+  ),
+}))
+
 function lap(overrides: Partial<ActivityLap> = {}): ActivityLap {
   return {
     id: overrides.lap_index ?? 1,

--- a/src/components/garmin/ActivityLapsTable.test.tsx
+++ b/src/components/garmin/ActivityLapsTable.test.tsx
@@ -523,6 +523,50 @@ describe('ActivityLapsTable', () => {
     )
   })
 
+  it('offers Save as segment only when the lap has 2+ route points', () => {
+    const selectedLap = lap({
+      lap_index: 1,
+      start_time: '2026-03-14T09:05:00Z',
+      end_time: '2026-03-14T09:10:00Z',
+    })
+
+    const { unmount } = render(
+      <ActivityLapsTable
+        laps={[selectedLap]}
+        chartPoints={[
+          {
+            timestamp: '2026-03-14T09:05:00Z',
+            latitude: 40.7,
+            longitude: -74.01,
+          },
+          {
+            timestamp: '2026-03-14T09:10:00Z',
+            latitude: 40.71,
+            longitude: -74.02,
+          },
+        ]}
+      />,
+    )
+    fireEvent.click(screen.getByTestId('lap-row-1'))
+    expect(screen.getByTestId('save-segment-trigger')).toBeInTheDocument()
+    unmount()
+
+    render(
+      <ActivityLapsTable
+        laps={[selectedLap]}
+        chartPoints={[
+          {
+            timestamp: '2026-03-14T09:07:00Z',
+            latitude: 40.7,
+            longitude: -74.01,
+          },
+        ]}
+      />,
+    )
+    fireEvent.click(screen.getByTestId('lap-row-1'))
+    expect(screen.queryByTestId('save-segment-trigger')).toBeNull()
+  })
+
   it('renders an empty state when no laps are available', () => {
     render(<ActivityLapsTable laps={[]} />)
 

--- a/src/components/garmin/ActivityLapsTable.tsx
+++ b/src/components/garmin/ActivityLapsTable.tsx
@@ -13,6 +13,7 @@ import { cn } from '@/lib/utils'
 import type { ActivityChartTrackPoint } from './ActivityChartData'
 import { toRoutePoints } from './ActivityLapRoutePoints'
 import { ActivityRouteMap } from './ActivityRouteMap'
+import { SaveSegmentPopover } from './SaveSegmentPopover'
 import {
   buildLapSummary,
   getLapSegmentPoints,
@@ -26,6 +27,7 @@ const MPS_TO_MPH = 2.2369362921
 interface ActivityLapsTableProps {
   laps: ActivityLap[]
   chartPoints?: ActivityChartTrackPoint[]
+  sport?: string | null
 }
 
 function formatDistanceMeters(value: number | null | undefined): string {
@@ -106,10 +108,12 @@ function ActivityLapDetailsPanel({
   lap,
   laps,
   chartPoints,
+  sport,
 }: {
   lap: ActivityLap
   laps: ActivityLap[]
   chartPoints: ActivityChartTrackPoint[]
+  sport?: string | null
 }) {
   const segmentPoints = useMemo(
     () => getLapSegmentPoints(lap, chartPoints, laps),
@@ -120,6 +124,10 @@ function ActivityLapDetailsPanel({
     [segmentPoints],
   )
   const timeWindow = useMemo(() => getLapTimeWindow(lap), [lap])
+
+  const canSaveSegment = routePoints.length >= 2
+  const segmentStart = canSaveSegment ? routePoints[0] : null
+  const segmentEnd = canSaveSegment ? routePoints[routePoints.length - 1] : null
 
   return (
     <div className="space-y-4" data-testid="activity-lap-details-panel">
@@ -137,6 +145,18 @@ function ActivityLapDetailsPanel({
                 )}
               </p>
             </div>
+            {segmentStart && segmentEnd && (
+              <SaveSegmentPopover
+                activityId={lap.activity_id}
+                lapIndex={lap.lap_index}
+                sport={sport}
+                startLatitude={segmentStart.latitude}
+                startLongitude={segmentStart.longitude}
+                endLatitude={segmentEnd.latitude}
+                endLongitude={segmentEnd.longitude}
+                distanceMeters={lap.distance_meters}
+              />
+            )}
           </div>
 
           <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
@@ -210,6 +230,7 @@ function ActivityLapDetailsPanel({
 export function ActivityLapsTable({
   laps,
   chartPoints = [],
+  sport,
 }: ActivityLapsTableProps) {
   const [selectedLapIndex, setSelectedLapIndex] = useState<number | null>(null)
   const orderedLaps = useMemo(
@@ -370,6 +391,7 @@ export function ActivityLapsTable({
           lap={selectedLap}
           laps={orderedLaps}
           chartPoints={chartPoints}
+          sport={sport}
         />
       )}
     </div>

--- a/src/components/garmin/SaveSegmentPopover.test.tsx
+++ b/src/components/garmin/SaveSegmentPopover.test.tsx
@@ -1,0 +1,103 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const authMocks = vi.hoisted(() => ({
+  useAuth: vi.fn(),
+}))
+const graphqlMocks = vi.hoisted(() => ({
+  useCreateGarminSegmentMutation: vi.fn(),
+}))
+const toastMocks = vi.hoisted(() => ({
+  error: vi.fn(),
+  success: vi.fn(),
+}))
+
+vi.mock('@/contexts/AuthContext', () => authMocks)
+vi.mock('@/__generated__/graphql', () => graphqlMocks)
+vi.mock('sonner', () => ({ toast: toastMocks }))
+
+import { SaveSegmentPopover } from './SaveSegmentPopover'
+
+const baseProps = {
+  activityId: '23493313338',
+  lapIndex: 1,
+  sport: 'cycling',
+  startLatitude: 40.79,
+  startLongitude: -73.96,
+  endLatitude: 40.791,
+  endLongitude: -73.965,
+  distanceMeters: 508.1,
+}
+
+describe('SaveSegmentPopover', () => {
+  const login = vi.fn()
+  const createSegment = vi.fn()
+
+  beforeEach(() => {
+    login.mockReset()
+    createSegment.mockReset()
+    authMocks.useAuth.mockReset()
+    graphqlMocks.useCreateGarminSegmentMutation.mockReset()
+    toastMocks.error.mockReset()
+    toastMocks.success.mockReset()
+
+    authMocks.useAuth.mockReturnValue({ isAuthenticated: true, login })
+    graphqlMocks.useCreateGarminSegmentMutation.mockReturnValue([
+      createSegment,
+      { loading: false },
+    ])
+  })
+
+  it('prompts unauthenticated users to log in', async () => {
+    const user = userEvent.setup()
+    authMocks.useAuth.mockReturnValue({ isAuthenticated: false, login })
+
+    render(<SaveSegmentPopover {...baseProps} />)
+    await user.click(screen.getByTestId('save-segment-trigger'))
+
+    expect(
+      screen.getByText('Log in to save this lap as a named segment.'),
+    ).toBeVisible()
+    await user.click(screen.getByRole('button', { name: /login/i }))
+    expect(login).toHaveBeenCalledTimes(1)
+    expect(createSegment).not.toHaveBeenCalled()
+  })
+
+  it('submits the segment with lap-derived coordinates', async () => {
+    const user = userEvent.setup()
+
+    render(<SaveSegmentPopover {...baseProps} />)
+    await user.click(screen.getByTestId('save-segment-trigger'))
+
+    await user.type(screen.getByTestId('save-segment-name'), 'Harlem Hill')
+    await user.click(screen.getByTestId('save-segment-submit'))
+
+    expect(createSegment).toHaveBeenCalledTimes(1)
+    expect(createSegment).toHaveBeenCalledWith({
+      variables: {
+        input: {
+          name: 'Harlem Hill',
+          sport: 'cycling',
+          start_latitude: 40.79,
+          start_longitude: -73.96,
+          end_latitude: 40.791,
+          end_longitude: -73.965,
+          distance_meters: 508.1,
+          match_tolerance_meters: 35,
+          source_activity_id: '23493313338',
+          source_lap_index: 1,
+        },
+      },
+    })
+  })
+
+  it('keeps the submit button disabled until a name is entered', async () => {
+    const user = userEvent.setup()
+
+    render(<SaveSegmentPopover {...baseProps} />)
+    await user.click(screen.getByTestId('save-segment-trigger'))
+
+    expect(screen.getByTestId('save-segment-submit')).toBeDisabled()
+  })
+})

--- a/src/components/garmin/SaveSegmentPopover.test.tsx
+++ b/src/components/garmin/SaveSegmentPopover.test.tsx
@@ -86,7 +86,7 @@ describe('SaveSegmentPopover', () => {
           distance_meters: 508.1,
           match_tolerance_meters: 35,
           source_activity_id: '23493313338',
-          source_lap_index: 1,
+          source_lap_index: 0,
         },
       },
     })

--- a/src/components/garmin/SaveSegmentPopover.tsx
+++ b/src/components/garmin/SaveSegmentPopover.tsx
@@ -80,7 +80,8 @@ export function SaveSegmentPopover({
           distance_meters: distanceMeters ?? null,
           match_tolerance_meters: toleranceValue,
           source_activity_id: activityId ?? null,
-          source_lap_index: lapIndex,
+          // lap.lap_index is 1-based; the API stores source_lap_index zero-based.
+          source_lap_index: lapIndex - 1,
         },
       },
     })

--- a/src/components/garmin/SaveSegmentPopover.tsx
+++ b/src/components/garmin/SaveSegmentPopover.tsx
@@ -1,0 +1,160 @@
+import { useId, useState } from 'react'
+import { LogIn, MapPinPlus } from 'lucide-react'
+import { toast } from 'sonner'
+import { useCreateGarminSegmentMutation } from '@/__generated__/graphql'
+import { GARMIN_SEGMENTS_QUERY } from '@/graphql/segments'
+import { useAuth } from '@/contexts/AuthContext'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '@/components/ui/popover'
+
+interface SaveSegmentPopoverProps {
+  activityId?: string | null
+  lapIndex: number
+  sport?: string | null
+  startLatitude: number
+  startLongitude: number
+  endLatitude: number
+  endLongitude: number
+  distanceMeters?: number | null
+  defaultName?: string
+}
+
+const DEFAULT_TOLERANCE = 35
+
+export function SaveSegmentPopover({
+  activityId,
+  lapIndex,
+  sport,
+  startLatitude,
+  startLongitude,
+  endLatitude,
+  endLongitude,
+  distanceMeters,
+  defaultName = '',
+}: SaveSegmentPopoverProps) {
+  const { isAuthenticated, login } = useAuth()
+  const [open, setOpen] = useState(false)
+  const [name, setName] = useState(defaultName)
+  const [tolerance, setTolerance] = useState(String(DEFAULT_TOLERANCE))
+  const nameId = useId()
+  const toleranceId = useId()
+
+  const [createSegment, { loading }] = useCreateGarminSegmentMutation({
+    refetchQueries: [{ query: GARMIN_SEGMENTS_QUERY }],
+    onCompleted(data) {
+      toast.success('Segment saved', {
+        description: `"${data.createGarminSegment.name}" is now tracking efforts.`,
+      })
+      setOpen(false)
+      setName('')
+    },
+    onError(error) {
+      toast.error('Could not save segment', { description: error.message })
+    },
+  })
+
+  const trimmedName = name.trim()
+  const toleranceValue = Number(tolerance)
+  const toleranceValid =
+    Number.isFinite(toleranceValue) &&
+    toleranceValue >= 5 &&
+    toleranceValue <= 200
+  const canSubmit = trimmedName.length > 0 && toleranceValid && !loading
+
+  const handleSubmit = () => {
+    if (!canSubmit) return
+    createSegment({
+      variables: {
+        input: {
+          name: trimmedName,
+          sport: sport ?? null,
+          start_latitude: startLatitude,
+          start_longitude: startLongitude,
+          end_latitude: endLatitude,
+          end_longitude: endLongitude,
+          distance_meters: distanceMeters ?? null,
+          match_tolerance_meters: toleranceValue,
+          source_activity_id: activityId ?? null,
+          source_lap_index: lapIndex,
+        },
+      },
+    })
+  }
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button variant="outline" size="sm" data-testid="save-segment-trigger">
+          <MapPinPlus className="h-4 w-4" />
+          Save as segment
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent align="start" className="w-80">
+        {!isAuthenticated ? (
+          <div className="space-y-3">
+            <p className="text-sm text-muted-foreground">
+              Log in to save this lap as a named segment.
+            </p>
+            <Button variant="outline" size="sm" onClick={() => login()}>
+              <LogIn className="h-4 w-4" />
+              Login
+            </Button>
+          </div>
+        ) : (
+          <form
+            className="space-y-3"
+            onSubmit={(event) => {
+              event.preventDefault()
+              handleSubmit()
+            }}
+          >
+            <div className="space-y-1">
+              <label htmlFor={nameId} className="text-sm font-medium">
+                Segment name
+              </label>
+              <Input
+                id={nameId}
+                value={name}
+                onChange={(event) => setName(event.target.value)}
+                placeholder="e.g. Harlem Hill"
+                autoFocus
+                data-testid="save-segment-name"
+              />
+            </div>
+            <div className="space-y-1">
+              <label htmlFor={toleranceId} className="text-sm font-medium">
+                Match tolerance (m)
+              </label>
+              <Input
+                id={toleranceId}
+                type="number"
+                min={5}
+                max={200}
+                value={tolerance}
+                onChange={(event) => setTolerance(event.target.value)}
+                data-testid="save-segment-tolerance"
+              />
+              <p className="text-xs text-muted-foreground">
+                Corridor radius used to match other activities (5–200 m).
+              </p>
+            </div>
+            <Button
+              type="submit"
+              size="sm"
+              className="w-full"
+              disabled={!canSubmit}
+              data-testid="save-segment-submit"
+            >
+              {loading ? 'Saving…' : 'Save segment'}
+            </Button>
+          </form>
+        )}
+      </PopoverContent>
+    </Popover>
+  )
+}

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -1,0 +1,22 @@
+import * as React from 'react'
+import { cn } from '@/lib/utils'
+
+function Input({ className, type, ...props }: React.ComponentProps<'input'>) {
+  return (
+    <input
+      type={type}
+      data-slot="input"
+      className={cn(
+        'flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm transition-colors',
+        'file:border-0 file:bg-transparent file:text-sm file:font-medium',
+        'placeholder:text-muted-foreground',
+        'focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring',
+        'disabled:cursor-not-allowed disabled:opacity-50',
+        className,
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Input }

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -1,22 +1,25 @@
 import * as React from 'react'
 import { cn } from '@/lib/utils'
 
-function Input({ className, type, ...props }: React.ComponentProps<'input'>) {
-  return (
-    <input
-      type={type}
-      data-slot="input"
-      className={cn(
-        'flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm transition-colors',
-        'file:border-0 file:bg-transparent file:text-sm file:font-medium',
-        'placeholder:text-muted-foreground',
-        'focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring',
-        'disabled:cursor-not-allowed disabled:opacity-50',
-        className,
-      )}
-      {...props}
-    />
-  )
-}
+const Input = React.forwardRef<HTMLInputElement, React.ComponentProps<'input'>>(
+  function Input({ className, type, ...props }, ref) {
+    return (
+      <input
+        ref={ref}
+        type={type}
+        data-slot="input"
+        className={cn(
+          'flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm transition-colors',
+          'file:border-0 file:bg-transparent file:text-sm file:font-medium',
+          'placeholder:text-muted-foreground',
+          'focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring',
+          'disabled:cursor-not-allowed disabled:opacity-50',
+          className,
+        )}
+        {...props}
+      />
+    )
+  },
+)
 
 export { Input }

--- a/src/graphql/segments.ts
+++ b/src/graphql/segments.ts
@@ -81,3 +81,30 @@ export const GARMIN_SEGMENT_EFFORTS_QUERY = gql`
     }
   }
 `
+
+export const CREATE_GARMIN_SEGMENT_MUTATION = gql`
+  mutation CreateGarminSegment($input: CreateGarminSegmentInput!) {
+    createGarminSegment(input: $input) {
+      id
+      name
+      sport
+      start_latitude
+      start_longitude
+      end_latitude
+      end_longitude
+      distance_meters
+      match_tolerance_meters
+      source_activity_id
+      source_lap_index
+      source_climb_index
+      created_at
+      updated_at
+    }
+  }
+`
+
+export const DELETE_GARMIN_SEGMENT_MUTATION = gql`
+  mutation DeleteGarminSegment($id: Int!) {
+    deleteGarminSegment(id: $id)
+  }
+`

--- a/src/pages/GarminDetailPage.tsx
+++ b/src/pages/GarminDetailPage.tsx
@@ -708,6 +708,7 @@ export function GarminDetailPage() {
             <ActivityLapsTable
               laps={lapsData?.garminActivityLaps ?? []}
               chartPoints={chartPoints}
+              sport={a.sport}
             />
           )}
         </TabsContent>


### PR DESCRIPTION
## Summary

Completes the Phase 3 segments UI (Refs #282) with the **authenticated create path**
— "Save as segment from this lap" — the last remaining acceptance criterion after
the read-path PR (#290).

## What's included

- **`SaveSegmentPopover`** — an auth-gated Popover form (segment **name** + **match
  tolerance**, default 35 m) rendered in the **lap details panel**
  (`ActivityLapsTable`). It's shown only when the selected lap has GPS route points.
- **Pre-filled from the lap**: start/end coordinates come from the lap's route
  points (`points[0]` → start, `points[n-1]` → end); distance, `sport` (threaded
  from `GarminDetailPage`), `source_activity_id`, and `source_lap_index` are set
  automatically.
- **Mutations**: `createGarminSegment` (refetches the segments list so the new
  segment appears immediately) and `deleteGarminSegment`.
- **Auth**: the caller's Cognito JWT is forwarded by the existing Apollo auth link;
  unauthenticated users see a **Login** prompt inside the popover.
- Adds the shadcn **`Input`** primitive (`src/components/ui/input.tsx`).

## How it works

1. Open a Garmin activity → **Laps** tab → select a lap.
2. The lap details panel shows **Save as segment**.
3. Name it, adjust tolerance, **Save** → toast confirms, and it shows up under
   **Segments** with its full effort leaderboard.

## Validation

- `npm run lint:all` ✅ · `npm run type-check` ✅ · `npm run build` ✅
- `npm run test:run` ✅ — **296 tests pass** (3 new for the popover: auth gating,
  coordinate-derived submission, disabled-until-named)

## Notes

- No `matchGarminSegment` "backfill" trigger — the API computes efforts on demand,
  so a newly created segment's leaderboard is populated immediately with no extra
  call.
- Segment `sport` is taken from the parent activity so efforts match the right
  discipline.

## Acceptance criteria (#282)

- [x] User can create a named segment from an existing lap
- [x] Segment list and detail (efforts leaderboard) render with sorting (#290)
- [x] Map preview of the segment is shown (#290)
- [x] `lint:all`, `type-check`, `build`, and tests pass
