### PR TITLE
Clear remaining major Sonar UI warnings

### DIFF
--- a/src/components/ui/calendar.tsx
+++ b/src/components/ui/calendar.tsx
@@ -5,7 +5,10 @@ import {
   DayPicker,
   DayButton,
   getDefaultClassNames,
+  type ChevronProps,
   type Locale,
+  type RootProps,
+  type WeekNumberProps,
 } from 'react-day-picker'
 
 import { cn } from '@/lib/utils'
@@ -19,6 +22,47 @@ import {
 type CalendarButtonVariant = NonNullable<
   React.ComponentProps<typeof Button>['variant']
 >
+
+const CalendarLocaleContext = React.createContext<Partial<Locale> | undefined>(
+  undefined,
+)
+
+function CalendarRoot({ className, rootRef, ...props }: Readonly<RootProps>) {
+  return (
+    <div
+      data-slot="calendar"
+      ref={rootRef}
+      className={cn(className)}
+      {...props}
+    />
+  )
+}
+
+function CalendarChevron({
+  className,
+  orientation,
+  ...props
+}: Readonly<ChevronProps>) {
+  if (orientation === 'left') {
+    return <ChevronLeftIcon className={cn('size-4', className)} {...props} />
+  }
+
+  if (orientation === 'right') {
+    return <ChevronRightIcon className={cn('size-4', className)} {...props} />
+  }
+
+  return <ChevronDownIcon className={cn('size-4', className)} {...props} />
+}
+
+function CalendarWeekNumber({ children, ...props }: Readonly<WeekNumberProps>) {
+  return (
+    <td {...props}>
+      <div className="flex size-(--cell-size) items-center justify-center text-center">
+        {children}
+      </div>
+    </td>
+  )
+}
 
 function Calendar({
   className,
@@ -36,158 +80,122 @@ function Calendar({
   const defaultClassNames = getDefaultClassNames()
 
   return (
-    <DayPicker
-      showOutsideDays={showOutsideDays}
-      className={cn(
-        'group/calendar bg-background p-2 [--cell-radius:var(--radius-md)] [--cell-size:--spacing(7)] in-data-[slot=card-content]:bg-transparent in-data-[slot=popover-content]:bg-transparent',
-        String.raw`rtl:**:[.rdp-button\_next>svg]:rotate-180`,
-        String.raw`rtl:**:[.rdp-button\_previous>svg]:rotate-180`,
-        className,
-      )}
-      captionLayout={captionLayout}
-      locale={locale}
-      formatters={{
-        formatMonthDropdown: (date) =>
-          date.toLocaleString(locale?.code, { month: 'short' }),
-        ...formatters,
-      }}
-      classNames={{
-        root: cn('w-fit', defaultClassNames.root),
-        months: cn(
-          'relative flex flex-col gap-4 md:flex-row',
-          defaultClassNames.months,
-        ),
-        month: cn('flex w-full flex-col gap-4', defaultClassNames.month),
-        nav: cn(
-          'absolute inset-x-0 top-0 flex w-full items-center justify-between gap-1',
-          defaultClassNames.nav,
-        ),
-        button_previous: cn(
-          buttonVariants({ variant: buttonVariant }),
-          'size-(--cell-size) p-0 select-none aria-disabled:opacity-50',
-          defaultClassNames.button_previous,
-        ),
-        button_next: cn(
-          buttonVariants({ variant: buttonVariant }),
-          'size-(--cell-size) p-0 select-none aria-disabled:opacity-50',
-          defaultClassNames.button_next,
-        ),
-        month_caption: cn(
-          'flex h-(--cell-size) w-full items-center justify-center px-(--cell-size)',
-          defaultClassNames.month_caption,
-        ),
-        dropdowns: cn(
-          'flex h-(--cell-size) w-full items-center justify-center gap-1.5 text-sm font-medium',
-          defaultClassNames.dropdowns,
-        ),
-        dropdown_root: cn(
-          'relative rounded-(--cell-radius)',
-          defaultClassNames.dropdown_root,
-        ),
-        dropdown: cn(
-          'absolute inset-0 bg-popover opacity-0',
-          defaultClassNames.dropdown,
-        ),
-        caption_label: cn(
-          'font-medium select-none',
-          captionLayout === 'label'
-            ? 'text-sm'
-            : 'flex items-center gap-1 rounded-(--cell-radius) text-sm [&>svg]:size-3.5 [&>svg]:text-muted-foreground',
-          defaultClassNames.caption_label,
-        ),
-        month_grid: 'w-full border-collapse',
-        weekdays: cn('flex', defaultClassNames.weekdays),
-        weekday: cn(
-          'flex-1 rounded-(--cell-radius) text-[0.8rem] font-normal text-muted-foreground select-none',
-          defaultClassNames.weekday,
-        ),
-        week: cn('mt-2 flex w-full', defaultClassNames.week),
-        week_number_header: cn(
-          'w-(--cell-size) select-none',
-          defaultClassNames.week_number_header,
-        ),
-        week_number: cn(
-          'text-[0.8rem] text-muted-foreground select-none',
-          defaultClassNames.week_number,
-        ),
-        day: cn(
-          'group/day relative aspect-square h-full w-full rounded-(--cell-radius) p-0 text-center select-none [&:last-child[data-selected=true]_button]:rounded-r-(--cell-radius)',
-          props.showWeekNumber
-            ? '[&:nth-child(2)[data-selected=true]_button]:rounded-l-(--cell-radius)'
-            : '[&:first-child[data-selected=true]_button]:rounded-l-(--cell-radius)',
-          defaultClassNames.day,
-        ),
-        range_start: cn(
-          'relative isolate z-0 rounded-l-(--cell-radius) bg-muted after:absolute after:inset-y-0 after:right-0 after:w-4 after:bg-muted',
-          defaultClassNames.range_start,
-        ),
-        range_middle: cn('rounded-none', defaultClassNames.range_middle),
-        range_end: cn(
-          'relative isolate z-0 rounded-r-(--cell-radius) bg-muted after:absolute after:inset-y-0 after:left-0 after:w-4 after:bg-muted',
-          defaultClassNames.range_end,
-        ),
-        today: cn(
-          'rounded-(--cell-radius) bg-muted text-foreground data-[selected=true]:rounded-none',
-          defaultClassNames.today,
-        ),
-        outside: cn(
-          'text-muted-foreground aria-selected:text-muted-foreground',
-          defaultClassNames.outside,
-        ),
-        disabled: cn(
-          'text-muted-foreground opacity-50',
-          defaultClassNames.disabled,
-        ),
-        hidden: cn('invisible', defaultClassNames.hidden),
-        ...classNames,
-      }}
-      components={{
-        Root: ({ className, rootRef, ...props }) => {
-          return (
-            <div
-              data-slot="calendar"
-              ref={rootRef}
-              className={cn(className)}
-              {...props}
-            />
-          )
-        },
-        Chevron: ({ className, orientation, ...props }) => {
-          if (orientation === 'left') {
-            return (
-              <ChevronLeftIcon className={cn('size-4', className)} {...props} />
-            )
-          }
-
-          if (orientation === 'right') {
-            return (
-              <ChevronRightIcon
-                className={cn('size-4', className)}
-                {...props}
-              />
-            )
-          }
-
-          return (
-            <ChevronDownIcon className={cn('size-4', className)} {...props} />
-          )
-        },
-        DayButton: ({ ...props }) => (
-          <CalendarDayButton locale={locale} {...props} />
-        ),
-        WeekNumber: ({ children, ...props }) => {
-          return (
-            <td {...props}>
-              <div className="flex size-(--cell-size) items-center justify-center text-center">
-                {children}
-              </div>
-            </td>
-          )
-        },
-        ...components,
-      }}
-      {...props}
-    />
+    <CalendarLocaleContext.Provider value={locale}>
+      <DayPicker
+        showOutsideDays={showOutsideDays}
+        className={cn(
+          'group/calendar bg-background p-2 [--cell-radius:var(--radius-md)] [--cell-size:--spacing(7)] in-data-[slot=card-content]:bg-transparent in-data-[slot=popover-content]:bg-transparent',
+          String.raw`rtl:**:[.rdp-button\_next>svg]:rotate-180`,
+          String.raw`rtl:**:[.rdp-button\_previous>svg]:rotate-180`,
+          className,
+        )}
+        captionLayout={captionLayout}
+        locale={locale}
+        formatters={{
+          formatMonthDropdown: (date) =>
+            date.toLocaleString(locale?.code, { month: 'short' }),
+          ...formatters,
+        }}
+        classNames={{
+          root: cn('w-fit', defaultClassNames.root),
+          months: cn(
+            'relative flex flex-col gap-4 md:flex-row',
+            defaultClassNames.months,
+          ),
+          month: cn('flex w-full flex-col gap-4', defaultClassNames.month),
+          nav: cn(
+            'absolute inset-x-0 top-0 flex w-full items-center justify-between gap-1',
+            defaultClassNames.nav,
+          ),
+          button_previous: cn(
+            buttonVariants({ variant: buttonVariant }),
+            'size-(--cell-size) p-0 select-none aria-disabled:opacity-50',
+            defaultClassNames.button_previous,
+          ),
+          button_next: cn(
+            buttonVariants({ variant: buttonVariant }),
+            'size-(--cell-size) p-0 select-none aria-disabled:opacity-50',
+            defaultClassNames.button_next,
+          ),
+          month_caption: cn(
+            'flex h-(--cell-size) w-full items-center justify-center px-(--cell-size)',
+            defaultClassNames.month_caption,
+          ),
+          dropdowns: cn(
+            'flex h-(--cell-size) w-full items-center justify-center gap-1.5 text-sm font-medium',
+            defaultClassNames.dropdowns,
+          ),
+          dropdown_root: cn(
+            'relative rounded-(--cell-radius)',
+            defaultClassNames.dropdown_root,
+          ),
+          dropdown: cn(
+            'absolute inset-0 bg-popover opacity-0',
+            defaultClassNames.dropdown,
+          ),
+          caption_label: cn(
+            'font-medium select-none',
+            captionLayout === 'label'
+              ? 'text-sm'
+              : 'flex items-center gap-1 rounded-(--cell-radius) text-sm [&>svg]:size-3.5 [&>svg]:text-muted-foreground',
+            defaultClassNames.caption_label,
+          ),
+          month_grid: 'w-full border-collapse',
+          weekdays: cn('flex', defaultClassNames.weekdays),
+          weekday: cn(
+            'flex-1 rounded-(--cell-radius) text-[0.8rem] font-normal text-muted-foreground select-none',
+            defaultClassNames.weekday,
+          ),
+          week: cn('mt-2 flex w-full', defaultClassNames.week),
+          week_number_header: cn(
+            'w-(--cell-size) select-none',
+            defaultClassNames.week_number_header,
+          ),
+          week_number: cn(
+            'text-[0.8rem] text-muted-foreground select-none',
+            defaultClassNames.week_number,
+          ),
+          day: cn(
+            'group/day relative aspect-square h-full w-full rounded-(--cell-radius) p-0 text-center select-none [&:last-child[data-selected=true]_button]:rounded-r-(--cell-radius)',
+            props.showWeekNumber
+              ? '[&:nth-child(2)[data-selected=true]_button]:rounded-l-(--cell-radius)'
+              : '[&:first-child[data-selected=true]_button]:rounded-l-(--cell-radius)',
+            defaultClassNames.day,
+          ),
+          range_start: cn(
+            'relative isolate z-0 rounded-l-(--cell-radius) bg-muted after:absolute after:inset-y-0 after:right-0 after:w-4 after:bg-muted',
+            defaultClassNames.range_start,
+          ),
+          range_middle: cn('rounded-none', defaultClassNames.range_middle),
+          range_end: cn(
+            'relative isolate z-0 rounded-r-(--cell-radius) bg-muted after:absolute after:inset-y-0 after:left-0 after:w-4 after:bg-muted',
+            defaultClassNames.range_end,
+          ),
+          today: cn(
+            'rounded-(--cell-radius) bg-muted text-foreground data-[selected=true]:rounded-none',
+            defaultClassNames.today,
+          ),
+          outside: cn(
+            'text-muted-foreground aria-selected:text-muted-foreground',
+            defaultClassNames.outside,
+          ),
+          disabled: cn(
+            'text-muted-foreground opacity-50',
+            defaultClassNames.disabled,
+          ),
+          hidden: cn('invisible', defaultClassNames.hidden),
+          ...classNames,
+        }}
+        components={{
+          Root: CalendarRoot,
+          Chevron: CalendarChevron,
+          DayButton: CalendarDayButton,
+          WeekNumber: CalendarWeekNumber,
+          ...components,
+        }}
+        {...props}
+      />
+    </CalendarLocaleContext.Provider>
   )
 }
 
@@ -195,10 +203,10 @@ function CalendarDayButton({
   className,
   day,
   modifiers,
-  locale,
   ...props
-}: React.ComponentProps<typeof DayButton> & { locale?: Partial<Locale> }) {
+}: Readonly<React.ComponentProps<typeof DayButton>>) {
   const defaultClassNames = getDefaultClassNames()
+  const locale = React.useContext(CalendarLocaleContext)
 
   const ref = React.useRef<HTMLButtonElement>(null)
   React.useEffect(() => {

--- a/src/components/ui/popover.tsx
+++ b/src/components/ui/popover.tsx
@@ -53,13 +53,21 @@ function PopoverHeader({ className, ...props }: React.ComponentProps<'div'>) {
   )
 }
 
-function PopoverTitle({ className, ...props }: React.ComponentProps<'h2'>) {
+function PopoverTitle({
+  className,
+  children,
+  ...props
+}: Readonly<React.ComponentProps<'h2'>>) {
+  if (children == null || children === '') return null
+
   return (
     <h2
       data-slot="popover-title"
       className={cn('font-heading font-medium', className)}
       {...props}
-    />
+    >
+      {children}
+    </h2>
   )
 }
 

--- a/src/components/ui/popover.tsx
+++ b/src/components/ui/popover.tsx
@@ -58,7 +58,7 @@ function PopoverTitle({
   children,
   ...props
 }: Readonly<React.ComponentProps<'h2'>>) {
-  if (children == null || children === '') return null
+  if (children == null || children === false || children === '') return null
 
   return (
     <h2


### PR DESCRIPTION
## Summary

- Clears the remaining major Sonar UI component warnings.
- Extracts the custom DayPicker calendar components out of the parent render path while preserving locale-aware day rendering through context.
- Avoids rendering an empty popover heading when `PopoverTitle` has no content.

## SonarQube

- Before this branch: 60 open issues, including 5 major issues.
- After final scan: 55 open issues, all minor code smells.
- Remaining issues are readonly prop warnings, deprecated API warnings, and one union type alias warning.

## Validation

- `npm run lint:all`
- `npm run type-check`
- `npm run build`
- `npm run test:run`
- `make sonar`
