### PR TITLE
fix(sonar): resolve critical S1186 and S3735 issues (batch 1)

### DIFF
--- a/src/components/dashboard/GarminActivityTotals.tsx
+++ b/src/components/dashboard/GarminActivityTotals.tsx
@@ -172,12 +172,11 @@ interface ChartBucket {
   total_calories: number
 }
 
-function getDateRange(period: 'year'): {
+function getDateRange(): {
   date_from?: string
   date_to?: string
 } {
-  // 'year' — let the API return all available history
-  void period
+  // 'year' period — let the API return all available history
   return {}
 }
 
@@ -255,7 +254,7 @@ export function GarminActivityTotals() {
       }
     }
     if (period === 'year') {
-      return getDateRange('year')
+      return getDateRange()
     }
     // 'week' uses a separate per-year fetch path; no main-query range.
     return {}

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -25,9 +25,15 @@ Object.defineProperty(window, 'matchMedia', {
 })
 
 class ResizeObserverMock {
-  observe() {}
-  unobserve() {}
-  disconnect() {}
+  observe() {
+    // no-op: jsdom does not implement ResizeObserver
+  }
+  unobserve() {
+    // no-op: jsdom does not implement ResizeObserver
+  }
+  disconnect() {
+    // no-op: jsdom does not implement ResizeObserver
+  }
 }
 
 vi.stubGlobal('ResizeObserver', ResizeObserverMock)


### PR DESCRIPTION
## Summary

First batch of fixes for the 10 HIGH-impact (CRITICAL) SonarQube issues on [`otel-data-ui`](https://sonar.lab.informationcart.com/dashboard?id=otel-data-ui&codeScope=overall). This PR covers the low-risk, mechanical fixes; the cognitive-complexity refactors (`S3776` × 5, `S2004` × 1) will follow in separate PRs.

Refs #313

## Changes

- **`S1186` × 3** — `src/test/setup.ts`: added `no-op` explanatory comments to the empty `ResizeObserver` mock methods (`observe`/`unobserve`/`disconnect`).
- **`S3735` × 1** — `src/components/dashboard/GarminActivityTotals.tsx`: removed the unused `period` parameter and its `void period` statement from `getDateRange()`, and updated the single call site.

## Validation

- ✅ `npm run type-check`
- ✅ `npm run lint:all` (ESLint + markdownlint + cspell + prettier)
- ✅ `npm run build`
- ✅ `npm run test:run` — 311/311 tests pass

## Risk

Very low. No behavioral change — the mock methods remain no-ops, and `getDateRange` always returned `{}` regardless of the removed parameter.

## Follow-up

- Batch 2+: `S3776` cognitive-complexity refactors in `DailySummaryDetailPage.tsx`, `ActivityStatsPanel.tsx`, `GarminDetailPage.tsx`, `lapComparison.ts`, `GarminActivityTotals.tsx`, and the `S2004` nesting refactor.