### PR TITLE
refactor(sonar): extract value-expression nested ternaries — S3358 (major batch 3a)

### DIFF
--- a/src/components/dashboard/CyclingInFocus.tsx
+++ b/src/components/dashboard/CyclingInFocus.tsx
@@ -28,6 +28,11 @@ const RECENT_DAYS = 28
 // Weekday initial keyed by Date#getDay() (0 = Sunday).
 const DAY_INITIALS = ['S', 'M', 'T', 'W', 'T', 'F', 'S']
 
+// Pluralize the recent-ride count word.
+function pluralizeRides(count: number): string {
+  return count === 1 ? 'ride' : 'rides'
+}
+
 interface DayBucket {
   /** ISO date for the bucket (yyyy-MM-dd). */
   date: string
@@ -297,9 +302,7 @@ export function CyclingInFocus() {
               <span className="block text-xs text-muted-foreground">
                 {recentLoading
                   ? 'Loading…'
-                  : `Last 4w · ${recentRideCount} ${
-                      recentRideCount === 1 ? 'ride' : 'rides'
-                    }`}
+                  : `Last 4w · ${recentRideCount} ${pluralizeRides(recentRideCount)}`}
               </span>
             </div>
           </>

--- a/src/components/dashboard/CyclingInFocus.tsx
+++ b/src/components/dashboard/CyclingInFocus.tsx
@@ -285,9 +285,7 @@ export function CyclingInFocus() {
               <div
                 data-testid="in-focus-activity-strip"
                 className="flex items-center justify-between"
-                aria-label={`${recentRideCount} ride${
-                  recentRideCount === 1 ? '' : 's'
-                } in the last 4 weeks`}
+                aria-label={`${recentRideCount} ${pluralizeRides(recentRideCount)} in the last 4 weeks`}
               >
                 {recentDays.map((day) => (
                   <span

--- a/src/components/garmin/ActivityChartData.ts
+++ b/src/components/garmin/ActivityChartData.ts
@@ -81,11 +81,10 @@ export function toChartDataPoint(
   hasReliableDistance: boolean,
 ): ChartDataPoint {
   return {
-    distance: hasReliableDistance
-      ? pt.distance_from_start_km != null
+    distance:
+      hasReliableDistance && pt.distance_from_start_km != null
         ? kmToMi(pt.distance_from_start_km)
-        : null
-      : null,
+        : null,
     distanceKm: pt.distance_from_start_km ?? null,
     time: (new Date(pt.timestamp).getTime() - startTime) / 60000,
     elevation: pt.altitude != null ? metersToFeet(pt.altitude) : null,

--- a/src/components/garmin/ActivityCharts.tsx
+++ b/src/components/garmin/ActivityCharts.tsx
@@ -140,18 +140,20 @@ function ChartTooltip({ label, payload, chart, xMode }: ChartTooltipProps) {
   )
 }
 
+// Recharts 3 may emit the tooltip index as a string; normalize it to a number.
+function normalizeTooltipIndex(
+  raw: number | string | null | undefined,
+): number {
+  if (typeof raw === 'number') return raw
+  if (typeof raw === 'string' && raw !== '') return Number(raw)
+  return NaN
+}
+
 function pointFromTooltipState(
   state: { activeTooltipIndex?: number | string | null } | undefined,
   chartData: ChartDataPoint[],
 ): ChartDataPoint | null {
-  const raw = state?.activeTooltipIndex
-  // Recharts 3 may emit the index as a string; normalize it.
-  const i =
-    typeof raw === 'number'
-      ? raw
-      : typeof raw === 'string' && raw !== ''
-        ? Number(raw)
-        : NaN
+  const i = normalizeTooltipIndex(state?.activeTooltipIndex)
 
   return Number.isInteger(i) && chartData[i] ? chartData[i] : null
 }
@@ -216,6 +218,7 @@ export function ActivityCharts({
     xMode === 'distance' && !hasReliableDistance ? 'time' : xMode
   const xKey = effectiveXMode === 'distance' ? 'distance' : 'time'
   const xLabel = effectiveXMode === 'distance' ? 'Distance (mi)' : 'Time (min)'
+  const xTickDigits = effectiveXMode === 'distance' ? 1 : 0
   const activeX =
     activePoint?.[xKey] != null && Number.isFinite(activePoint[xKey])
       ? activePoint[xKey]
@@ -485,9 +488,7 @@ export function ActivityCharts({
                   type="number"
                   domain={[0, 'dataMax']}
                   tickFormatter={(v: number) =>
-                    v != null
-                      ? v.toFixed(effectiveXMode === 'distance' ? 1 : 0)
-                      : ''
+                    v != null ? v.toFixed(xTickDigits) : ''
                   }
                   label={{
                     value: xLabel,

--- a/src/components/garmin/ActivityCharts.tsx
+++ b/src/components/garmin/ActivityCharts.tsx
@@ -145,7 +145,10 @@ function normalizeTooltipIndex(
   raw: number | string | null | undefined,
 ): number {
   if (typeof raw === 'number') return raw
-  if (typeof raw === 'string' && raw !== '') return Number(raw)
+  if (typeof raw === 'string') {
+    const trimmed = raw.trim()
+    return trimmed === '' ? NaN : Number(trimmed)
+  }
   return NaN
 }
 

--- a/src/components/garmin/ActivityHoverDetails.tsx
+++ b/src/components/garmin/ActivityHoverDetails.tsx
@@ -169,18 +169,7 @@ export function ActivityHoverDetails({
             label="Time"
             value={`${timeStr} (${point.time.toFixed(1)} min)`}
           />
-          <Field
-            label="Distance"
-            value={
-              point.distance != null
-                ? `${point.distance.toFixed(2)} mi${
-                    point.distanceKm != null
-                      ? ` (${point.distanceKm.toFixed(2)} km)`
-                      : ''
-                  }`
-                : '—'
-            }
-          />
+          <Field label="Distance" value={formatHoverDistance(point)} />
           <Field
             label="Lat/Lon"
             value={
@@ -221,6 +210,14 @@ function renderAddress(state: AddressState): string {
     default:
       return '—'
   }
+}
+
+// Format the hover distance in miles, appending the km value when available.
+function formatHoverDistance(point: ChartDataPoint): string {
+  if (point.distance == null) return '—'
+  const km =
+    point.distanceKm != null ? ` (${point.distanceKm.toFixed(2)} km)` : ''
+  return `${point.distance.toFixed(2)} mi${km}`
 }
 
 function Field({ label, value }: { label: string; value: string }) {

--- a/src/components/garmin/ActivityStatsPanel.tsx
+++ b/src/components/garmin/ActivityStatsPanel.tsx
@@ -241,6 +241,16 @@ function TrainingEffectGraphic({
   )
 }
 
+// Format the observed HR range for a zone, collapsing equal min/max to a single
+// value and returning null when either bound is missing.
+function formatObservedRange(
+  min: number | null | undefined,
+  max: number | null | undefined,
+): string | null {
+  if (min == null || max == null) return null
+  return min === max ? `${min} bpm` : `${min} - ${max} bpm`
+}
+
 function HeartRateZoneBreakdown({
   summaries,
 }: {
@@ -258,12 +268,10 @@ function HeartRateZoneBreakdown({
       </CardHeader>
       <CardContent className="space-y-4">
         {summaries.map((summary) => {
-          const observedRange =
-            summary.minHeartRate != null && summary.maxHeartRate != null
-              ? summary.minHeartRate === summary.maxHeartRate
-                ? `${summary.minHeartRate} bpm`
-                : `${summary.minHeartRate} - ${summary.maxHeartRate} bpm`
-              : null
+          const observedRange = formatObservedRange(
+            summary.minHeartRate,
+            summary.maxHeartRate,
+          )
 
           return (
             <div


### PR DESCRIPTION
## Summary

MAJOR-tier batch 3a. Starts on `S3358` (nested ternaries, 17 total) with the **6 value/expression** cases — localized, low-risk un-nesting. The 11 loading/error/empty **JSX ternary chains** need larger JSX relocations and will land in a dedicated follow-up PR.

Refs #331

## Changes (no behavioral change)

| File | Fix |
|------|-----|
| `ActivityChartData.ts` | Flatten `hasReliableDistance ? (x != null ? … : null) : null` → `hasReliableDistance && x != null ? … : null` |
| `ActivityCharts.tsx` | Extract `normalizeTooltipIndex(raw)`; hoist `xTickDigits` out of the tick formatter |
| `CyclingInFocus.tsx` | Extract `pluralizeRides(count)` |
| `ActivityStatsPanel.tsx` | Extract `formatObservedRange(min, max)` |
| `ActivityHoverDetails.tsx` | Extract `formatHoverDistance(point)` |

## Validation

- ✅ `npm run type-check`
- ✅ `npm run lint:all`
- ✅ `npm run build`
- ✅ `npm run test:run` — 311/311 (affected suites 44/44)

`make sonar` after merge should show `S3358` drop from 17 → 11.

## Follow-up

Dedicated PR for the 11 loading/error/empty ternary chains (`GarminSegmentsPage`, `LapComparisonPage`, `GarminSegmentDetailPage`, `GarminDayActivitiesPopover`, `GarminActivityTotals`, `GarminActivityHeatmap`).