### PR TITLE
fix(sonar): modernize ui helper APIs

### DIFF
--- a/src/components/dashboard/GarminActivityTotals.test.tsx
+++ b/src/components/dashboard/GarminActivityTotals.test.tsx
@@ -524,7 +524,7 @@ describe('GarminActivityTotals', () => {
 
     // Chart data has one bar per year, distance increasing with year.
     await waitFor(() => {
-      expect(latestBarChartData.length).toBe(expectedYears)
+      expect(latestBarChartData).toHaveLength(expectedYears)
     })
     expect(latestBarChartData[0]).toEqual(
       expect.objectContaining({ label: '2010', distance_km: 10 }),

--- a/src/components/dashboard/GarminActivityTotals.tsx
+++ b/src/components/dashboard/GarminActivityTotals.tsx
@@ -309,9 +309,9 @@ async function fetchWeeklyTotalsByYear(
     })
   }
   if (isCancelled()) return null
-  return trimLeadingEmptyBuckets(
-    results.sort((a, b) => a.label.localeCompare(b.label)),
-  )
+  const sortedResults = [...results]
+  sortedResults.sort((a, b) => a.label.localeCompare(b.label))
+  return trimLeadingEmptyBuckets(sortedResults)
 }
 
 interface RelevantBucket {
@@ -658,7 +658,7 @@ export function GarminActivityTotals() {
                 </SelectTrigger>
                 <SelectContent>
                   {MONTH_LABELS.map((label, index) => (
-                    <SelectItem key={index} value={String(index)}>
+                    <SelectItem key={label} value={String(index)}>
                       {label}
                     </SelectItem>
                   ))}

--- a/src/components/dashboard/GarminSyncCard.tsx
+++ b/src/components/dashboard/GarminSyncCard.tsx
@@ -34,8 +34,8 @@ export function GarminSyncCard() {
 
   const handleSync = () => {
     const variables: { window_hours?: number; lookback?: number } = {}
-    if (windowHours) variables.window_hours = parseInt(windowHours, 10)
-    if (lookback) variables.lookback = parseInt(lookback, 10)
+    if (windowHours) variables.window_hours = Number.parseInt(windowHours, 10)
+    if (lookback) variables.lookback = Number.parseInt(lookback, 10)
     triggerSync({ variables })
   }
 

--- a/src/components/garmin/ActivityChartData.ts
+++ b/src/components/garmin/ActivityChartData.ts
@@ -59,8 +59,8 @@ function downsample<T>(data: T[], target: number): T[] {
   for (let i = 0; i < target; i++) {
     result.push(data[Math.floor(i * step)])
   }
-  if (result[result.length - 1] !== data[data.length - 1]) {
-    result.push(data[data.length - 1])
+  if (result.at(-1) !== data.at(-1)) {
+    result.push(data.at(-1) as T)
   }
   return result
 }

--- a/src/components/garmin/ActivityChartData.ts
+++ b/src/components/garmin/ActivityChartData.ts
@@ -59,8 +59,9 @@ function downsample<T>(data: T[], target: number): T[] {
   for (let i = 0; i < target; i++) {
     result.push(data[Math.floor(i * step)])
   }
-  if (result.at(-1) !== data.at(-1)) {
-    result.push(data.at(-1) as T)
+  const lastDataPoint = data.at(-1)!
+  if (result.at(-1) !== lastDataPoint) {
+    result.push(lastDataPoint)
   }
   return result
 }

--- a/src/components/garmin/ActivityCharts.tsx
+++ b/src/components/garmin/ActivityCharts.tsx
@@ -147,9 +147,9 @@ function normalizeTooltipIndex(
   if (typeof raw === 'number') return raw
   if (typeof raw === 'string') {
     const trimmed = raw.trim()
-    return trimmed === '' ? NaN : Number(trimmed)
+    return trimmed === '' ? Number.NaN : Number(trimmed)
   }
-  return NaN
+  return Number.NaN
 }
 
 function pointFromTooltipState(

--- a/src/components/garmin/ActivityHeader.tsx
+++ b/src/components/garmin/ActivityHeader.tsx
@@ -54,7 +54,7 @@ export function ActivityHeader({
       <div className="text-muted-foreground">{icon}</div>
       <div className="flex-1">
         <h1 className="text-2xl font-bold capitalize tracking-tight">
-          {sport.replace(/_/g, ' ')}
+          {sport.replaceAll('_', ' ')}
         </h1>
         <p className="text-sm text-muted-foreground">
           {startTime
@@ -72,7 +72,7 @@ export function ActivityHeader({
       <div className="flex gap-2">
         {subSport && (
           <Badge variant="secondary" className="capitalize">
-            {subSport.replace(/_/g, ' ')}
+            {subSport.replaceAll('_', ' ')}
           </Badge>
         )}
         {deviceModel ? (

--- a/src/components/garmin/ActivityLapsTable.tsx
+++ b/src/components/garmin/ActivityLapsTable.tsx
@@ -127,7 +127,7 @@ function ActivityLapDetailsPanel({
 
   const canSaveSegment = routePoints.length >= 2
   const segmentStart = canSaveSegment ? routePoints[0] : null
-  const segmentEnd = canSaveSegment ? routePoints[routePoints.length - 1] : null
+  const segmentEnd = canSaveSegment ? routePoints.at(-1) : null
 
   return (
     <div className="space-y-4" data-testid="activity-lap-details-panel">

--- a/src/components/garmin/ActivityRouteMap.tsx
+++ b/src/components/garmin/ActivityRouteMap.tsx
@@ -115,7 +115,8 @@ export function ActivityRouteMap({
     }
 
     // Extend bounds with last point
-    const last = trackPoints[trackPoints.length - 1]
+    const last = trackPoints.at(-1)
+    if (!last) return
     bounds.extend([last.latitude, last.longitude])
 
     // Start marker (green circle)

--- a/src/components/garmin/ClimbDetailsPanel.tsx
+++ b/src/components/garmin/ClimbDetailsPanel.tsx
@@ -181,7 +181,8 @@ function valueToBucketColor(
   if (value == null || !Number.isFinite(value)) return fallback
   return (
     stops.find((stop) => value < stop.max)?.color ??
-    stops[stops.length - 1].color
+    stops.at(-1)?.color ??
+    fallback
   )
 }
 
@@ -542,7 +543,8 @@ function ClimbSegmentMap({ points }: { points: ClimbMapPoint[] }) {
     if (!mapRef.current || points.length < 2) return
 
     const first = points[0]
-    const last = points[points.length - 1]
+    const last = points.at(-1)
+    if (!last) return
     const map = L.map(mapRef.current).setView(
       [first.latitude, first.longitude],
       15,

--- a/src/components/spatial/ReverseGeocode.tsx
+++ b/src/components/spatial/ReverseGeocode.tsx
@@ -12,8 +12,8 @@ export function ReverseGeocode() {
   const [error, setError] = useState<string | null>(null)
 
   const handleLookup = async () => {
-    const latNum = parseFloat(lat)
-    const lonNum = parseFloat(lon)
+    const latNum = Number.parseFloat(lat)
+    const lonNum = Number.parseFloat(lon)
 
     if (
       !Number.isFinite(latNum) ||

--- a/src/lib/export.ts
+++ b/src/lib/export.ts
@@ -11,7 +11,7 @@ export function escapeCsvValue(value: unknown): string {
   if (value == null) return ''
   const str = String(value)
   if (/[,"\n\r]/.test(str)) {
-    return `"${str.replace(/"/g, '""')}"`
+    return `"${str.replaceAll('"', '""')}"`
   }
   return str
 }
@@ -35,7 +35,7 @@ export function triggerDownload(
   a.download = filename
   document.body.appendChild(a)
   a.click()
-  document.body.removeChild(a)
+  a.remove()
   const revokeObjectURL =
     typeof URL.revokeObjectURL === 'function'
       ? URL.revokeObjectURL.bind(URL)

--- a/src/pages/GeocodingPage.tsx
+++ b/src/pages/GeocodingPage.tsx
@@ -47,8 +47,8 @@ export function GeocodingPage() {
 
   const handleTrigger = () => {
     const variables: { batch_size?: number; retry_failed?: boolean } = {}
-    const size = parseInt(batchSize, 10)
-    if (isNaN(size) || size < 1 || size > 200) {
+    const size = Number.parseInt(batchSize, 10)
+    if (Number.isNaN(size) || size < 1 || size > 200) {
       toast.error('Invalid batch size', {
         description: 'Batch size must be between 1 and 200.',
       })

--- a/src/pages/SpatialPage.tsx
+++ b/src/pages/SpatialPage.tsx
@@ -33,9 +33,9 @@ export function SpatialPage() {
 
   const { data: nearbyData, loading: nearbyLoading } = useNearbyPointsQuery({
     variables: {
-      lat: parseFloat(nearbyLat),
-      lon: parseFloat(nearbyLon),
-      radius_meters: parseFloat(nearbyRadius),
+      lat: Number.parseFloat(nearbyLat),
+      lon: Number.parseFloat(nearbyLon),
+      radius_meters: Number.parseFloat(nearbyRadius),
       limit: 20,
     },
     skip: !runNearby,
@@ -44,10 +44,10 @@ export function SpatialPage() {
   const { data: distanceData, loading: distanceLoading } =
     useCalculateDistanceQuery({
       variables: {
-        from_lat: parseFloat(fromLat),
-        from_lon: parseFloat(fromLon),
-        to_lat: parseFloat(toLat),
-        to_lon: parseFloat(toLon),
+        from_lat: Number.parseFloat(fromLat),
+        from_lon: Number.parseFloat(fromLon),
+        to_lat: Number.parseFloat(toLat),
+        to_lon: Number.parseFloat(toLon),
       },
       skip: !runDistance,
     })


### PR DESCRIPTION
## Summary
Continues the SonarQube warning cleanup with a low-risk modernization batch for TypeScript and DOM helper APIs.

## Changes
- Replaces global parsing helpers with `Number.parseInt`, `Number.parseFloat`, and `Number.isNaN`.
- Replaces `NaN` with `Number.NaN` in tooltip normalization.
- Uses `.at(-1)` for last-element access where Sonar flagged it.
- Uses `replaceAll` for string replacements.
- Replaces `removeChild` with direct element removal in download helper.
- Moves an in-place sort into a separate copied-array sort statement.
- Uses a stable month label key instead of the array index.
- Makes a test assertion more specific with `toHaveLength`.

## SonarQube Verification
Before this batch, SonarQube reported 104 open code smells: 85 minor and 19 major.
After `make sonar`, SonarQube reports 75 open code smells: 59 minor and 16 major.

## Validation
- `npm run lint`
- `npm run lint:all`
- `npm run type-check`
- `npm run build`
- `npm run test:run`
- `make sonar`
