### PR TITLE
refactor(sonar): finish clearing S3776 criticals (batch 5)

### DIFF
--- a/src/components/garmin/lapComparison.ts
+++ b/src/components/garmin/lapComparison.ts
@@ -191,6 +191,21 @@ function computeLapCount(items: ComparisonItem[]): number {
   }, 0)
 }
 
+// Finite metric values for a single lap column across all activities.
+function collectColumnValues(
+  items: ComparisonItem[],
+  def: MetricDef,
+  lapIndex: number,
+): number[] {
+  const values: number[] = []
+  for (const item of items) {
+    const lap = item.laps.find((l) => l.lap_index === lapIndex)
+    const v = lap ? def.extract(lap) : null
+    if (v != null && Number.isFinite(v)) values.push(v)
+  }
+  return values
+}
+
 // Per-column min/max/best/worst stats used for heat-map scoring and summaries.
 // A column with no finite values yields null.
 function computeColumnStats(
@@ -200,12 +215,7 @@ function computeColumnStats(
 ): (ColumnStat | null)[] {
   const colStats: (ColumnStat | null)[] = []
   for (let c = 1; c <= lapCount; c++) {
-    const values: number[] = []
-    for (const item of items) {
-      const lap = item.laps.find((l) => l.lap_index === c)
-      const v = lap ? def.extract(lap) : null
-      if (v != null && Number.isFinite(v)) values.push(v)
-    }
+    const values = collectColumnValues(items, def, c)
     if (values.length === 0) {
       colStats.push(null)
       continue

--- a/src/pages/GarminDetailPage.tsx
+++ b/src/pages/GarminDetailPage.tsx
@@ -370,6 +370,38 @@ function buildTrackPointsCsv(
   return [EXPORT_CSV_HEADERS.join(','), ...rows].join('\n')
 }
 
+// Climb-related GeoJSON properties for a track point, defaulting to
+// null/false when the point falls outside any climb window.
+function buildClimbGeoJsonProperties(marker: ClimbExportMarker | undefined) {
+  return {
+    is_climb_point: marker?.isClimbPoint ?? false,
+    climb_id: marker?.climbId ?? null,
+    climb_index: marker?.climbIndex ?? null,
+    climb_label: marker?.climbLabel ?? null,
+    climb_type: marker?.climbType ?? null,
+    climb_difficulty: marker?.climbDifficulty ?? null,
+  }
+}
+
+// Geocode/address GeoJSON properties for a track point, defaulting missing
+// fields to null.
+function buildAddressGeoJsonProperties(address: GarminExportPoint['address']) {
+  return {
+    geocode_status: address?.status ?? null,
+    confidence: address?.confidence ?? null,
+    waypoint_kind: address?.waypoint_kind ?? null,
+    display_address: address?.display_address ?? null,
+    street: address?.street ?? null,
+    housenumber: address?.housenumber ?? null,
+    neighbourhood: address?.neighbourhood ?? null,
+    locality: address?.locality ?? null,
+    region: address?.region ?? null,
+    country: address?.country ?? null,
+    postalcode: address?.postalcode ?? null,
+    geocoded_at: address?.geocoded_at ?? null,
+  }
+}
+
 function buildTrackPointsGeoJson(
   points: GarminExportPoint[],
   climbMarkers: Map<number, ClimbExportMarker>,
@@ -396,27 +428,11 @@ function buildTrackPointsGeoJson(
           respiration_rate: p.respiration_rate,
           cadence: p.cadence,
           temperature_c: p.temperature_c,
-          is_climb_point: marker?.isClimbPoint ?? false,
-          climb_id: marker?.climbId ?? null,
-          climb_index: marker?.climbIndex ?? null,
-          climb_label: marker?.climbLabel ?? null,
-          climb_type: marker?.climbType ?? null,
-          climb_difficulty: marker?.climbDifficulty ?? null,
+          ...buildClimbGeoJsonProperties(marker),
           surface_type: p.surface_type,
           effort_level: p.effort_level,
           created_at: p.created_at,
-          geocode_status: p.address?.status ?? null,
-          confidence: p.address?.confidence ?? null,
-          waypoint_kind: p.address?.waypoint_kind ?? null,
-          display_address: p.address?.display_address ?? null,
-          street: p.address?.street ?? null,
-          housenumber: p.address?.housenumber ?? null,
-          neighbourhood: p.address?.neighbourhood ?? null,
-          locality: p.address?.locality ?? null,
-          region: p.address?.region ?? null,
-          country: p.address?.country ?? null,
-          postalcode: p.address?.postalcode ?? null,
-          geocoded_at: p.address?.geocoded_at ?? null,
+          ...buildAddressGeoJsonProperties(p.address),
         },
       }
     }),


### PR DESCRIPTION
## Summary

Finishes the SonarQube CRITICAL cleanup. A post-merge `make sonar` re-scan (after batch 4, #320) showed **2 CRITICALs remain** — both `S3776` in helpers that batch 4 extracted but which themselves landed just over 15. This PR clears them, bringing the project's HIGH-severity count to **0**.

Refs #322

## Changes (no behavioral change)

- **`lapComparison.ts`** — `computeColumnStats` was 16 due to a nested per-column value-collection loop. Extracted that loop into `collectColumnValues(items, def, lapIndex)`.
- **`GarminDetailPage.tsx`** — `buildTrackPointsGeoJson` was 17 from ~18 `?? null` operators (SonarQube's TS analyzer counts nullish-coalescing toward cognitive complexity). Split the climb and address property groups into `buildClimbGeoJsonProperties(marker)` and `buildAddressGeoJsonProperties(address)`, spread in place — GeoJSON shape/key order unchanged.

## Validation

- ✅ `npm run type-check`
- ✅ `npm run lint:all` (ESLint + markdownlint + cspell + prettier)
- ✅ `npm run build`
- ✅ `npm run test:run` — 311/311 tests pass (affected suites `lapComparison`, `GarminDetailPage`, `LapComparisonPage` = 36/36)

## Verification note

Please confirm with `make sonar` after merge — this should take the project's HIGH-severity CRITICAL count to **0**. (No reliable offline analyzer matches the server's calc.)

## What's next

CRITICAL tier done. Remaining tiers for future PRs: **MAJOR (~59)** and **MINOR (~85)**.