### PR TITLE
feat(garmin): add Delete button to segment detail page

### DIFF
--- a/src/components/garmin/DeleteSegmentButton.test.tsx
+++ b/src/components/garmin/DeleteSegmentButton.test.tsx
@@ -75,17 +75,32 @@ describe('DeleteSegmentButton', () => {
     await user.click(screen.getByTestId('delete-segment-confirm'))
 
     expect(deleteSegment).toHaveBeenCalledTimes(1)
+    expect(deleteSegment).toHaveBeenCalledWith({ variables: { id: 1 } })
   })
 
-  it('passes the segment id to the mutation hook', () => {
+  it('treats a false result as a failure (no navigation)', async () => {
+    const user = userEvent.setup()
+    graphqlMocks.useDeleteGarminSegmentMutation.mockImplementation(
+      (options: { onCompleted?: (data: unknown) => void }) => {
+        const fn = vi.fn(() => {
+          options.onCompleted?.({ deleteGarminSegment: false })
+        })
+        return [fn, { loading: false }]
+      },
+    )
+
     render(
       <DeleteSegmentButton
-        segmentId={7}
-        segmentName="Test"
+        segmentId={1}
+        segmentName="Harlem Hill"
         onDeleted={onDeleted}
       />,
     )
-    const options = graphqlMocks.useDeleteGarminSegmentMutation.mock.calls[0][0]
-    expect(options.variables).toEqual({ id: 7 })
+    await user.click(screen.getByTestId('delete-segment-trigger'))
+    await user.click(screen.getByTestId('delete-segment-confirm'))
+
+    expect(onDeleted).not.toHaveBeenCalled()
+    expect(toastMocks.error).toHaveBeenCalled()
+    expect(toastMocks.success).not.toHaveBeenCalled()
   })
 })

--- a/src/components/garmin/DeleteSegmentButton.test.tsx
+++ b/src/components/garmin/DeleteSegmentButton.test.tsx
@@ -1,0 +1,91 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const authMocks = vi.hoisted(() => ({
+  useAuth: vi.fn(),
+}))
+const graphqlMocks = vi.hoisted(() => ({
+  useDeleteGarminSegmentMutation: vi.fn(),
+}))
+const toastMocks = vi.hoisted(() => ({
+  error: vi.fn(),
+  success: vi.fn(),
+}))
+
+vi.mock('@/contexts/AuthContext', () => authMocks)
+vi.mock('@/__generated__/graphql', () => graphqlMocks)
+vi.mock('sonner', () => ({ toast: toastMocks }))
+
+import { DeleteSegmentButton } from './DeleteSegmentButton'
+
+describe('DeleteSegmentButton', () => {
+  const login = vi.fn()
+  const deleteSegment = vi.fn()
+  const onDeleted = vi.fn()
+
+  beforeEach(() => {
+    login.mockReset()
+    deleteSegment.mockReset()
+    onDeleted.mockReset()
+    authMocks.useAuth.mockReset()
+    graphqlMocks.useDeleteGarminSegmentMutation.mockReset()
+    toastMocks.error.mockReset()
+    toastMocks.success.mockReset()
+
+    authMocks.useAuth.mockReturnValue({ isAuthenticated: true, login })
+    graphqlMocks.useDeleteGarminSegmentMutation.mockReturnValue([
+      deleteSegment,
+      { loading: false },
+    ])
+  })
+
+  it('prompts unauthenticated users to log in', async () => {
+    const user = userEvent.setup()
+    authMocks.useAuth.mockReturnValue({ isAuthenticated: false, login })
+
+    render(
+      <DeleteSegmentButton
+        segmentId={1}
+        segmentName="Harlem Hill"
+        onDeleted={onDeleted}
+      />,
+    )
+    await user.click(screen.getByTestId('delete-segment-trigger'))
+
+    expect(screen.getByText('Log in to delete this segment.')).toBeVisible()
+    await user.click(screen.getByRole('button', { name: /login/i }))
+    expect(login).toHaveBeenCalledTimes(1)
+    expect(deleteSegment).not.toHaveBeenCalled()
+  })
+
+  it('confirms and calls the delete mutation', async () => {
+    const user = userEvent.setup()
+
+    render(
+      <DeleteSegmentButton
+        segmentId={1}
+        segmentName="Harlem Hill"
+        onDeleted={onDeleted}
+      />,
+    )
+    await user.click(screen.getByTestId('delete-segment-trigger'))
+
+    expect(screen.getByText('Delete “Harlem Hill”?')).toBeVisible()
+    await user.click(screen.getByTestId('delete-segment-confirm'))
+
+    expect(deleteSegment).toHaveBeenCalledTimes(1)
+  })
+
+  it('passes the segment id to the mutation hook', () => {
+    render(
+      <DeleteSegmentButton
+        segmentId={7}
+        segmentName="Test"
+        onDeleted={onDeleted}
+      />,
+    )
+    const options = graphqlMocks.useDeleteGarminSegmentMutation.mock.calls[0][0]
+    expect(options.variables).toEqual({ id: 7 })
+  })
+})

--- a/src/components/garmin/DeleteSegmentButton.tsx
+++ b/src/components/garmin/DeleteSegmentButton.tsx
@@ -26,11 +26,16 @@ export function DeleteSegmentButton({
   const [open, setOpen] = useState(false)
 
   const [deleteSegment, { loading }] = useDeleteGarminSegmentMutation({
-    variables: { id: segmentId },
     refetchQueries: [{ query: GARMIN_SEGMENTS_QUERY }],
-    onCompleted() {
+    onCompleted(data) {
+      if (!data.deleteGarminSegment) {
+        toast.error('Could not delete segment', {
+          description: 'The server did not confirm the deletion.',
+        })
+        return
+      }
       toast.success('Segment deleted', {
-        description: `"${segmentName}" was removed (and will be removed from Garmin Connect).`,
+        description: `"${segmentName}" was removed and will be cleared from Garmin Connect shortly.`,
       })
       setOpen(false)
       onDeleted()
@@ -69,8 +74,8 @@ export function DeleteSegmentButton({
             <div className="space-y-1">
               <p className="text-sm font-medium">Delete “{segmentName}”?</p>
               <p className="text-sm text-muted-foreground">
-                This removes the saved segment and deletes it from Garmin
-                Connect too. This can’t be undone.
+                This removes the saved segment and queues it for removal from
+                Garmin Connect (cleared on the next sync). This can’t be undone.
               </p>
             </div>
             <div className="flex justify-end gap-2">

--- a/src/components/garmin/DeleteSegmentButton.tsx
+++ b/src/components/garmin/DeleteSegmentButton.tsx
@@ -1,0 +1,100 @@
+import { useState } from 'react'
+import { LogIn, Trash2 } from 'lucide-react'
+import { toast } from 'sonner'
+import { useDeleteGarminSegmentMutation } from '@/__generated__/graphql'
+import { GARMIN_SEGMENTS_QUERY } from '@/graphql/segments'
+import { useAuth } from '@/contexts/AuthContext'
+import { Button } from '@/components/ui/button'
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '@/components/ui/popover'
+
+interface DeleteSegmentButtonProps {
+  segmentId: number
+  segmentName: string
+  onDeleted: () => void
+}
+
+export function DeleteSegmentButton({
+  segmentId,
+  segmentName,
+  onDeleted,
+}: DeleteSegmentButtonProps) {
+  const { isAuthenticated, login } = useAuth()
+  const [open, setOpen] = useState(false)
+
+  const [deleteSegment, { loading }] = useDeleteGarminSegmentMutation({
+    variables: { id: segmentId },
+    refetchQueries: [{ query: GARMIN_SEGMENTS_QUERY }],
+    onCompleted() {
+      toast.success('Segment deleted', {
+        description: `"${segmentName}" was removed (and will be removed from Garmin Connect).`,
+      })
+      setOpen(false)
+      onDeleted()
+    },
+    onError(error) {
+      toast.error('Could not delete segment', { description: error.message })
+    },
+  })
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          variant="outline"
+          size="sm"
+          className="text-destructive hover:text-destructive"
+          data-testid="delete-segment-trigger"
+        >
+          <Trash2 className="h-4 w-4" />
+          Delete
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent align="end" className="w-80">
+        {!isAuthenticated ? (
+          <div className="space-y-3">
+            <p className="text-sm text-muted-foreground">
+              Log in to delete this segment.
+            </p>
+            <Button variant="outline" size="sm" onClick={() => login()}>
+              <LogIn className="h-4 w-4" />
+              Login
+            </Button>
+          </div>
+        ) : (
+          <div className="space-y-3">
+            <div className="space-y-1">
+              <p className="text-sm font-medium">Delete “{segmentName}”?</p>
+              <p className="text-sm text-muted-foreground">
+                This removes the saved segment and deletes it from Garmin
+                Connect too. This can’t be undone.
+              </p>
+            </div>
+            <div className="flex justify-end gap-2">
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => setOpen(false)}
+                disabled={loading}
+              >
+                Cancel
+              </Button>
+              <Button
+                variant="destructive"
+                size="sm"
+                onClick={() => deleteSegment({ variables: { id: segmentId } })}
+                disabled={loading}
+                data-testid="delete-segment-confirm"
+              >
+                {loading ? 'Deleting…' : 'Delete'}
+              </Button>
+            </div>
+          </div>
+        )}
+      </PopoverContent>
+    </Popover>
+  )
+}

--- a/src/pages/GarminSegmentDetailPage.test.tsx
+++ b/src/pages/GarminSegmentDetailPage.test.tsx
@@ -14,6 +14,11 @@ vi.mock('@/lib/newrelic-browser', () => ({ setNRCustomAttribute: vi.fn() }))
 vi.mock('@/components/garmin/SegmentStartEndMap', () => ({
   SegmentStartEndMap: () => <div data-testid="segment-map">map</div>,
 }))
+vi.mock('@/components/garmin/DeleteSegmentButton', () => ({
+  DeleteSegmentButton: () => (
+    <div data-testid="delete-segment-trigger">delete</div>
+  ),
+}))
 
 const segment = {
   id: 1,

--- a/src/pages/GarminSegmentDetailPage.tsx
+++ b/src/pages/GarminSegmentDetailPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect } from 'react'
-import { Link, useParams } from 'react-router-dom'
+import { Link, useNavigate, useParams } from 'react-router-dom'
 import { ArrowLeft } from 'lucide-react'
 import {
   useGarminSegmentQuery,
@@ -12,6 +12,7 @@ import { Badge } from '@/components/ui/badge'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { SegmentStartEndMap } from '@/components/garmin/SegmentStartEndMap'
 import { SegmentEffortsLeaderboard } from '@/components/garmin/SegmentEffortsLeaderboard'
+import { DeleteSegmentButton } from '@/components/garmin/DeleteSegmentButton'
 import {
   formatDistanceMi,
   formatTolerance,
@@ -23,6 +24,7 @@ const EFFORTS_LIMIT = 100
 
 export function GarminSegmentDetailPage() {
   const { segmentId } = useParams<{ segmentId: string }>()
+  const navigate = useNavigate()
   const id = Number(segmentId)
   const validId = Number.isInteger(id) && id > 0
 
@@ -115,11 +117,14 @@ export function GarminSegmentDetailPage() {
             {total.toLocaleString()} matching effort{total === 1 ? '' : 's'}
           </p>
         </div>
-        {segment.sport && (
-          <Badge variant="secondary" className="mt-2">
-            {segment.sport}
-          </Badge>
-        )}
+        <div className="mt-2 flex items-center gap-2">
+          {segment.sport && <Badge variant="secondary">{segment.sport}</Badge>}
+          <DeleteSegmentButton
+            segmentId={segment.id}
+            segmentName={segment.name}
+            onDeleted={() => navigate('/garmin/segments')}
+          />
+        </div>
       </div>
 
       <div className="grid gap-6 lg:grid-cols-2">


### PR DESCRIPTION
Closes the end-to-end delete loop from the UI — the final piece of the Garmin segments feature.

## What it adds
An auth-gated **Delete** action on the segment detail page (`/garmin/segments/:id`):
- Confirm popover ("Delete '{name}'? This removes it from Garmin Connect too.")
- Calls the `deleteGarminSegment` mutation, then navigates back to the segments list
- Unauthenticated users get a **Login** prompt (writes require auth)

## End-to-end behavior (already deployed backend)
- The API marks a synced segment `delete_pending`; the garmin-sync agent removes it from Garmin Connect (`DELETE /segment-service/segment/{uuid}`) then deletes the DB row.
- The segments list already excludes `delete_pending`, so the segment disappears from the UI immediately.

## Validation
- `npm run type-check`, `npm run build` ✅
- `npm run test:run` → **300 tests pass** (3 new: auth gating, confirm→mutation, id passthrough)
- ESLint / cspell / prettier clean

## Context
Completes the delete cascade whose backend shipped in otel-data-api (delete → `delete_pending`) and otel-agents (`segment_sync` reconciler + empty-body DELETE fix). Push side (segments visible on Garmin) is already live.