### PR TITLE
fix(sonar): prefer optional chaining — S6582 (major batch 2)

### DIFF
--- a/src/components/dashboard/GarminActivityHeatmap.tsx
+++ b/src/components/dashboard/GarminActivityHeatmap.tsx
@@ -32,7 +32,7 @@ interface HeatmapValue {
 type HeatmapCallbackValue = { date: string; [key: string]: unknown } | undefined
 
 function getColorClass(value: HeatmapCallbackValue): string {
-  if (!value || !value.count) return 'color-empty'
+  if (!value?.count) return 'color-empty'
   const count = value.count as number
   if (count === 1) return 'color-scale-1'
   if (count === 2) return 'color-scale-2'
@@ -41,7 +41,7 @@ function getColorClass(value: HeatmapCallbackValue): string {
 }
 
 function getTitleForValue(value: HeatmapCallbackValue): string {
-  if (!value || !value.date) return 'No activities'
+  if (!value?.date) return 'No activities'
   const count = (value.count as number) ?? 0
   if (count === 0) return `No activities on ${value.date}`
   return `${count} ${count === 1 ? 'activity' : 'activities'} on ${value.date}`
@@ -154,7 +154,7 @@ export function GarminActivityHeatmap() {
               showWeekdayLabels
               gutterSize={2}
               onClick={(value: HeatmapCallbackValue) => {
-                if (!value || !value.date || !value.count) return
+                if (!value?.date || !value?.count) return
                 setAnchorPos(pendingAnchor.current)
                 setSelectedDate(value.date)
                 setPopoverOpen(true)

--- a/src/components/garmin/ActivityHoverDetails.tsx
+++ b/src/components/garmin/ActivityHoverDetails.tsx
@@ -35,17 +35,18 @@ interface CoordKey {
 }
 
 function coordKey(point: ChartDataPoint | null): CoordKey | null {
+  const latitude = point?.latitude
+  const longitude = point?.longitude
   if (
-    !point ||
-    point.latitude == null ||
-    point.longitude == null ||
-    !Number.isFinite(point.latitude) ||
-    !Number.isFinite(point.longitude)
+    latitude == null ||
+    longitude == null ||
+    !Number.isFinite(latitude) ||
+    !Number.isFinite(longitude)
   ) {
     return null
   }
-  const lat = roundCoord(point.latitude)
-  const lon = roundCoord(point.longitude)
+  const lat = roundCoord(latitude)
+  const lon = roundCoord(longitude)
   return { key: `${lat},${lon}`, lat, lon }
 }
 
@@ -97,7 +98,7 @@ export function ActivityHoverDetails({
       const cached = addressCache.get(target.key)
       return cached ? { status: 'ok', label: cached } : { status: 'empty' }
     }
-    if (pendingState && pendingState.key === target.key) {
+    if (pendingState?.key === target.key) {
       return pendingState.state
     }
     return { status: 'loading' }


### PR DESCRIPTION
## Summary

MAJOR-tier batch 2. Fixes all 5 `S6582` — "Prefer using an optional chain expression" — across two dashboard/garmin components.

Refs #329

## Changes (no behavioral change)

- **`GarminActivityHeatmap.tsx`** — `!value || !value.count` → `!value?.count` (and `!value?.date`, and `!value?.date || !value?.count`) in `getColorClass`, `getTitleForValue`, and the heatmap `onClick`. TypeScript still narrows `value` to non-nullish on the truthy branch, so the following `value.count` / `value.date` accesses remain valid.
- **`ActivityHoverDetails.tsx`** — `coordKey` now lifts `point?.latitude` / `point?.longitude` into locals before validating (optional chaining + preserved narrowing); `pendingState && pendingState.key === target.key` → `pendingState?.key === target.key`.

## Validation

- ✅ `npm run type-check`
- ✅ `npm run lint:all`
- ✅ `npm run build`
- ✅ `npm run test:run` — 311/311 (affected suites pass)

Confirm with `make sonar` after merge — `S6582` should drop to 0.

## Next

Largest remaining MAJOR rule: `S3358` (nested ternaries ×17) — dedicated batch to follow.