### PR TITLE
fix(sonar): resolve ambiguous JSX child spacing — S6772 (major batch 4)

### DIFF
--- a/src/components/dashboard/CyclingInFocus.tsx
+++ b/src/components/dashboard/CyclingInFocus.tsx
@@ -244,7 +244,7 @@ export function CyclingInFocus() {
                 <span className="block font-semibold tabular-nums text-foreground">
                   {formatDuration(totalSeconds)}
                 </span>
-                Total Time
+                <span>Total Time</span>
               </span>
             </div>
 

--- a/src/components/garmin/ActivityRouteMap.tsx
+++ b/src/components/garmin/ActivityRouteMap.tsx
@@ -256,19 +256,19 @@ export function ActivityRouteMap({
         <div className="flex items-center justify-center gap-4 mt-3 text-xs text-muted-foreground">
           <div className="flex items-center gap-1">
             <span className="inline-block h-3 w-3 rounded-full bg-blue-500" />
-            Slow
+            <span>Slow</span>
           </div>
           <div className="flex items-center gap-1">
             <span className="inline-block h-3 w-3 rounded-full bg-green-500" />
-            Moderate
+            <span>Moderate</span>
           </div>
           <div className="flex items-center gap-1">
             <span className="inline-block h-3 w-3 rounded-full bg-yellow-500" />
-            Fast
+            <span>Fast</span>
           </div>
           <div className="flex items-center gap-1">
             <span className="inline-block h-3 w-3 rounded-full bg-red-500" />
-            Sprint
+            <span>Sprint</span>
           </div>
         </div>
       </CardContent>

--- a/src/components/garmin/ActivityStatsPanel.tsx
+++ b/src/components/garmin/ActivityStatsPanel.tsx
@@ -205,7 +205,7 @@ function TrainingEffectGraphic({
             <div className="flex items-baseline justify-between gap-3">
               <div className="flex items-center gap-2 text-sm text-muted-foreground">
                 <span className="h-2.5 w-2.5 rounded-full bg-green-500" />
-                Aerobic
+                <span>Aerobic</span>
               </div>
               <div className="text-2xl font-semibold tabular-nums">
                 {formatTrainingEffect(aerobic)}
@@ -216,7 +216,7 @@ function TrainingEffectGraphic({
             <div className="flex items-baseline justify-between gap-3">
               <div className="flex items-center gap-2 text-sm text-muted-foreground">
                 <span className="h-2.5 w-2.5 rounded-full bg-blue-400" />
-                Anaerobic
+                <span>Anaerobic</span>
               </div>
               <div className="text-2xl font-semibold tabular-nums">
                 {formatTrainingEffect(anaerobic)}

--- a/src/pages/GeocodingPage.tsx
+++ b/src/pages/GeocodingPage.tsx
@@ -171,7 +171,7 @@ export function GeocodingPage() {
                     onChange={(e) => setRetryFailed(e.target.checked)}
                     className="rounded border"
                   />
-                  Retry failed
+                  <span>Retry failed</span>
                 </label>
 
                 <Button onClick={handleTrigger} disabled={triggering}>


### PR DESCRIPTION
## Summary

MAJOR-tier batch 4. Fixes all 8 `S6772` — "Ambiguous spacing after previous element" (`react/jsx-child-element-spacing`).

Refs #335

## Changes (no behavioral change)

Each case was an inline element (`<span>` icon / `<input>`) directly followed by bare text across a newline. JSX renders no space there, but the rule flags the ambiguity. All sit inside `flex … gap-*` (or block) containers where spacing is handled by layout, so wrapping the bare text in a `<span>` makes the adjacency element-to-element (unambiguous) with **no visual change**.

- `ActivityRouteMap.tsx` — speed legend labels (Slow / Moderate / Fast / Sprint)
- `ActivityStatsPanel.tsx` — Aerobic / Anaerobic
- `CyclingInFocus.tsx` — Total Time
- `GeocodingPage.tsx` — Retry failed (checkbox label, `flex items-center gap-2`)

## Validation

- ✅ `npm run type-check`
- ✅ `npm run lint:all`
- ✅ `npm run build`
- ✅ `npm run test:run` — 311/311 (affected suites pass)

`make sonar` after merge should show `S6772` = 0.

## Remaining MAJOR

`S6478` (nested components ×5), `S6481` (context-value memo ×2), a11y/misc (~11). Then MINOR (`S6759` readonly props ×51).