### PR TITLE
refactor(sonar): un-nest loading/error/empty JSX chains — S3358 (major batch 3b)

### DIFF
--- a/src/components/dashboard/GarminActivityHeatmap.tsx
+++ b/src/components/dashboard/GarminActivityHeatmap.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useRef } from 'react'
+import { useState, useMemo, useRef, type ReactNode } from 'react'
 import CalendarHeatmap from 'react-calendar-heatmap'
 import { format } from 'date-fns'
 import { Activity } from 'lucide-react'
@@ -88,6 +88,23 @@ export function GarminActivityHeatmap() {
   const totalActivities = heatmapValues.reduce((sum, v) => sum + v.count, 0)
   const activeDays = heatmapValues.filter((v) => v.count > 0).length
 
+  let statusNode: ReactNode = null
+  if (loading) {
+    statusNode = (
+      <div className="flex h-32 items-center justify-center">
+        <p className="text-sm text-muted-foreground">
+          Loading activity data...
+        </p>
+      </div>
+    )
+  } else if (error) {
+    statusNode = (
+      <div className="flex h-32 items-center justify-center">
+        <p className="text-sm text-destructive">Failed to load activity data</p>
+      </div>
+    )
+  }
+
   return (
     <Card data-testid="garmin-heatmap-card">
       <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
@@ -119,19 +136,7 @@ export function GarminActivityHeatmap() {
         </div>
       </CardHeader>
       <CardContent>
-        {loading ? (
-          <div className="flex h-32 items-center justify-center">
-            <p className="text-sm text-muted-foreground">
-              Loading activity data...
-            </p>
-          </div>
-        ) : error ? (
-          <div className="flex h-32 items-center justify-center">
-            <p className="text-sm text-destructive">
-              Failed to load activity data
-            </p>
-          </div>
-        ) : (
+        {statusNode ?? (
           <div
             className="garmin-heatmap"
             onClickCapture={(e) => {

--- a/src/components/dashboard/GarminActivityTotals.tsx
+++ b/src/components/dashboard/GarminActivityTotals.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useState, type ReactNode } from 'react'
 import { addDays, endOfMonth, format, parseISO, subDays } from 'date-fns'
 import {
   Bar,
@@ -601,6 +601,21 @@ export function GarminActivityTotals() {
     }
   }
 
+  let statusNode: ReactNode = null
+  if (isLoading) {
+    statusNode = <LoadingState message="Loading activity totals..." />
+  } else if (activeError) {
+    statusNode = (
+      <ErrorState message={activeError.message} onRetry={handleRetry} />
+    )
+  } else if (chartData.length === 0) {
+    statusNode = (
+      <p className="py-12 text-center text-sm text-muted-foreground">
+        No activities found for this period.
+      </p>
+    )
+  }
+
   return (
     <Card data-testid="activity-totals-card">
       <CardHeader>
@@ -694,15 +709,7 @@ export function GarminActivityTotals() {
         </div>
       </CardHeader>
       <CardContent>
-        {isLoading ? (
-          <LoadingState message="Loading activity totals..." />
-        ) : activeError ? (
-          <ErrorState message={activeError.message} onRetry={handleRetry} />
-        ) : chartData.length === 0 ? (
-          <p className="py-12 text-center text-sm text-muted-foreground">
-            No activities found for this period.
-          </p>
-        ) : (
+        {statusNode ?? (
           <div className="h-80 w-full">
             <ResponsiveContainer width="100%" height="100%">
               <BarChart

--- a/src/components/dashboard/GarminDayActivitiesPopover.tsx
+++ b/src/components/dashboard/GarminDayActivitiesPopover.tsx
@@ -1,5 +1,6 @@
 import { Loader2 } from 'lucide-react'
 import { format } from 'date-fns'
+import type { ReactNode } from 'react'
 
 import { useGarminActivitiesQuery } from '@/__generated__/graphql'
 import { Popover, PopoverAnchor, PopoverContent } from '@/components/ui/popover'
@@ -36,6 +37,37 @@ export function GarminDayActivitiesPopover({
     ? format(new Date(`${date}T00:00:00`), 'EEE, MMM d, yyyy')
     : ''
 
+  let statusNode: ReactNode = null
+  if (loading) {
+    statusNode = (
+      <div
+        className="flex h-20 items-center justify-center gap-2 text-sm text-muted-foreground"
+        data-testid="garmin-day-popover-loading"
+      >
+        <Loader2 className="h-4 w-4 animate-spin" />
+        Loading...
+      </div>
+    )
+  } else if (error) {
+    statusNode = (
+      <div
+        className="flex h-20 items-center justify-center px-3 text-center text-sm text-destructive"
+        data-testid="garmin-day-popover-error"
+      >
+        Failed to load activities
+      </div>
+    )
+  } else if (activities.length === 0) {
+    statusNode = (
+      <div
+        className="flex h-20 items-center justify-center text-sm text-muted-foreground"
+        data-testid="garmin-day-popover-empty"
+      >
+        No activities.
+      </div>
+    )
+  }
+
   return (
     <Popover open={open} onOpenChange={onOpenChange}>
       <PopoverAnchor asChild>
@@ -67,29 +99,7 @@ export function GarminDayActivitiesPopover({
           )}
         </div>
 
-        {loading ? (
-          <div
-            className="flex h-20 items-center justify-center gap-2 text-sm text-muted-foreground"
-            data-testid="garmin-day-popover-loading"
-          >
-            <Loader2 className="h-4 w-4 animate-spin" />
-            Loading...
-          </div>
-        ) : error ? (
-          <div
-            className="flex h-20 items-center justify-center px-3 text-center text-sm text-destructive"
-            data-testid="garmin-day-popover-error"
-          >
-            Failed to load activities
-          </div>
-        ) : activities.length === 0 ? (
-          <div
-            className="flex h-20 items-center justify-center text-sm text-muted-foreground"
-            data-testid="garmin-day-popover-empty"
-          >
-            No activities.
-          </div>
-        ) : (
+        {statusNode ?? (
           <div
             className="max-h-72 overflow-y-auto"
             data-testid="garmin-day-popover-list"

--- a/src/pages/GarminSegmentDetailPage.tsx
+++ b/src/pages/GarminSegmentDetailPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo } from 'react'
+import { useEffect, useMemo, type ReactNode } from 'react'
 import { Link, useNavigate, useParams } from 'react-router-dom'
 import { ArrowLeft } from 'lucide-react'
 import {
@@ -126,6 +126,25 @@ export function GarminSegmentDetailPage() {
     )
   }
 
+  let effortsStatusNode: ReactNode = null
+  if (effortsLoading && !effortsData) {
+    effortsStatusNode = <LoadingState message="Loading efforts..." />
+  } else if (effortsError) {
+    effortsStatusNode = (
+      <ErrorState
+        message={effortsError.message}
+        onRetry={() => refetchEfforts()}
+      />
+    )
+  } else if (efforts.length === 0) {
+    effortsStatusNode = (
+      <EmptyState
+        title="No efforts yet"
+        message="No activities have traversed this segment's corridor."
+      />
+    )
+  }
+
   return (
     <div className="space-y-6">
       {backLink}
@@ -195,19 +214,7 @@ export function GarminSegmentDetailPage() {
             <CardTitle>Effort leaderboard</CardTitle>
           </CardHeader>
           <CardContent>
-            {effortsLoading && !effortsData ? (
-              <LoadingState message="Loading efforts..." />
-            ) : effortsError ? (
-              <ErrorState
-                message={effortsError.message}
-                onRetry={() => refetchEfforts()}
-              />
-            ) : efforts.length === 0 ? (
-              <EmptyState
-                title="No efforts yet"
-                message="No activities have traversed this segment's corridor."
-              />
-            ) : (
+            {effortsStatusNode ?? (
               <SegmentEffortsLeaderboard efforts={efforts} />
             )}
           </CardContent>

--- a/src/pages/GarminSegmentsPage.tsx
+++ b/src/pages/GarminSegmentsPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react'
+import { useEffect, type ReactNode } from 'react'
 import { Link } from 'react-router-dom'
 import { Route } from 'lucide-react'
 import { useGarminSegmentsQuery } from '@/__generated__/graphql'
@@ -23,6 +23,22 @@ export function GarminSegmentsPage() {
   const { data, loading, error, refetch } = useGarminSegmentsQuery()
   const segments = data?.garminSegments ?? []
 
+  let statusNode: ReactNode = null
+  if (loading && !data) {
+    statusNode = <LoadingState message="Loading segments..." />
+  } else if (error) {
+    statusNode = (
+      <ErrorState message={error.message} onRetry={() => refetch()} />
+    )
+  } else if (segments.length === 0) {
+    statusNode = (
+      <EmptyState
+        title="No saved segments"
+        message="Saved segments will appear here. Creating a segment from an activity lap or climb is coming soon."
+      />
+    )
+  }
+
   return (
     <div className="space-y-6">
       <div>
@@ -32,16 +48,7 @@ export function GarminSegmentsPage() {
         </p>
       </div>
 
-      {loading && !data ? (
-        <LoadingState message="Loading segments..." />
-      ) : error ? (
-        <ErrorState message={error.message} onRetry={() => refetch()} />
-      ) : segments.length === 0 ? (
-        <EmptyState
-          title="No saved segments"
-          message="Saved segments will appear here. Creating a segment from an activity lap or climb is coming soon."
-        />
-      ) : (
+      {statusNode ?? (
         <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
           {segments.map((segment) => (
             <Link

--- a/src/pages/LapComparisonPage.tsx
+++ b/src/pages/LapComparisonPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useState, type ReactNode } from 'react'
 import { useSearchParams } from 'react-router-dom'
 import { format as formatDate } from 'date-fns'
 import {
@@ -85,6 +85,22 @@ export function LapComparisonPage() {
   const total = data?.garminLapsComparison?.total ?? 0
   const metricUnit = getMetricDef(metric).unit
 
+  let statusNode: ReactNode = null
+  if (loading && !data) {
+    statusNode = <LoadingState message="Loading laps..." />
+  } else if (error) {
+    statusNode = (
+      <ErrorState message={error.message} onRetry={() => refetch()} />
+    )
+  } else if (items.length === 0) {
+    statusNode = (
+      <EmptyState
+        title="No laps to compare"
+        message="No cycling laps found for this date range."
+      />
+    )
+  }
+
   return (
     <div className="space-y-6">
       <div>
@@ -126,16 +142,7 @@ export function LapComparisonPage() {
         </div>
       </div>
 
-      {loading && !data ? (
-        <LoadingState message="Loading laps..." />
-      ) : error ? (
-        <ErrorState message={error.message} onRetry={() => refetch()} />
-      ) : items.length === 0 ? (
-        <EmptyState
-          title="No laps to compare"
-          message="No cycling laps found for this date range."
-        />
-      ) : (
+      {statusNode ?? (
         <div className="space-y-3">
           <p className="text-sm text-muted-foreground">
             {items.length} of {total.toLocaleString()} activities


### PR DESCRIPTION
## Summary

Completes `S3358` (nested ternaries). Following #332 (batch 3a), this clears the remaining **11 loading/error/empty JSX ternary chains** across 6 files → `S3358` reaches 0.

Refs #333

## Approach (no behavioral change)

Each chain (`loading ? … : error ? … : empty ? … : content`) becomes a `statusNode` computed with `if/else` before the return, rendered as `{statusNode ?? (<content/>)}`:

- Removes the nested ternaries.
- `error` is narrowed inside its `else if` branch → `error.message` stays valid, no assertions.
- `??` short-circuits, so the (often large) content JSX is only built when `statusNode` is null — preserving the original lazy evaluation. Content JSX stays **in place**, keeping the diff minimal and low-risk.

## Files

`GarminSegmentsPage`, `LapComparisonPage`, `GarminSegmentDetailPage`, `GarminDayActivitiesPopover`, `GarminActivityTotals`, `GarminActivityHeatmap`.

## Validation

- ✅ `npm run type-check`
- ✅ `npm run lint:all`
- ✅ `npm run build`
- ✅ `npm run test:run` — 311/311 (affected suites 28/28)

`make sonar` after merge should show `S3358` = 0 (combined with #332).

## Remaining MAJOR

`S6772` (JSX whitespace ×8), `S6478` (nested components ×5), a11y/misc (~13). Then MINOR (`S6759` readonly props ×51, etc.).