### PR TITLE
Improve Garmin segment route map

### DIFF
--- a/e2e/garmin-segment-route-map.spec.ts
+++ b/e2e/garmin-segment-route-map.spec.ts
@@ -1,0 +1,42 @@
+import { expect, test } from '@playwright/test'
+
+test.describe('Garmin segment route map', () => {
+  test('renders the source activity points for the saved segment route', async ({
+    page,
+  }) => {
+    const chartDataResponse = page.waitForResponse(async (response) => {
+      if (response.request().method() !== 'POST') return false
+
+      const body = response.request().postData() ?? ''
+      return body.includes('GarminChartData')
+    })
+
+    await page.goto('/garmin/segments/6')
+    await expect(
+      page.getByRole('heading', { name: 'Central Park 2' }),
+    ).toBeVisible({ timeout: 15_000 })
+
+    await chartDataResponse
+
+    const map = page.getByTestId('segment-map')
+    await expect(map).toBeVisible()
+
+    const routePaths = map.locator(
+      '.leaflet-overlay-pane svg path[fill="none"]',
+    )
+    await expect(async () => {
+      expect(await routePaths.count()).toBeGreaterThan(10)
+    }).toPass({ timeout: 10_000 })
+
+    const strokeColors = await routePaths.evaluateAll((paths) =>
+      Array.from(
+        new Set(
+          paths
+            .map((path) => path.getAttribute('stroke'))
+            .filter((stroke): stroke is string => stroke != null),
+        ),
+      ),
+    )
+    expect(strokeColors.length).toBeGreaterThan(1)
+  })
+})

--- a/src/components/garmin/SegmentEffortsLeaderboard.test.tsx
+++ b/src/components/garmin/SegmentEffortsLeaderboard.test.tsx
@@ -1,0 +1,58 @@
+import { render, screen, within } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { describe, expect, it } from 'vitest'
+import { SegmentEffortsLeaderboard } from './SegmentEffortsLeaderboard'
+import type { SegmentEffort } from './segmentEfforts'
+
+function effort(overrides: Partial<SegmentEffort>): SegmentEffort {
+  return {
+    rank: 1,
+    activity_id: 'activity',
+    sport: 'cycling',
+    activity_start_time: '2026-07-01T10:00:00Z',
+    effort_start: '2026-07-01T10:00:00Z',
+    effort_end: '2026-07-01T10:01:30Z',
+    elapsed_seconds: 90,
+    distance_km: 0.43,
+    avg_speed_kmh: 16,
+    avg_heart_rate: 150,
+    max_heart_rate: 160,
+    ...overrides,
+  }
+}
+
+function renderLeaderboard(efforts: SegmentEffort[]) {
+  render(
+    <MemoryRouter>
+      <SegmentEffortsLeaderboard efforts={efforts} />
+    </MemoryRouter>,
+  )
+}
+
+describe('SegmentEffortsLeaderboard', () => {
+  it('defaults to most recent sort', () => {
+    renderLeaderboard([
+      effort({
+        activity_id: 'fastest',
+        activity_start_time: '2026-07-01T10:00:00Z',
+        elapsed_seconds: 80,
+      }),
+      effort({
+        activity_id: 'newest',
+        activity_start_time: '2026-07-08T10:00:00Z',
+        elapsed_seconds: 95,
+      }),
+    ])
+
+    expect(screen.getByRole('button', { name: 'Most recent' })).toHaveClass(
+      'bg-primary',
+    )
+    expect(screen.getByRole('button', { name: 'Fastest' })).not.toHaveClass(
+      'bg-primary',
+    )
+
+    const rows = screen.getAllByTestId('segment-effort-row')
+    expect(within(rows[0]).getByText('Jul 8, 2026')).toBeVisible()
+    expect(within(rows[1]).getByText('Jul 1, 2026')).toBeVisible()
+  })
+})

--- a/src/components/garmin/SegmentEffortsLeaderboard.tsx
+++ b/src/components/garmin/SegmentEffortsLeaderboard.tsx
@@ -32,7 +32,7 @@ interface SegmentEffortsLeaderboardProps {
 export function SegmentEffortsLeaderboard({
   efforts,
 }: SegmentEffortsLeaderboardProps) {
-  const [sort, setSort] = useState<EffortSort>('time')
+  const [sort, setSort] = useState<EffortSort>('date')
 
   const bestActivityId = useMemo(() => bestEffortActivityId(efforts), [efforts])
   const sorted = useMemo(() => sortEfforts(efforts, sort), [efforts, sort])

--- a/src/components/garmin/SegmentStartEndMap.tsx
+++ b/src/components/garmin/SegmentStartEndMap.tsx
@@ -7,11 +7,40 @@ interface SegmentStartEndMapProps {
   startLon: number
   endLat: number
   endLon: number
+  routePoints?: Array<{
+    latitude: number
+    longitude: number
+    altitude?: number | null
+  }>
+}
+
+function elevationToColor(
+  elevation: number | null,
+  minElevation: number | null,
+  maxElevation: number | null,
+): string {
+  if (
+    elevation == null ||
+    minElevation == null ||
+    maxElevation == null ||
+    maxElevation <= minElevation
+  ) {
+    return '#2563eb'
+  }
+
+  const ratio = Math.min(
+    1,
+    Math.max(0, (elevation - minElevation) / (maxElevation - minElevation)),
+  )
+  if (ratio < 0.25) return '#2563eb'
+  if (ratio < 0.5) return '#16a34a'
+  if (ratio < 0.75) return '#f59e0b'
+  return '#dc2626'
 }
 
 /**
  * Compact preview map for a saved segment: green start marker, red finish
- * marker, and a dashed line between them, fitted to bounds. Uses vanilla
+ * marker, and the source route between them, fitted to bounds. Uses vanilla
  * Leaflet (circle markers) to avoid marker-icon asset setup, mirroring
  * {@link ActivityRouteMap}.
  */
@@ -20,6 +49,7 @@ export function SegmentStartEndMap({
   startLon,
   endLat,
   endLon,
+  routePoints = [],
 }: SegmentStartEndMapProps) {
   const mapRef = useRef<HTMLDivElement>(null)
   const mapInstanceRef = useRef<L.Map | null>(null)
@@ -39,13 +69,53 @@ export function SegmentStartEndMap({
       attribution: '&copy; OpenStreetMap contributors',
     }).addTo(map)
 
-    L.polyline(
-      [
-        [startLat, startLon],
-        [endLat, endLon],
-      ],
-      { color: '#6366f1', weight: 3, opacity: 0.8, dashArray: '6 6' },
-    ).addTo(map)
+    const routeLatLngs = routePoints.map(
+      (point) => [point.latitude, point.longitude] as L.LatLngTuple,
+    )
+    const hasRoute = routeLatLngs.length >= 2
+
+    if (hasRoute) {
+      const elevations = routePoints
+        .map((point) => point.altitude)
+        .filter(
+          (value): value is number => value != null && Number.isFinite(value),
+        )
+      const minElevation =
+        elevations.length > 0 ? Math.min(...elevations) : null
+      const maxElevation =
+        elevations.length > 0 ? Math.max(...elevations) : null
+
+      for (let index = 0; index < routePoints.length - 1; index++) {
+        const point = routePoints[index]
+        const nextPoint = routePoints[index + 1]
+
+        L.polyline(
+          [
+            [point.latitude, point.longitude],
+            [nextPoint.latitude, nextPoint.longitude],
+          ],
+          {
+            color: elevationToColor(
+              point.altitude ?? null,
+              minElevation,
+              maxElevation,
+            ),
+            weight: 5,
+            opacity: 0.95,
+            lineCap: 'butt',
+            lineJoin: 'round',
+          },
+        ).addTo(map)
+      }
+    } else {
+      L.polyline(
+        [
+          [startLat, startLon],
+          [endLat, endLon],
+        ],
+        { color: '#6366f1', weight: 3, opacity: 0.8, dashArray: '6 6' },
+      ).addTo(map)
+    }
 
     L.circleMarker([startLat, startLon], {
       radius: 7,
@@ -67,10 +137,14 @@ export function SegmentStartEndMap({
       .bindPopup('Finish')
       .addTo(map)
 
-    const bounds = L.latLngBounds([
-      [startLat, startLon],
-      [endLat, endLon],
-    ])
+    const bounds = L.latLngBounds(
+      hasRoute
+        ? routeLatLngs
+        : [
+            [startLat, startLon],
+            [endLat, endLon],
+          ],
+    )
     if (bounds.isValid()) {
       map.fitBounds(bounds, { padding: [40, 40], maxZoom: 16 })
     }
@@ -79,7 +153,7 @@ export function SegmentStartEndMap({
       map.remove()
       mapInstanceRef.current = null
     }
-  }, [startLat, startLon, endLat, endLon])
+  }, [startLat, startLon, endLat, endLon, routePoints])
 
   return (
     <div

--- a/src/components/garmin/segmentRoute.test.ts
+++ b/src/components/garmin/segmentRoute.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest'
+import { getSegmentRoutePoints } from './segmentRoute'
+
+describe('getSegmentRoutePoints', () => {
+  it('returns the inclusive source-track slice between segment endpoints', () => {
+    const points = [
+      { latitude: 40.0, longitude: -73.0, id: 'before' },
+      { latitude: 40.1, longitude: -73.1, id: 'start' },
+      { latitude: 40.2, longitude: -73.2, id: 'middle' },
+      { latitude: 40.3, longitude: -73.3, id: 'end' },
+      { latitude: 40.4, longitude: -73.4, id: 'after' },
+    ]
+
+    const route = getSegmentRoutePoints(
+      points,
+      { lat: 40.101, lon: -73.101 },
+      { lat: 40.299, lon: -73.299 },
+    )
+
+    expect(route.map((point) => point.id)).toEqual(['start', 'middle', 'end'])
+  })
+
+  it('keeps the route ordered by source activity even when endpoints are reversed', () => {
+    const points = [
+      { latitude: 40.0, longitude: -73.0, id: 'start' },
+      { latitude: 40.1, longitude: -73.1, id: 'middle' },
+      { latitude: 40.2, longitude: -73.2, id: 'end' },
+    ]
+
+    const route = getSegmentRoutePoints(
+      points,
+      { lat: 40.2, lon: -73.2 },
+      { lat: 40.0, lon: -73.0 },
+    )
+
+    expect(route.map((point) => point.id)).toEqual(['start', 'middle', 'end'])
+  })
+
+  it('drops points without usable coordinates', () => {
+    const route = getSegmentRoutePoints(
+      [
+        { latitude: null, longitude: -73.0, id: 'bad-start' },
+        { latitude: 40.1, longitude: -73.1, id: 'start' },
+        { latitude: Number.NaN, longitude: -73.2, id: 'bad-middle' },
+        { latitude: 40.3, longitude: -73.3, id: 'end' },
+      ],
+      { lat: 40.1, lon: -73.1 },
+      { lat: 40.3, lon: -73.3 },
+    )
+
+    expect(route.map((point) => point.id)).toEqual(['start', 'end'])
+  })
+})

--- a/src/components/garmin/segmentRoute.ts
+++ b/src/components/garmin/segmentRoute.ts
@@ -1,0 +1,70 @@
+export interface SegmentRoutePoint {
+  latitude?: number | null
+  longitude?: number | null
+}
+
+export interface SegmentRouteTarget {
+  lat: number
+  lon: number
+}
+
+function hasFiniteCoordinates(
+  point: SegmentRoutePoint,
+): point is SegmentRoutePoint & { latitude: number; longitude: number } {
+  return (
+    point.latitude != null &&
+    point.longitude != null &&
+    Number.isFinite(point.latitude) &&
+    Number.isFinite(point.longitude)
+  )
+}
+
+function squaredDistance(point: SegmentRoutePoint, target: SegmentRouteTarget) {
+  if (!hasFiniteCoordinates(point)) return Number.POSITIVE_INFINITY
+  return (
+    (point.latitude - target.lat) ** 2 + (point.longitude - target.lon) ** 2
+  )
+}
+
+function nearestPointIndex(
+  points: readonly SegmentRoutePoint[],
+  target: SegmentRouteTarget,
+): number | null {
+  let bestIndex: number | null = null
+  let bestDistance = Number.POSITIVE_INFINITY
+
+  points.forEach((point, index) => {
+    const distance = squaredDistance(point, target)
+    if (distance < bestDistance) {
+      bestDistance = distance
+      bestIndex = index
+    }
+  })
+
+  return bestIndex
+}
+
+/**
+ * Return the source-activity track slice that corresponds to a saved segment.
+ * Segment records store only start/end coordinates, so the route is recovered
+ * by snapping those coordinates to their nearest source track points.
+ */
+export function getSegmentRoutePoints<T extends SegmentRoutePoint>(
+  points: readonly T[],
+  start: SegmentRouteTarget,
+  end: SegmentRouteTarget,
+): Array<T & { latitude: number; longitude: number }> {
+  const validPoints = points.filter(
+    (point): point is T & { latitude: number; longitude: number } =>
+      hasFiniteCoordinates(point),
+  )
+  if (validPoints.length === 0) return []
+
+  const startIndex = nearestPointIndex(validPoints, start)
+  const endIndex = nearestPointIndex(validPoints, end)
+  if (startIndex == null || endIndex == null) return []
+
+  const from = Math.min(startIndex, endIndex)
+  const to = Math.max(startIndex, endIndex)
+  return validPoints.slice(from, to + 1)
+}

--- a/src/pages/GarminSegmentDetailPage.test.tsx
+++ b/src/pages/GarminSegmentDetailPage.test.tsx
@@ -7,12 +7,15 @@ import { GarminSegmentDetailPage } from './GarminSegmentDetailPage'
 const segmentHooks = vi.hoisted(() => ({
   useGarminSegmentQuery: vi.fn(),
   useGarminSegmentEffortsQuery: vi.fn(),
+  useGarminChartDataQuery: vi.fn(),
 }))
 
 vi.mock('@/__generated__/graphql', () => segmentHooks)
 vi.mock('@/lib/newrelic-browser', () => ({ setNRCustomAttribute: vi.fn() }))
 vi.mock('@/components/garmin/SegmentStartEndMap', () => ({
-  SegmentStartEndMap: () => <div data-testid="segment-map">map</div>,
+  SegmentStartEndMap: ({ routePoints = [] }: { routePoints?: unknown[] }) => (
+    <div data-testid="segment-map">map points: {routePoints.length}</div>
+  ),
 }))
 vi.mock('@/components/garmin/DeleteSegmentButton', () => ({
   DeleteSegmentButton: () => (
@@ -26,8 +29,8 @@ const segment = {
   sport: 'cycling',
   start_latitude: 40.79,
   start_longitude: -73.96,
-  end_latitude: 40.79,
-  end_longitude: -73.96,
+  end_latitude: 40.8,
+  end_longitude: -73.97,
   distance_meters: 508.1,
   match_tolerance_meters: 35,
   source_activity_id: '23493313338',
@@ -52,6 +55,11 @@ function renderDetail() {
 describe('GarminSegmentDetailPage', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    segmentHooks.useGarminChartDataQuery.mockReturnValue({
+      data: undefined,
+      loading: false,
+      error: undefined,
+    })
   })
 
   it('renders segment metadata, map, and leaderboard with a PR badge', () => {
@@ -67,8 +75,8 @@ describe('GarminSegmentDetailPage', () => {
           segment: {
             start_lat: 40.79,
             start_lon: -73.96,
-            end_lat: 40.79,
-            end_lon: -73.96,
+            end_lat: 40.8,
+            end_lon: -73.97,
             tolerance_meters: 35,
           },
           items: [
@@ -105,12 +113,40 @@ describe('GarminSegmentDetailPage', () => {
       loading: false,
       error: undefined,
     })
+    segmentHooks.useGarminChartDataQuery.mockReturnValue({
+      data: {
+        garminChartData: [
+          {
+            latitude: 40.78,
+            longitude: -73.95,
+            timestamp: '2025-07-04T11:59:00Z',
+          },
+          {
+            latitude: 40.79,
+            longitude: -73.96,
+            timestamp: '2025-07-04T12:00:00Z',
+          },
+          {
+            latitude: 40.795,
+            longitude: -73.965,
+            timestamp: '2025-07-04T12:00:30Z',
+          },
+          {
+            latitude: 40.8,
+            longitude: -73.97,
+            timestamp: '2025-07-04T12:01:00Z',
+          },
+        ],
+      },
+      loading: false,
+      error: undefined,
+    })
 
     renderDetail()
 
     expect(screen.getByRole('heading', { name: 'Harlem Hill' })).toBeVisible()
     expect(screen.getByText('2 matching efforts')).toBeVisible()
-    expect(screen.getByTestId('segment-map')).toBeVisible()
+    expect(screen.getByTestId('segment-map')).toHaveTextContent('map points: 3')
     expect(screen.getAllByTestId('segment-effort-row')).toHaveLength(2)
     // Exactly one PR badge, on the fastest effort.
     expect(screen.getAllByTestId('segment-effort-pr')).toHaveLength(1)

--- a/src/pages/GarminSegmentDetailPage.tsx
+++ b/src/pages/GarminSegmentDetailPage.tsx
@@ -1,9 +1,10 @@
-import { useEffect } from 'react'
+import { useEffect, useMemo } from 'react'
 import { Link, useNavigate, useParams } from 'react-router-dom'
 import { ArrowLeft } from 'lucide-react'
 import {
   useGarminSegmentQuery,
   useGarminSegmentEffortsQuery,
+  useGarminChartDataQuery,
 } from '@/__generated__/graphql'
 import { LoadingState } from '@/components/shared/LoadingState'
 import { ErrorState } from '@/components/shared/ErrorState'
@@ -18,6 +19,7 @@ import {
   formatTolerance,
   type SegmentEffort,
 } from '@/components/garmin/segmentEfforts'
+import { getSegmentRoutePoints } from '@/components/garmin/segmentRoute'
 import { setNRCustomAttribute } from '@/lib/newrelic-browser'
 
 const EFFORTS_LIMIT = 100
@@ -50,9 +52,27 @@ export function GarminSegmentDetailPage() {
   })
 
   const segment = segmentData?.garminSegment
+
+  const { data: sourceTrackData } = useGarminChartDataQuery({
+    variables: { activity_id: segment?.source_activity_id ?? '' },
+    skip: !segment?.source_activity_id,
+    fetchPolicy: 'no-cache',
+  })
+
   const efforts = (effortsData?.garminSegmentEfforts?.items ??
     []) as SegmentEffort[]
   const total = effortsData?.garminSegmentEfforts?.total ?? 0
+  const routePoints = useMemo(
+    () =>
+      segment
+        ? getSegmentRoutePoints(
+            sourceTrackData?.garminChartData ?? [],
+            { lat: segment.start_latitude, lon: segment.start_longitude },
+            { lat: segment.end_latitude, lon: segment.end_longitude },
+          )
+        : [],
+    [segment, sourceTrackData?.garminChartData],
+  )
 
   const backLink = (
     <Link
@@ -138,6 +158,7 @@ export function GarminSegmentDetailPage() {
               startLon={segment.start_longitude}
               endLat={segment.end_latitude}
               endLon={segment.end_longitude}
+              routePoints={routePoints}
             />
             <dl className="grid grid-cols-2 gap-x-4 gap-y-1 text-sm">
               <dt className="text-muted-foreground">Distance</dt>


### PR DESCRIPTION
## Summary

Refs #299

- Render saved Garmin segment maps from the source activity route instead of only the start/end coordinates.
- Color the segment route by elevation while preserving start and finish markers, with a dashed start/end fallback when source route data is unavailable.
- Default the segment effort leaderboard to Most recent and add focused coverage for the default sort.

## Root Cause

Saved segment records only store start/end coordinates, so the detail map previously drew a direct preview line. The UI was not using the segment's source activity track to recover the actual route geometry.

## Validation

- `npm run test:run` — 50 files / 309 tests passed
- `npm run type-check`
- `npm run build` — passed; existing large chunk warning emitted
- `npm run lint:all`
- `BASE_URL=http://localhost:5173 npx playwright test e2e/garmin-segment-route-map.spec.ts --project=chromium`
- Browser smoke check confirmed `/garmin/segments/6` defaults the leaderboard to Most recent
