### PR TITLE
feat(garmin): save analysis segments as named segments

### DIFF
--- a/src/components/garmin/SaveSegmentPopover.test.tsx
+++ b/src/components/garmin/SaveSegmentPopover.test.tsx
@@ -64,6 +64,24 @@ describe('SaveSegmentPopover', () => {
     expect(createSegment).not.toHaveBeenCalled()
   })
 
+  it('uses a custom source label in the login prompt', async () => {
+    const user = userEvent.setup()
+    authMocks.useAuth.mockReturnValue({ isAuthenticated: false, login })
+
+    render(
+      <SaveSegmentPopover
+        {...baseProps}
+        sourceLapIndex={null}
+        sourceLabel="range"
+      />,
+    )
+    await user.click(screen.getByTestId('save-segment-trigger'))
+
+    expect(
+      screen.getByText('Log in to save this range as a named segment.'),
+    ).toBeVisible()
+  })
+
   it('submits the segment with lap-derived coordinates', async () => {
     const user = userEvent.setup()
 

--- a/src/components/garmin/SaveSegmentPopover.tsx
+++ b/src/components/garmin/SaveSegmentPopover.tsx
@@ -25,6 +25,11 @@ interface SaveSegmentPopoverProps {
   sourceLapIndex?: number | null
   /** Zero-based climb (typed split) index this segment is created from, if any. */
   sourceClimbIndex?: number | null
+  /**
+   * Noun used in the unauthenticated prompt ("Log in to save this {label}…").
+   * Defaults to "climb" or "lap" based on the source index.
+   */
+  sourceLabel?: string
 }
 
 const DEFAULT_TOLERANCE = 35
@@ -40,6 +45,7 @@ export function SaveSegmentPopover({
   defaultName = '',
   sourceLapIndex = null,
   sourceClimbIndex = null,
+  sourceLabel,
 }: SaveSegmentPopoverProps) {
   const { isAuthenticated, login } = useAuth()
   const [open, setOpen] = useState(false)
@@ -70,7 +76,8 @@ export function SaveSegmentPopover({
     toleranceValue <= 200
   const canSubmit = trimmedName.length > 0 && toleranceValid && !loading
 
-  const sourceLabel = sourceClimbIndex != null ? 'climb' : 'lap'
+  const resolvedSourceLabel =
+    sourceLabel ?? (sourceClimbIndex != null ? 'climb' : 'lap')
 
   const handleSubmit = () => {
     if (!canSubmit) return
@@ -105,7 +112,7 @@ export function SaveSegmentPopover({
         {!isAuthenticated ? (
           <div className="space-y-3">
             <p className="text-sm text-muted-foreground">
-              Log in to save this {sourceLabel} as a named segment.
+              Log in to save this {resolvedSourceLabel} as a named segment.
             </p>
             <Button variant="outline" size="sm" onClick={() => login()}>
               <LogIn className="h-4 w-4" />

--- a/src/components/garmin/SegmentAnalysis.test.tsx
+++ b/src/components/garmin/SegmentAnalysis.test.tsx
@@ -1,7 +1,13 @@
 import { render, screen } from '@testing-library/react'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import type { SavedPoint } from './ActivityChartData'
 import { SegmentAnalysis } from './SegmentAnalysis'
+
+vi.mock('./SaveSegmentPopover', () => ({
+  SaveSegmentPopover: () => (
+    <div data-testid="save-segment-trigger">save-segment</div>
+  ),
+}))
 
 function savedPoint(overrides: Partial<SavedPoint> = {}): SavedPoint {
   return {
@@ -61,6 +67,19 @@ describe('SegmentAnalysis', () => {
     expect(screen.getByText('10.0 mph')).toBeInTheDocument()
     expect(screen.getByText('6:00 /mi')).toBeInTheDocument()
     expect(screen.getByText('+100 ft')).toBeInTheDocument()
+    // No coordinates on these points, so the save-as-segment control is hidden.
+    expect(screen.queryByTestId('save-segment-trigger')).not.toBeInTheDocument()
+  })
+
+  it('shows a save-as-segment control for segments with coordinates', () => {
+    const points = [
+      savedPoint({ id: 'a', time: 0, latitude: 40.0, longitude: -74.0 }),
+      savedPoint({ id: 'b', time: 10, latitude: 40.0, longitude: -73.9 }),
+    ]
+
+    render(<SegmentAnalysis points={points} activityId="42" sport="cycling" />)
+
+    expect(screen.getByTestId('save-segment-trigger')).toBeInTheDocument()
   })
 
   it('flags a straight-line distance with a direct suffix', () => {

--- a/src/components/garmin/SegmentAnalysis.tsx
+++ b/src/components/garmin/SegmentAnalysis.tsx
@@ -1,14 +1,32 @@
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { formatDuration } from '@/lib/units'
 import type { SavedPoint } from './ActivityChartData'
+import { SaveSegmentPopover } from './SaveSegmentPopover'
 import {
   buildSavedSegments,
   formatPaceMinPerMi,
   type SavedSegment,
 } from './segmentAnalysis'
 
+const METERS_PER_MILE = 1609.344
+
 interface SegmentAnalysisProps {
   points: SavedPoint[]
+  activityId?: string | null
+  sport?: string | null
+}
+
+function isFiniteNumber(value: number | null | undefined): value is number {
+  return typeof value === 'number' && Number.isFinite(value)
+}
+
+function canSaveSegment(segment: SavedSegment): boolean {
+  return (
+    isFiniteNumber(segment.from.latitude) &&
+    isFiniteNumber(segment.from.longitude) &&
+    isFiniteNumber(segment.to.latitude) &&
+    isFiniteNumber(segment.to.longitude)
+  )
 }
 
 function formatDistance(segment: SavedSegment): string {
@@ -38,7 +56,11 @@ function formatGrade(value: number | null): string {
  * each pair of consecutive saved points. Renders nothing until at least two
  * points are saved (i.e. there is a segment to analyze).
  */
-export function SegmentAnalysis({ points }: SegmentAnalysisProps) {
+export function SegmentAnalysis({
+  points,
+  activityId,
+  sport,
+}: SegmentAnalysisProps) {
   const segments = buildSavedSegments(points)
   if (segments.length === 0) return null
 
@@ -59,7 +81,8 @@ export function SegmentAnalysis({ points }: SegmentAnalysisProps) {
               <th className="py-1 pr-3 font-medium">Avg Speed</th>
               <th className="py-1 pr-3 font-medium">Pace</th>
               <th className="py-1 pr-3 font-medium">Elev Δ</th>
-              <th className="py-1 font-medium">Grade</th>
+              <th className="py-1 pr-3 font-medium">Grade</th>
+              <th className="py-1 font-medium sr-only">Actions</th>
             </tr>
           </thead>
           <tbody>
@@ -94,8 +117,26 @@ export function SegmentAnalysis({ points }: SegmentAnalysisProps) {
                 <td className="py-1 pr-3 tabular-nums">
                   {formatElevation(s.elevationChangeFt)}
                 </td>
-                <td className="py-1 tabular-nums">
+                <td className="py-1 pr-3 tabular-nums">
                   {formatGrade(s.gradePercent)}
+                </td>
+                <td className="py-1">
+                  {canSaveSegment(s) && (
+                    <SaveSegmentPopover
+                      activityId={activityId}
+                      sport={sport}
+                      sourceLabel="range"
+                      startLatitude={s.from.latitude as number}
+                      startLongitude={s.from.longitude as number}
+                      endLatitude={s.to.latitude as number}
+                      endLongitude={s.to.longitude as number}
+                      distanceMeters={
+                        s.distanceMi != null
+                          ? s.distanceMi * METERS_PER_MILE
+                          : null
+                      }
+                    />
+                  )}
                 </td>
               </tr>
             ))}

--- a/src/pages/GarminDetailPage.test.tsx
+++ b/src/pages/GarminDetailPage.test.tsx
@@ -170,6 +170,12 @@ vi.mock('@/components/garmin/ActivityLapsTable', () => ({
   ),
 }))
 
+vi.mock('@/components/garmin/SegmentAnalysis', () => ({
+  SegmentAnalysis: ({ points }: { points: unknown[] }) => (
+    <div data-testid="segment-analysis">segments:{points.length}</div>
+  ),
+}))
+
 import { GarminDetailPage } from './GarminDetailPage'
 
 describe('GarminDetailPage', () => {

--- a/src/pages/GarminDetailPage.tsx
+++ b/src/pages/GarminDetailPage.tsx
@@ -797,7 +797,11 @@ export function GarminDetailPage() {
                 onRemove={removeSavedPoint}
                 onClear={clearSavedPoints}
               />
-              <SegmentAnalysis points={savedPoints} />
+              <SegmentAnalysis
+                points={savedPoints}
+                activityId={activityId}
+                sport={a.sport}
+              />
             </>
           )}
         </TabsContent>


### PR DESCRIPTION
## Summary

Adds a "Save as segment" action to each **Segment Analysis** row on the Garmin
activity page, mirroring the existing lap and climb save flows. Users can now
turn any stretch between two saved points into a named Garmin segment.

This is a **UI-only** change — the API (`createGarminSegment`) and gateway
already support this input; no backend changes are required.

## Changes

- **SegmentAnalysis**: added `activityId` / `sport` props and a per-row
  `SaveSegmentPopover` built from the two saved endpoints' coordinates
  (`from`/`to`). The control only renders when both endpoints have finite
  coordinates. Segment distance is converted from miles to meters for the
  create input. Both `source_lap_index` and `source_climb_index` are null for
  these point-to-point segments.
- **SaveSegmentPopover**: added an optional `sourceLabel` prop so the
  unauthenticated prompt reads correctly for point-to-point ranges
  (`"Log in to save this range as a named segment."`). Defaults to the existing
  climb/lap derivation, so lap and climb behavior is unchanged.
- **GarminDetailPage**: threads `activityId` and `sport` into
  `SegmentAnalysis`.
- **Tests**: mock `SaveSegmentPopover` in the `SegmentAnalysis` tests with
  explicit render/gating assertions, add a `sourceLabel` test to the popover
  suite, and mock `SegmentAnalysis` in the page test (its import graph now
  pulls the auth-dependent popover).

## Validation

- `npm run type-check` — pass
- `npm run lint` — pass
- `npm run lint:spell` — pass
- `npm run build` — pass
- `npm run test:run` — 305 tests pass (48 files)

Refs: Garmin Segments feature (Project #10)