### PR TITLE
fix(sonar): associate form labels with controls — S6853 (major batch 1)

### DIFF
--- a/src/components/spatial/ReverseGeocode.tsx
+++ b/src/components/spatial/ReverseGeocode.tsx
@@ -51,8 +51,14 @@ export function ReverseGeocode() {
       <CardContent className="space-y-4">
         <div className="grid grid-cols-2 gap-2">
           <div>
-            <label className="text-xs text-muted-foreground">Latitude</label>
+            <label
+              htmlFor="reverse-geocode-lat"
+              className="text-xs text-muted-foreground"
+            >
+              Latitude
+            </label>
             <input
+              id="reverse-geocode-lat"
               type="text"
               value={lat}
               onChange={(e) => setLat(e.target.value)}
@@ -60,8 +66,14 @@ export function ReverseGeocode() {
             />
           </div>
           <div>
-            <label className="text-xs text-muted-foreground">Longitude</label>
+            <label
+              htmlFor="reverse-geocode-lon"
+              className="text-xs text-muted-foreground"
+            >
+              Longitude
+            </label>
             <input
+              id="reverse-geocode-lon"
               type="text"
               value={lon}
               onChange={(e) => setLon(e.target.value)}

--- a/src/pages/SpatialPage.tsx
+++ b/src/pages/SpatialPage.tsx
@@ -77,10 +77,14 @@ export function SpatialPage() {
               <CardContent className="space-y-4">
                 <div className="grid grid-cols-3 gap-2">
                   <div>
-                    <label className="text-xs text-muted-foreground">
+                    <label
+                      htmlFor="nearby-lat"
+                      className="text-xs text-muted-foreground"
+                    >
                       Latitude
                     </label>
                     <input
+                      id="nearby-lat"
                       type="text"
                       value={nearbyLat}
                       onChange={(e) => setNearbyLat(e.target.value)}
@@ -88,10 +92,14 @@ export function SpatialPage() {
                     />
                   </div>
                   <div>
-                    <label className="text-xs text-muted-foreground">
+                    <label
+                      htmlFor="nearby-lon"
+                      className="text-xs text-muted-foreground"
+                    >
                       Longitude
                     </label>
                     <input
+                      id="nearby-lon"
                       type="text"
                       value={nearbyLon}
                       onChange={(e) => setNearbyLon(e.target.value)}
@@ -99,10 +107,14 @@ export function SpatialPage() {
                     />
                   </div>
                   <div>
-                    <label className="text-xs text-muted-foreground">
+                    <label
+                      htmlFor="nearby-radius"
+                      className="text-xs text-muted-foreground"
+                    >
                       Radius (m)
                     </label>
                     <input
+                      id="nearby-radius"
                       type="text"
                       value={nearbyRadius}
                       onChange={(e) => setNearbyRadius(e.target.value)}
@@ -157,10 +169,14 @@ export function SpatialPage() {
               <CardContent className="space-y-4">
                 <div className="grid grid-cols-2 gap-2">
                   <div>
-                    <label className="text-xs text-muted-foreground">
+                    <label
+                      htmlFor="distance-from-lat"
+                      className="text-xs text-muted-foreground"
+                    >
                       From Lat
                     </label>
                     <input
+                      id="distance-from-lat"
                       type="text"
                       value={fromLat}
                       onChange={(e) => setFromLat(e.target.value)}
@@ -168,10 +184,14 @@ export function SpatialPage() {
                     />
                   </div>
                   <div>
-                    <label className="text-xs text-muted-foreground">
+                    <label
+                      htmlFor="distance-from-lon"
+                      className="text-xs text-muted-foreground"
+                    >
                       From Lon
                     </label>
                     <input
+                      id="distance-from-lon"
                       type="text"
                       value={fromLon}
                       onChange={(e) => setFromLon(e.target.value)}
@@ -179,10 +199,14 @@ export function SpatialPage() {
                     />
                   </div>
                   <div>
-                    <label className="text-xs text-muted-foreground">
+                    <label
+                      htmlFor="distance-to-lat"
+                      className="text-xs text-muted-foreground"
+                    >
                       To Lat
                     </label>
                     <input
+                      id="distance-to-lat"
                       type="text"
                       value={toLat}
                       onChange={(e) => setToLat(e.target.value)}
@@ -190,10 +214,14 @@ export function SpatialPage() {
                     />
                   </div>
                   <div>
-                    <label className="text-xs text-muted-foreground">
+                    <label
+                      htmlFor="distance-to-lon"
+                      className="text-xs text-muted-foreground"
+                    >
                       To Lon
                     </label>
                     <input
+                      id="distance-to-lon"
                       type="text"
                       value={toLon}
                       onChange={(e) => setToLon(e.target.value)}


### PR DESCRIPTION
## Summary

First **MAJOR-tier** SonarQube batch (the CRITICAL tier is done). Fixes all 9 `S6853` — "A form label must be associated with a control" — an accessibility improvement in the spatial tools.

Refs #326

## Changes (no behavioral change)

Each flagged `<label>` sat above an unassociated `<input>`. Added a unique `id` to each input and a matching `htmlFor` on its label:

- **`src/pages/SpatialPage.tsx`** — Nearby Points (lat/lon/radius) and Distance Calculator (from/to lat/lon) → `nearby-lat`, `nearby-lon`, `nearby-radius`, `distance-from-lat`, `distance-from-lon`, `distance-to-lat`, `distance-to-lon`.
- **`src/components/spatial/ReverseGeocode.tsx`** — lat/lon → `reverse-geocode-lat`, `reverse-geocode-lon`.

## Validation

- ✅ `npm run type-check`
- ✅ `npm run lint:all`
- ✅ `npm run build`
- ✅ `npm run test:run` — 311/311 (spatial suites `SpatialPage`, `SpatialTools` pass)
- Verified no `<label className="text-xs text-muted-foreground">` without association remains.

Confirm with `make sonar` after merge — `S6853` should drop to 0.

## What's next

More MAJOR batches to follow: `S3358` (nested ternaries ×17), `S6772` (JSX spacing ×8), `S6478` (nested components ×5), `S6582` (optional chaining ×5), then the MINOR tier (`S6759` readonly props ×51, etc.).