### PR TITLE
Resolve shared UI readonly Sonar warnings

### DIFF
--- a/src/components/garmin/ActivityCharts.tsx
+++ b/src/components/garmin/ActivityCharts.tsx
@@ -128,7 +128,12 @@ interface ChartTooltipProps {
   xMode: XAxisMode
 }
 
-function ChartTooltip({ label, payload, chart, xMode }: ChartTooltipProps) {
+function ChartTooltip({
+  label,
+  payload,
+  chart,
+  xMode,
+}: Readonly<ChartTooltipProps>) {
   const metricValue = coerceTooltipMetricValue(payload?.[0]?.value)
   const xValue = formatXAxisValue(label, xMode)
 
@@ -152,8 +157,11 @@ function normalizeTooltipIndex(
   return Number.NaN
 }
 
+type TooltipState =
+  Readonly<{ activeTooltipIndex?: number | string | null }> | undefined
+
 function pointFromTooltipState(
-  state: { activeTooltipIndex?: number | string | null } | undefined,
+  state: TooltipState,
   chartData: ChartDataPoint[],
 ): ChartDataPoint | null {
   const i = normalizeTooltipIndex(state?.activeTooltipIndex)
@@ -168,7 +176,7 @@ export function ActivityCharts({
   onActivePointChange,
   onPointToggle,
   cadenceAverage,
-}: ActivityChartsProps) {
+}: Readonly<ActivityChartsProps>) {
   const [xMode, setXMode] = useState<XAxisMode>('distance')
   const [smoothRespiration, setSmoothRespiration] = useState(false)
   const [collapsedCharts, setCollapsedCharts] = useState<Set<MetricKey>>(

--- a/src/components/garmin/ActivityStatsBar.tsx
+++ b/src/components/garmin/ActivityStatsBar.tsx
@@ -12,11 +12,11 @@ function StatItem({
   label,
   value,
   unit,
-}: {
+}: Readonly<{
   label: string
   value: string
   unit: string
-}) {
+}>) {
   return (
     <Card className="flex-1">
       <CardContent className="p-4 text-center">
@@ -35,7 +35,7 @@ export function ActivityStatsBar({
   durationSeconds,
   avgSpeedKmh,
   totalAscentM,
-}: ActivityStatsBarProps) {
+}: Readonly<ActivityStatsBarProps>) {
   return (
     <div className="grid grid-cols-2 gap-3 md:grid-cols-4">
       <StatItem

--- a/src/components/garmin/HeartRateZoneRibbon.tsx
+++ b/src/components/garmin/HeartRateZoneRibbon.tsx
@@ -5,10 +5,10 @@ import { buildHeartRateZoneSegments, ZONE_COLORS } from './heartRateZones'
 export function HeartRateZoneRibbon({
   data,
   xKey,
-}: {
+}: Readonly<{
   data: ChartDataPoint[]
   xKey: 'distance' | 'time'
-}) {
+}>) {
   const segments = buildHeartRateZoneSegments(data, xKey)
   if (segments.length === 0) return null
 

--- a/src/components/shared/EmptyState.tsx
+++ b/src/components/shared/EmptyState.tsx
@@ -6,12 +6,12 @@ export function EmptyState({
   message,
   onReset,
   resetLabel = 'Clear filters',
-}: {
+}: Readonly<{
   title?: string
   message?: string
   onReset?: () => void
   resetLabel?: string
-}) {
+}>) {
   return (
     <div className="flex flex-col items-center justify-center py-12 text-center">
       <Inbox className="h-8 w-8 text-muted-foreground" />

--- a/src/components/shared/ErrorState.tsx
+++ b/src/components/shared/ErrorState.tsx
@@ -4,10 +4,10 @@ import { Button } from '@/components/ui/button'
 export function ErrorState({
   message = 'Something went wrong',
   onRetry,
-}: {
+}: Readonly<{
   message?: string
   onRetry?: () => void
-}) {
+}>) {
   return (
     <div className="flex flex-col items-center justify-center py-12">
       <AlertCircle className="h-8 w-8 text-destructive" />

--- a/src/components/shared/LoadingState.tsx
+++ b/src/components/shared/LoadingState.tsx
@@ -1,6 +1,8 @@
 import { Loader2 } from 'lucide-react'
 
-export function LoadingState({ message = 'Loading...' }: { message?: string }) {
+export function LoadingState({
+  message = 'Loading...',
+}: Readonly<{ message?: string }>) {
   return (
     <div className="flex flex-col items-center justify-center py-12">
       <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />

--- a/src/components/shared/StatsCard.tsx
+++ b/src/components/shared/StatsCard.tsx
@@ -8,7 +8,12 @@ interface StatsCardProps {
   description?: string
 }
 
-export function StatsCard({ title, value, icon, description }: StatsCardProps) {
+export function StatsCard({
+  title,
+  value,
+  icon,
+  description,
+}: Readonly<StatsCardProps>) {
   return (
     <Card>
       <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -25,7 +25,7 @@ export interface BadgeProps
     React.HTMLAttributes<HTMLDivElement>,
     VariantProps<typeof badgeVariants> {}
 
-function Badge({ className, variant, ...props }: BadgeProps) {
+function Badge({ className, variant, ...props }: Readonly<BadgeProps>) {
   return (
     <div className={cn(badgeVariants({ variant }), className)} {...props} />
   )

--- a/src/components/ui/popover.tsx
+++ b/src/components/ui/popover.tsx
@@ -5,13 +5,13 @@ import { cn } from '@/lib/utils'
 
 function Popover({
   ...props
-}: React.ComponentProps<typeof PopoverPrimitive.Root>) {
+}: Readonly<React.ComponentProps<typeof PopoverPrimitive.Root>>) {
   return <PopoverPrimitive.Root data-slot="popover" {...props} />
 }
 
 function PopoverTrigger({
   ...props
-}: React.ComponentProps<typeof PopoverPrimitive.Trigger>) {
+}: Readonly<React.ComponentProps<typeof PopoverPrimitive.Trigger>>) {
   return <PopoverPrimitive.Trigger data-slot="popover-trigger" {...props} />
 }
 
@@ -20,7 +20,7 @@ function PopoverContent({
   align = 'center',
   sideOffset = 4,
   ...props
-}: React.ComponentProps<typeof PopoverPrimitive.Content>) {
+}: Readonly<React.ComponentProps<typeof PopoverPrimitive.Content>>) {
   return (
     <PopoverPrimitive.Portal>
       <PopoverPrimitive.Content
@@ -39,11 +39,14 @@ function PopoverContent({
 
 function PopoverAnchor({
   ...props
-}: React.ComponentProps<typeof PopoverPrimitive.Anchor>) {
+}: Readonly<React.ComponentProps<typeof PopoverPrimitive.Anchor>>) {
   return <PopoverPrimitive.Anchor data-slot="popover-anchor" {...props} />
 }
 
-function PopoverHeader({ className, ...props }: React.ComponentProps<'div'>) {
+function PopoverHeader({
+  className,
+  ...props
+}: Readonly<React.ComponentProps<'div'>>) {
   return (
     <div
       data-slot="popover-header"
@@ -74,7 +77,7 @@ function PopoverTitle({
 function PopoverDescription({
   className,
   ...props
-}: React.ComponentProps<'p'>) {
+}: Readonly<React.ComponentProps<'p'>>) {
   return (
     <p
       data-slot="popover-description"


### PR DESCRIPTION
## Summary

- Marks shared and UI component props as readonly for Sonar S6759.
- Marks small Garmin chart component props as readonly.
- Replaces the inline tooltip state union with a named alias in ActivityCharts.

## SonarQube

- Before this branch: 55 open minor code smells.
- After final scan: 43 open minor code smells.
- Remaining issues are 38 readonly-prop warnings and 5 deprecated API warnings.

## Validation

- `npm run lint:all`
- `npm run type-check`
- `npm run build`
- `npm run test:run`
- `make sonar`
