### PR TITLE
refactor(sonar): reduce GarminDetailPage component complexity (batch 6)

### DIFF
--- a/src/pages/GarminDetailPage.tsx
+++ b/src/pages/GarminDetailPage.tsx
@@ -461,6 +461,61 @@ function exportGarminTrackPoints(
   )
 }
 
+// Resolve which climb is selected: none when there are no climbs, the current
+// selection when it still exists, otherwise the first climb.
+function resolveSelectedClimbId(
+  mainClimbs: ActivityClimb[],
+  selectedClimbId: number | null,
+): number | null {
+  if (mainClimbs.length === 0) return null
+  if (
+    selectedClimbId != null &&
+    mainClimbs.some((climb) => climb.id === selectedClimbId)
+  ) {
+    return selectedClimbId
+  }
+  return mainClimbs[0].id
+}
+
+// Whether the activity has any usable heart-rate data (summary or samples).
+function computeHasHrData(
+  avgHeartRate: number | null | undefined,
+  maxHeartRate: number | null | undefined,
+  chartPoints: { heart_rate?: number | null }[],
+): boolean {
+  return (
+    avgHeartRate != null ||
+    maxHeartRate != null ||
+    chartPoints.some((point) => point.heart_rate != null)
+  )
+}
+
+// Whether the currently displayed point is in the saved set (by timestamp).
+function isSavedPoint(
+  point: ChartDataPoint | null,
+  savedPoints: SavedPoint[],
+): boolean {
+  return point != null && savedPoints.some((p) => p.id === point.timestamp)
+}
+
+// Saved points that have finite coordinates, shaped for the map layer.
+function toSavedMapPoints(savedPoints: SavedPoint[]) {
+  return savedPoints
+    .filter(
+      (p) =>
+        p.latitude != null &&
+        p.longitude != null &&
+        Number.isFinite(p.latitude) &&
+        Number.isFinite(p.longitude),
+    )
+    .map((p) => ({
+      id: p.id,
+      lat: p.latitude as number,
+      lng: p.longitude as number,
+      color: p.color,
+    }))
+}
+
 export function GarminDetailPage() {
   const { activityId } = useParams<{ activityId: string }>()
   const location = useLocation()
@@ -655,13 +710,10 @@ export function GarminDetailPage() {
   useEffect(() => {
     mainClimbsRef.current = mainClimbs
   }, [mainClimbs])
-  const effectiveSelectedClimbId =
-    mainClimbs.length === 0
-      ? null
-      : selectedClimbId != null &&
-          mainClimbs.some((climb) => climb.id === selectedClimbId)
-        ? selectedClimbId
-        : mainClimbs[0].id
+  const effectiveSelectedClimbId = resolveSelectedClimbId(
+    mainClimbs,
+    selectedClimbId,
+  )
   const selectedClimbIndex = mainClimbs.findIndex(
     (climb) => climb.id === effectiveSelectedClimbId,
   )
@@ -685,29 +737,15 @@ export function GarminDetailPage() {
   const a = data?.garminActivity
   if (!a) return <ErrorState message="Activity not found" />
 
-  const hasHrData =
-    a.avg_heart_rate != null ||
-    a.max_heart_rate != null ||
-    chartPoints.some((point) => point.heart_rate != null)
+  const hasHrData = computeHasHrData(
+    a.avg_heart_rate,
+    a.max_heart_rate,
+    chartPoints,
+  )
   const trackLoading = mapTrackLoading || chartLoading
   const displayPoint = activePoint
-  const displayPointSaved =
-    displayPoint != null &&
-    savedPoints.some((p) => p.id === displayPoint.timestamp)
-  const savedMapPoints = savedPoints
-    .filter(
-      (p) =>
-        p.latitude != null &&
-        p.longitude != null &&
-        Number.isFinite(p.latitude) &&
-        Number.isFinite(p.longitude),
-    )
-    .map((p) => ({
-      id: p.id,
-      lat: p.latitude as number,
-      lng: p.longitude as number,
-      color: p.color,
-    }))
+  const displayPointSaved = isSavedPoint(displayPoint, savedPoints)
+  const savedMapPoints = toSavedMapPoints(savedPoints)
 
   return (
     <div className="space-y-6">

--- a/src/pages/GarminDetailPage.tsx
+++ b/src/pages/GarminDetailPage.tsx
@@ -61,9 +61,9 @@ function toRadians(degrees: number): number {
   return (degrees * Math.PI) / 180
 }
 
-function isFiniteCoordinate(
-  point: ActivityChartTrackPoint,
-): point is ActivityChartTrackPoint & { latitude: number; longitude: number } {
+function isFiniteCoordinate<
+  T extends { latitude?: number | null; longitude?: number | null },
+>(point: T): point is T & { latitude: number; longitude: number } {
   return (
     point.latitude != null &&
     point.longitude != null &&
@@ -481,7 +481,7 @@ function resolveSelectedClimbId(
 function computeHasHrData(
   avgHeartRate: number | null | undefined,
   maxHeartRate: number | null | undefined,
-  chartPoints: { heart_rate?: number | null }[],
+  chartPoints: ActivityChartTrackPoint[],
 ): boolean {
   return (
     avgHeartRate != null ||
@@ -498,22 +498,21 @@ function isSavedPoint(
   return point != null && savedPoints.some((p) => p.id === point.timestamp)
 }
 
+interface SavedMapPoint {
+  id: string
+  lat: number
+  lng: number
+  color: string
+}
+
 // Saved points that have finite coordinates, shaped for the map layer.
-function toSavedMapPoints(savedPoints: SavedPoint[]) {
-  return savedPoints
-    .filter(
-      (p) =>
-        p.latitude != null &&
-        p.longitude != null &&
-        Number.isFinite(p.latitude) &&
-        Number.isFinite(p.longitude),
-    )
-    .map((p) => ({
-      id: p.id,
-      lat: p.latitude as number,
-      lng: p.longitude as number,
-      color: p.color,
-    }))
+function toSavedMapPoints(savedPoints: SavedPoint[]): SavedMapPoint[] {
+  return savedPoints.filter(isFiniteCoordinate).map((p) => ({
+    id: p.id,
+    lat: p.latitude,
+    lng: p.longitude,
+    color: p.color,
+  }))
 }
 
 export function GarminDetailPage() {


### PR DESCRIPTION
## Summary

The genuine last CRITICAL. A post-merge `make sonar` after batch 5 (#323) still shows 1 `S3776` open: the **`GarminDetailPage` component itself** at complexity **17**.

This was the original batch-4 target. Batch 4's export-helper extraction didn't reduce it because SonarJS analyzes nested functions (`handleExport`, useCallback/useMemo bodies) **separately** — only the component's **direct-body** control flow counts. The flagged line drifted (261 → 448 → 464) as helpers were added above it, which is why batch 5 mistakenly split `buildTrackPointsGeoJson` (still a valid improvement; `computeColumnStats` was the real batch-5 fix).

Refs #324

## Changes (no behavioral change)

Extracted the direct-body ternary/logical expressions into pure module helpers:

- `resolveSelectedClimbId(mainClimbs, selectedClimbId)` — the nested selected-climb ternary (−3)
- `computeHasHrData(avgHr, maxHr, chartPoints)` — the HR `||` chain (−1)
- `isSavedPoint(point, savedPoints)` — the `displayPointSaved` `&&` (−1)
- `toSavedMapPoints(savedPoints)` — the saved-points filter/map (cleanup)

Net ≈ −5 on the component's own complexity (17 → ~12).

## Validation

- ✅ `npm run type-check`
- ✅ `npm run lint:all`
- ✅ `npm run build`
- ✅ `npm run test:run` — 311/311 (GarminDetailPage suite 21/21)

## Verification note

Please confirm with `make sonar` after merge — this should finally take the project's HIGH-severity CRITICAL count to **0**. If it's still marginally over, I'll extract one or two more direct-body items.

## What's next

CRITICAL tier complete after this. Remaining: **MAJOR (~59)**, **MINOR (~85)** — future PRs.