### PR TITLE
feat(garmin): save climbs as segments

### DIFF
--- a/src/components/garmin/ActivityLapsTable.tsx
+++ b/src/components/garmin/ActivityLapsTable.tsx
@@ -148,7 +148,7 @@ function ActivityLapDetailsPanel({
             {segmentStart && segmentEnd && (
               <SaveSegmentPopover
                 activityId={lap.activity_id}
-                lapIndex={lap.lap_index}
+                sourceLapIndex={lap.lap_index - 1}
                 sport={sport}
                 startLatitude={segmentStart.latitude}
                 startLongitude={segmentStart.longitude}

--- a/src/components/garmin/ClimbDetailsPanel.test.tsx
+++ b/src/components/garmin/ClimbDetailsPanel.test.tsx
@@ -57,6 +57,12 @@ vi.mock('leaflet', () => ({
   },
 }))
 
+vi.mock('./SaveSegmentPopover', () => ({
+  SaveSegmentPopover: () => (
+    <div data-testid="save-segment-trigger">save-segment</div>
+  ),
+}))
+
 describe('ClimbDetailsPanel', () => {
   beforeEach(() => {
     leafletMocks.map.mockClear()

--- a/src/components/garmin/ClimbDetailsPanel.test.tsx
+++ b/src/components/garmin/ClimbDetailsPanel.test.tsx
@@ -136,6 +136,46 @@ describe('ClimbDetailsPanel', () => {
     )
   })
 
+  it('renders the save-as-segment control when the climb has coordinates', () => {
+    render(
+      <ClimbDetailsPanel
+        climb={mockClimb()}
+        climbIndex={0}
+        totalClimbs={1}
+        chartPoints={mockChartPoints()}
+        onPrevious={vi.fn()}
+        onNext={vi.fn()}
+        canPrevious={false}
+        canNext={false}
+      />,
+    )
+
+    expect(screen.getByTestId('save-segment-trigger')).toBeInTheDocument()
+  })
+
+  it('hides the save-as-segment control when the climb lacks coordinates', () => {
+    render(
+      <ClimbDetailsPanel
+        climb={{
+          ...mockClimb(),
+          start_latitude: null,
+          start_longitude: null,
+          end_latitude: null,
+          end_longitude: null,
+        }}
+        climbIndex={0}
+        totalClimbs={1}
+        chartPoints={mockChartPoints()}
+        onPrevious={vi.fn()}
+        onNext={vi.fn()}
+        canPrevious={false}
+        canNext={false}
+      />,
+    )
+
+    expect(screen.queryByTestId('save-segment-trigger')).not.toBeInTheDocument()
+  })
+
   it('hides sensor overlay options when older climb points lack sensor data', async () => {
     render(
       <ClimbDetailsPanel

--- a/src/components/garmin/ClimbDetailsPanel.tsx
+++ b/src/components/garmin/ClimbDetailsPanel.tsx
@@ -14,11 +14,16 @@ import {
   SelectValue,
 } from '@/components/ui/select'
 import { formatDurationShort, metersToFeet } from '@/lib/units'
+import { SaveSegmentPopover } from './SaveSegmentPopover'
 import {
   getClimbSegmentPoints,
   getGradeBucket,
   GRADE_BUCKETS,
 } from './ClimbDetailsPanel.helpers'
+
+function isFiniteNumber(value: number | null | undefined): value is number {
+  return typeof value === 'number' && Number.isFinite(value)
+}
 
 const METERS_PER_MILE = 1609.344
 const FEET_PER_MILE = 5280
@@ -42,6 +47,7 @@ interface ClimbDetailsPanelProps {
   onNext: () => void
   canPrevious: boolean
   canNext: boolean
+  sport?: string | null
 }
 
 interface ClimbGraphPoint {
@@ -686,6 +692,7 @@ export function ClimbDetailsPanel({
   onNext,
   canPrevious,
   canNext,
+  sport,
 }: ClimbDetailsPanelProps) {
   const segmentPoints = useMemo(
     () => getClimbSegmentPoints(climb, chartPoints),
@@ -697,11 +704,31 @@ export function ClimbDetailsPanel({
   )
   const mapPoints = useMemo(() => toMapPoints(segmentPoints), [segmentPoints])
 
+  const canSaveSegment =
+    isFiniteNumber(climb.start_latitude) &&
+    isFiniteNumber(climb.start_longitude) &&
+    isFiniteNumber(climb.end_latitude) &&
+    isFiniteNumber(climb.end_longitude)
+
   return (
     <Card data-testid="climb-details-panel">
       <CardHeader className="space-y-4">
         <div className="flex flex-wrap items-center justify-between gap-3">
-          <CardTitle className="text-base">Climb Details</CardTitle>
+          <div className="flex items-center gap-2">
+            <CardTitle className="text-base">Climb Details</CardTitle>
+            {canSaveSegment && (
+              <SaveSegmentPopover
+                activityId={climb.activity_id}
+                sourceClimbIndex={climbIndex}
+                sport={sport}
+                startLatitude={climb.start_latitude as number}
+                startLongitude={climb.start_longitude as number}
+                endLatitude={climb.end_latitude as number}
+                endLongitude={climb.end_longitude as number}
+                distanceMeters={climb.distance_meters}
+              />
+            )}
+          </div>
           <div className="flex items-center gap-2">
             <Button
               type="button"

--- a/src/components/garmin/ClimbDetailsPanel.tsx
+++ b/src/components/garmin/ClimbDetailsPanel.tsx
@@ -719,7 +719,7 @@ export function ClimbDetailsPanel({
             {canSaveSegment && (
               <SaveSegmentPopover
                 activityId={climb.activity_id}
-                sourceClimbIndex={climbIndex}
+                sourceClimbIndex={climb.source_split_index}
                 sport={sport}
                 startLatitude={climb.start_latitude as number}
                 startLongitude={climb.start_longitude as number}

--- a/src/components/garmin/SaveSegmentPopover.test.tsx
+++ b/src/components/garmin/SaveSegmentPopover.test.tsx
@@ -96,9 +96,13 @@ describe('SaveSegmentPopover', () => {
   it('submits the segment with a climb source index', async () => {
     const user = userEvent.setup()
 
-    const { sourceLapIndex: _omit, ...climbProps } = baseProps
-    void _omit
-    render(<SaveSegmentPopover {...climbProps} sourceClimbIndex={2} />)
+    render(
+      <SaveSegmentPopover
+        {...baseProps}
+        sourceLapIndex={null}
+        sourceClimbIndex={2}
+      />,
+    )
     await user.click(screen.getByTestId('save-segment-trigger'))
 
     await user.type(screen.getByTestId('save-segment-name'), 'Harlem Hill')

--- a/src/components/garmin/SaveSegmentPopover.test.tsx
+++ b/src/components/garmin/SaveSegmentPopover.test.tsx
@@ -21,7 +21,7 @@ import { SaveSegmentPopover } from './SaveSegmentPopover'
 
 const baseProps = {
   activityId: '23493313338',
-  lapIndex: 1,
+  sourceLapIndex: 0,
   sport: 'cycling',
   startLatitude: 40.79,
   startLongitude: -73.96,
@@ -87,6 +87,38 @@ describe('SaveSegmentPopover', () => {
           match_tolerance_meters: 35,
           source_activity_id: '23493313338',
           source_lap_index: 0,
+          source_climb_index: null,
+        },
+      },
+    })
+  })
+
+  it('submits the segment with a climb source index', async () => {
+    const user = userEvent.setup()
+
+    const { sourceLapIndex: _omit, ...climbProps } = baseProps
+    void _omit
+    render(<SaveSegmentPopover {...climbProps} sourceClimbIndex={2} />)
+    await user.click(screen.getByTestId('save-segment-trigger'))
+
+    await user.type(screen.getByTestId('save-segment-name'), 'Harlem Hill')
+    await user.click(screen.getByTestId('save-segment-submit'))
+
+    expect(createSegment).toHaveBeenCalledTimes(1)
+    expect(createSegment).toHaveBeenCalledWith({
+      variables: {
+        input: {
+          name: 'Harlem Hill',
+          sport: 'cycling',
+          start_latitude: 40.79,
+          start_longitude: -73.96,
+          end_latitude: 40.791,
+          end_longitude: -73.965,
+          distance_meters: 508.1,
+          match_tolerance_meters: 35,
+          source_activity_id: '23493313338',
+          source_lap_index: null,
+          source_climb_index: 2,
         },
       },
     })

--- a/src/components/garmin/SaveSegmentPopover.tsx
+++ b/src/components/garmin/SaveSegmentPopover.tsx
@@ -70,6 +70,8 @@ export function SaveSegmentPopover({
     toleranceValue <= 200
   const canSubmit = trimmedName.length > 0 && toleranceValid && !loading
 
+  const sourceLabel = sourceClimbIndex != null ? 'climb' : 'lap'
+
   const handleSubmit = () => {
     if (!canSubmit) return
     createSegment({
@@ -103,7 +105,7 @@ export function SaveSegmentPopover({
         {!isAuthenticated ? (
           <div className="space-y-3">
             <p className="text-sm text-muted-foreground">
-              Log in to save this lap as a named segment.
+              Log in to save this {sourceLabel} as a named segment.
             </p>
             <Button variant="outline" size="sm" onClick={() => login()}>
               <LogIn className="h-4 w-4" />

--- a/src/components/garmin/SaveSegmentPopover.tsx
+++ b/src/components/garmin/SaveSegmentPopover.tsx
@@ -14,7 +14,6 @@ import {
 
 interface SaveSegmentPopoverProps {
   activityId?: string | null
-  lapIndex: number
   sport?: string | null
   startLatitude: number
   startLongitude: number
@@ -22,13 +21,16 @@ interface SaveSegmentPopoverProps {
   endLongitude: number
   distanceMeters?: number | null
   defaultName?: string
+  /** Zero-based lap index this segment is created from, if any. */
+  sourceLapIndex?: number | null
+  /** Zero-based climb (typed split) index this segment is created from, if any. */
+  sourceClimbIndex?: number | null
 }
 
 const DEFAULT_TOLERANCE = 35
 
 export function SaveSegmentPopover({
   activityId,
-  lapIndex,
   sport,
   startLatitude,
   startLongitude,
@@ -36,6 +38,8 @@ export function SaveSegmentPopover({
   endLongitude,
   distanceMeters,
   defaultName = '',
+  sourceLapIndex = null,
+  sourceClimbIndex = null,
 }: SaveSegmentPopoverProps) {
   const { isAuthenticated, login } = useAuth()
   const [open, setOpen] = useState(false)
@@ -80,8 +84,8 @@ export function SaveSegmentPopover({
           distance_meters: distanceMeters ?? null,
           match_tolerance_meters: toleranceValue,
           source_activity_id: activityId ?? null,
-          // lap.lap_index is 1-based; the API stores source_lap_index zero-based.
-          source_lap_index: lapIndex - 1,
+          source_lap_index: sourceLapIndex,
+          source_climb_index: sourceClimbIndex,
         },
       },
     })

--- a/src/pages/GarminDetailPage.tsx
+++ b/src/pages/GarminDetailPage.tsx
@@ -824,6 +824,7 @@ export function GarminDetailPage() {
                   onNext={selectNextClimb}
                   canPrevious={selectedClimbIndex > 0}
                   canNext={selectedClimbIndex < mainClimbs.length - 1}
+                  sport={a.sport}
                 />
               )}
             </>


### PR DESCRIPTION
## Summary

Adds the ability to save a Garmin **climb** as a named segment, mirroring the
existing "Save as segment" functionality for laps.

The `SaveSegmentPopover` component is generalized to accept either a lap or a
climb as its source, and it is wired into the climb details panel using the
climb's explicit start/end coordinates.

This is a **UI-only** change. The API (`GarminSegmentCreate.source_climb_index`)
and gateway (`createGarminSegment`) already support the climb source index — no
backend changes are required.

## Changes

- **SaveSegmentPopover**: replaced the required `lapIndex` prop with two
  nullable, already zero-based props — `sourceLapIndex` and `sourceClimbIndex`.
  Both are forwarded to the `createGarminSegment` input as `source_lap_index`
  and `source_climb_index`.
- **ActivityLapsTable**: now passes `sourceLapIndex={lap.lap_index - 1}`
  (lap index is 1-based; API stores it zero-based).
- **ClimbDetailsPanel**: added a "Save as segment" button in the panel header,
  using the climb's `start_/end_latitude/longitude` and `climbIndex` as
  `source_climb_index`. The button only renders when the climb has valid
  start/end coordinates.
- **GarminDetailPage**: threads the activity `sport` into `ClimbDetailsPanel`.
- **Tests**: updated the popover assertions for the new props, added a
  climb source-index test case, and mocked `SaveSegmentPopover` in the climb
  panel test.

## Validation

- `npm run type-check` — pass
- `npm run lint` — pass
- `npm run lint:spell` — pass
- `npm run build` — pass
- `npm run test:run` — 301 tests pass (48 files)

Refs: Garmin Segments feature (Project #10)