### PR TITLE
Resolve next batch of Sonar UI warnings

### DIFF
--- a/src/components/garmin/ActivityCharts.tsx
+++ b/src/components/garmin/ActivityCharts.tsx
@@ -369,7 +369,6 @@ export function ActivityCharts({
                     aria-label={`About ${chart.title}: ${chart.description}`}
                     className="inline-flex text-muted-foreground"
                     role="note"
-                    tabIndex={0}
                     title={chart.description}
                   >
                     <CircleHelp aria-hidden="true" className="size-4" />
@@ -387,10 +386,9 @@ export function ActivityCharts({
                       {formatNumber(stats.minimum, 0)} · Max{' '}
                       {formatNumber(stats.maximum, 0)} breaths/min
                     </div>
-                    <div
+                    <fieldset
                       aria-label="Respiration rate display"
                       className="flex rounded border p-0.5"
-                      role="group"
                     >
                       <Button
                         aria-pressed={!smoothRespiration}
@@ -410,7 +408,7 @@ export function ActivityCharts({
                       >
                         Smoothed
                       </Button>
-                    </div>
+                    </fieldset>
                   </>
                 ) : (
                   <div
@@ -508,14 +506,9 @@ export function ActivityCharts({
                 />
                 <Tooltip
                   cursor={{ stroke: 'currentColor', strokeOpacity: 0.4 }}
-                  content={({ label, payload }) => (
-                    <ChartTooltip
-                      label={label}
-                      payload={payload}
-                      chart={chart}
-                      xMode={effectiveXMode}
-                    />
-                  )}
+                  content={
+                    <ChartTooltip chart={chart} xMode={effectiveXMode} />
+                  }
                 />
                 {chart.dataKey === 'respirationRate' &&
                   stats.average != null && (

--- a/src/components/garmin/ActivityStatsPanel.tsx
+++ b/src/components/garmin/ActivityStatsPanel.tsx
@@ -566,8 +566,8 @@ export function ActivityStatsPanel({
             </CardTitle>
           </CardHeader>
           <CardContent className="space-y-2">
-            {section.rows.map((row, i) => (
-              <div key={i} className="flex justify-between text-sm">
+            {section.rows.map((row) => (
+              <div key={row.label} className="flex justify-between text-sm">
                 <span className="text-muted-foreground">{row.label}</span>
                 <span className="flex items-center gap-1.5 font-medium">
                   {row.value}

--- a/src/components/garmin/ActivityStatsPanel.tsx
+++ b/src/components/garmin/ActivityStatsPanel.tsx
@@ -56,6 +56,7 @@ interface ActivityStatsPanelProps {
 }
 
 interface StatRow {
+  id?: string
   label: string
   value: string
   badge?: string
@@ -327,10 +328,15 @@ function buildStatSections(
       title: 'Distance',
       rows: [
         {
+          id: 'total-distance-mi',
           label: 'Total Distance',
           value: fmtConverted(a.distance_km, kmToMi, 2, 'mi'),
         },
-        { label: 'Total Distance', value: fmt(a.distance_km, 2, 'km') },
+        {
+          id: 'total-distance-km',
+          label: 'Total Distance',
+          value: fmt(a.distance_km, 2, 'km'),
+        },
       ],
     },
     {
@@ -361,8 +367,16 @@ function buildStatSections(
           label: 'Descent',
           value: fmtConverted(a.total_descent_m, metersToFeet, 0, 'ft'),
         },
-        { label: 'Ascent', value: fmt(a.total_ascent_m, 0, 'm') },
-        { label: 'Descent', value: fmt(a.total_descent_m, 0, 'm') },
+        {
+          id: 'ascent-m',
+          label: 'Ascent',
+          value: fmt(a.total_ascent_m, 0, 'm'),
+        },
+        {
+          id: 'descent-m',
+          label: 'Descent',
+          value: fmt(a.total_descent_m, 0, 'm'),
+        },
       ],
     },
     {
@@ -377,8 +391,16 @@ function buildStatSections(
           value: fmtConverted(a.max_speed_kmh, kmhToMph, 1, 'mph'),
         },
         { label: 'Avg Pace', value: formatPace(a.avg_speed_kmh ?? null) },
-        { label: 'Avg Speed', value: fmt(a.avg_speed_kmh, 1, 'km/h') },
-        { label: 'Max Speed', value: fmt(a.max_speed_kmh, 1, 'km/h') },
+        {
+          id: 'avg-speed-kmh',
+          label: 'Avg Speed',
+          value: fmt(a.avg_speed_kmh, 1, 'km/h'),
+        },
+        {
+          id: 'max-speed-kmh',
+          label: 'Max Speed',
+          value: fmt(a.max_speed_kmh, 1, 'km/h'),
+        },
       ],
     },
     ...(hrAvailable
@@ -414,6 +436,7 @@ function buildStatSections(
       title: 'Temperature',
       rows: [
         {
+          id: 'avg-temperature-f',
           label: 'Avg Temperature',
           value: fmtConverted(
             a.avg_temperature_c,
@@ -441,6 +464,7 @@ function buildStatSections(
           ),
         },
         {
+          id: 'avg-temperature-c',
           label: 'Avg Temperature',
           value: fmtUnit(a.avg_temperature_c, '°C'),
         },
@@ -567,7 +591,10 @@ export function ActivityStatsPanel({
           </CardHeader>
           <CardContent className="space-y-2">
             {section.rows.map((row) => (
-              <div key={row.label} className="flex justify-between text-sm">
+              <div
+                key={`${section.title}-${row.id ?? row.label}`}
+                className="flex justify-between text-sm"
+              >
                 <span className="text-muted-foreground">{row.label}</span>
                 <span className="flex items-center gap-1.5 font-medium">
                   {row.value}

--- a/src/components/garmin/SegmentMiniMap.tsx
+++ b/src/components/garmin/SegmentMiniMap.tsx
@@ -25,7 +25,7 @@ export function SegmentMiniMap({
   label,
   route,
 }: SegmentMiniMapProps) {
-  const mapRef = useRef<HTMLDivElement>(null)
+  const mapRef = useRef<HTMLElement>(null)
   const mapInstanceRef = useRef<L.Map | null>(null)
 
   const routeLatLngs = useMemo<L.LatLngTuple[]>(
@@ -120,12 +120,11 @@ export function SegmentMiniMap({
   }, [startLat, startLon, endLat, endLon, routeLatLngs])
 
   return (
-    <div
+    <figure
       ref={mapRef}
       aria-label={`${label} segment map`}
-      role="img"
       data-testid="segment-mini-map"
-      className="h-24 w-28 shrink-0 overflow-hidden rounded-md border border-border/70 sm:h-28 sm:w-32"
+      className="m-0 h-24 w-28 shrink-0 overflow-hidden rounded-md border border-border/70 sm:h-28 sm:w-32"
     />
   )
 }

--- a/src/components/layout/AppLayout.test.tsx
+++ b/src/components/layout/AppLayout.test.tsx
@@ -87,47 +87,22 @@ describe('AppLayout', () => {
     expect(login).toHaveBeenCalledTimes(1)
   })
 
-  it('cycles the theme toggle using the current theme', async () => {
+  it.each([
+    ['dark', 'system'],
+    ['light', 'dark'],
+    ['system', 'light'],
+  ] as const)('cycles %s theme to %s', async (theme, expectedTheme) => {
     const user = userEvent.setup()
     const setTheme = vi.fn()
     useThemeMock.mockReturnValue({
-      theme: 'dark',
-      setTheme,
-    })
-
-    renderLayout()
-    await user.click(screen.getByTitle('Theme: dark'))
-
-    expect(setTheme).toHaveBeenCalledWith('system')
-  })
-
-  it('cycles light theme to dark', async () => {
-    const user = userEvent.setup()
-    const setTheme = vi.fn()
-    useThemeMock.mockReturnValue({
-      theme: 'light',
+      theme,
       setTheme,
     })
 
     renderLayout()
 
-    await user.click(screen.getByTitle('Theme: light'))
-    expect(setTheme).toHaveBeenCalledWith('dark')
-  })
-
-  it('cycles system theme to light', async () => {
-    const user = userEvent.setup()
-    const setTheme = vi.fn()
-
-    useThemeMock.mockReturnValue({
-      theme: 'system',
-      setTheme,
-    })
-
-    renderLayout()
-
-    await user.click(screen.getByTitle('Theme: system'))
-    expect(setTheme).toHaveBeenCalledWith('light')
+    await user.click(screen.getByTitle(`Theme: ${theme}`))
+    expect(setTheme).toHaveBeenCalledWith(expectedTheme)
   })
 
   it('keeps the daily summary nav item active on day detail pages', () => {

--- a/src/components/layout/AppLayout.tsx
+++ b/src/components/layout/AppLayout.tsx
@@ -69,7 +69,9 @@ export function AppLayout() {
     <div className="flex h-screen overflow-hidden">
       {/* Mobile overlay */}
       {sidebarOpen && (
-        <div
+        <button
+          type="button"
+          aria-label="Close navigation menu"
           className="fixed inset-0 z-40 bg-black/50 lg:hidden"
           onClick={() => setSidebarOpen(false)}
         />

--- a/src/components/ui/calendar.tsx
+++ b/src/components/ui/calendar.tsx
@@ -16,6 +16,10 @@ import {
   ChevronDownIcon,
 } from 'lucide-react'
 
+type CalendarButtonVariant = NonNullable<
+  React.ComponentProps<typeof Button>['variant']
+>
+
 function Calendar({
   className,
   classNames,
@@ -27,7 +31,7 @@ function Calendar({
   components,
   ...props
 }: React.ComponentProps<typeof DayPicker> & {
-  buttonVariant?: React.ComponentProps<typeof Button>['variant']
+  buttonVariant?: CalendarButtonVariant
 }) {
   const defaultClassNames = getDefaultClassNames()
 

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -1,4 +1,11 @@
-import { createContext, useContext, useEffect, useState } from 'react'
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react'
 import type { ReactNode } from 'react'
 import type { User } from 'oidc-client-ts'
 import { authService } from '@/services/auth'
@@ -20,7 +27,7 @@ interface AuthContextType {
 
 const AuthContext = createContext<AuthContextType | undefined>(undefined)
 
-export function AuthProvider({ children }: { children: ReactNode }) {
+export function AuthProvider({ children }: Readonly<{ children: ReactNode }>) {
   const [user, setUser] = useState<User | null>(null)
   const [isLoading, setIsLoading] = useState(true)
   const [userProfile, setUserProfile] = useState<{
@@ -29,7 +36,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     sub?: string
   } | null>(null)
 
-  const loadUser = async () => {
+  const loadUser = useCallback(async () => {
     try {
       const currentUser = await authService.getUser()
       setUser(currentUser)
@@ -46,14 +53,14 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     } finally {
       setIsLoading(false)
     }
-  }
+  }, [])
 
   useEffect(() => {
     // eslint-disable-next-line react-hooks/set-state-in-effect
     loadUser()
-  }, [])
+  }, [loadUser])
 
-  const login = async () => {
+  const login = useCallback(async () => {
     setIsLoading(true)
     try {
       await authService.login()
@@ -62,9 +69,9 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       setIsLoading(false)
       throw error
     }
-  }
+  }, [])
 
-  const logout = async () => {
+  const logout = useCallback(async () => {
     setIsLoading(true)
     try {
       await authService.logout()
@@ -76,26 +83,29 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     } finally {
       setIsLoading(false)
     }
-  }
+  }, [])
 
-  const getAccessToken = async () => {
+  const getAccessToken = useCallback(async () => {
     return await authService.getAccessToken()
-  }
+  }, [])
 
-  const refreshUser = async () => {
+  const refreshUser = useCallback(async () => {
     await loadUser()
-  }
+  }, [loadUser])
 
-  const value: AuthContextType = {
-    user,
-    isAuthenticated: user !== null && !user.expired,
-    isLoading,
-    login,
-    logout,
-    getAccessToken,
-    refreshUser,
-    userProfile,
-  }
+  const value = useMemo<AuthContextType>(
+    () => ({
+      user,
+      isAuthenticated: user !== null && !user.expired,
+      isLoading,
+      login,
+      logout,
+      getAccessToken,
+      refreshUser,
+      userProfile,
+    }),
+    [getAccessToken, isLoading, login, logout, refreshUser, user, userProfile],
+  )
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>
 }

--- a/src/contexts/ThemeContext.tsx
+++ b/src/contexts/ThemeContext.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, useEffect, useState } from 'react'
+import { createContext, useContext, useEffect, useMemo, useState } from 'react'
 import type { ReactNode } from 'react'
 
 type Theme = 'light' | 'dark' | 'system'
@@ -17,7 +17,7 @@ function getSystemTheme(): 'light' | 'dark' {
     : 'light'
 }
 
-export function ThemeProvider({ children }: { children: ReactNode }) {
+export function ThemeProvider({ children }: Readonly<{ children: ReactNode }>) {
   const [theme, setTheme] = useState<Theme>(() => {
     if (typeof window === 'undefined') return 'system'
     return (localStorage.getItem('theme') as Theme) || 'system'
@@ -45,11 +45,12 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
     return () => mediaQuery.removeEventListener('change', handler)
   }, [theme])
 
-  return (
-    <ThemeContext.Provider value={{ theme, setTheme }}>
-      {children}
-    </ThemeContext.Provider>
+  const value = useMemo<ThemeContextType>(
+    () => ({ theme, setTheme }),
+    [theme, setTheme],
   )
+
+  return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>
 }
 
 // eslint-disable-next-line react-refresh/only-export-components

--- a/src/lib/export.ts
+++ b/src/lib/export.ts
@@ -14,7 +14,11 @@ export function escapeCsvValue(value: unknown): string {
     /[,"\n\r]/.test(str) ? `"${str.replaceAll('"', '""')}"` : str
 
   if (typeof value === 'object') {
-    return quoteIfNeeded(JSON.stringify(value) ?? '')
+    try {
+      return quoteIfNeeded(JSON.stringify(value) ?? '')
+    } catch {
+      return ''
+    }
   }
 
   if (typeof value === 'string') {

--- a/src/lib/export.ts
+++ b/src/lib/export.ts
@@ -9,11 +9,35 @@
  */
 export function escapeCsvValue(value: unknown): string {
   if (value == null) return ''
-  const str = String(value)
-  if (/[,"\n\r]/.test(str)) {
-    return `"${str.replaceAll('"', '""')}"`
+
+  const quoteIfNeeded = (str: string) =>
+    /[,"\n\r]/.test(str) ? `"${str.replaceAll('"', '""')}"` : str
+
+  if (typeof value === 'object') {
+    return quoteIfNeeded(JSON.stringify(value) ?? '')
   }
-  return str
+
+  if (typeof value === 'string') {
+    return quoteIfNeeded(value)
+  }
+
+  if (typeof value === 'symbol') {
+    return quoteIfNeeded(value.description ?? value.toString())
+  }
+
+  if (typeof value === 'function') {
+    return quoteIfNeeded(value.name)
+  }
+
+  if (typeof value === 'number') {
+    return quoteIfNeeded(value.toString())
+  }
+
+  if (typeof value === 'bigint') {
+    return quoteIfNeeded(value.toString())
+  }
+
+  return quoteIfNeeded(value ? 'true' : 'false')
 }
 
 /**

--- a/src/pages/GarminPage.tsx
+++ b/src/pages/GarminPage.tsx
@@ -202,9 +202,7 @@ export function GarminPage() {
                         ? `${a.avg_heart_rate} bpm`
                         : '—'}
                     </TableCell>
-                    <TableCell>
-                      {a.calories != null ? a.calories : '—'}
-                    </TableCell>
+                    <TableCell>{a.calories ?? '—'}</TableCell>
                     <TableCell>
                       {a.track_point_count != null
                         ? a.track_point_count.toLocaleString()

--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -50,7 +50,7 @@ const userManagerConfig = {
 const userManager = new UserManager(userManagerConfig)
 
 class AuthService {
-  private userManager: UserManager
+  private readonly userManager: UserManager
 
   constructor() {
     this.userManager = userManager


### PR DESCRIPTION
## Summary

- Resolves the next focused batch of Sonar UI warnings across accessibility, context provider stability, CSV value conversion, and stable React keys.
- Replaces the mobile overlay div click target with a native button and improves Garmin chart/mini-map semantics.
- Memoizes Auth/Theme provider values and marks the auth service manager readonly.
- Parameterizes repeated AppLayout theme-toggle tests.

## SonarQube

- Before this branch: 76 open issues (16 major, 60 minor).
- After final scan: 60 open issues (5 major, 55 minor).
- Remaining issues are primarily readonly prop warnings, deprecated API warnings, calendar inline component warnings, and one popover heading warning.

## Validation

- npm run lint:all
- npm run type-check
- npm run build
- npm run test:run
- make sonar

Note: one full `npm run test:run` attempt had an intermittent DashboardPage timeout; rerunning `DashboardPage`, then the full suite, and later `make sonar` coverage all passed.
