### PR TITLE
Resolve dashboard readonly Sonar warnings

### DIFF
--- a/src/components/dashboard/CyclingInFocus.tsx
+++ b/src/components/dashboard/CyclingInFocus.tsx
@@ -52,10 +52,10 @@ interface DayBucket {
 function ActivityTooltip({
   active,
   payload,
-}: {
+}: Readonly<{
   active?: boolean
   payload?: Array<{ payload: DayBucket }>
-}) {
+}>) {
   const day = payload?.[0]?.payload
   if (!active || !day) return null
 

--- a/src/components/dashboard/GarminActivitiesTable.tsx
+++ b/src/components/dashboard/GarminActivitiesTable.tsx
@@ -34,7 +34,7 @@ export function GarminActivitiesTable({
   onSportClick,
   rowTestId = 'garmin-activity-table-row',
   sportLinkTestId = 'garmin-activity-table-sport-link',
-}: GarminActivitiesTableProps) {
+}: Readonly<GarminActivitiesTableProps>) {
   return (
     <table className="w-full text-xs">
       <thead className="sticky top-0 bg-popover">

--- a/src/components/dashboard/GarminActivityTotals.tsx
+++ b/src/components/dashboard/GarminActivityTotals.tsx
@@ -48,7 +48,7 @@ function SegmentedControl<T extends string>({
   value,
   onChange,
   options,
-}: SegmentedControlProps<T>) {
+}: Readonly<SegmentedControlProps<T>>) {
   return (
     <div
       role="radiogroup"

--- a/src/components/dashboard/GarminDayActivitiesPopover.tsx
+++ b/src/components/dashboard/GarminDayActivitiesPopover.tsx
@@ -18,7 +18,7 @@ export function GarminDayActivitiesPopover({
   open,
   onOpenChange,
   anchorPos,
-}: GarminDayActivitiesPopoverProps) {
+}: Readonly<GarminDayActivitiesPopoverProps>) {
   const { data, loading, error } = useGarminActivitiesQuery({
     variables: {
       date_from: date ?? undefined,

--- a/src/components/garmin/DeleteSegmentButton.tsx
+++ b/src/components/garmin/DeleteSegmentButton.tsx
@@ -21,7 +21,7 @@ export function DeleteSegmentButton({
   segmentId,
   segmentName,
   onDeleted,
-}: DeleteSegmentButtonProps) {
+}: Readonly<DeleteSegmentButtonProps>) {
   const { isAuthenticated, login } = useAuth()
   const [open, setOpen] = useState(false)
 

--- a/src/components/garmin/LapComparisonMatrix.tsx
+++ b/src/components/garmin/LapComparisonMatrix.tsx
@@ -32,7 +32,7 @@ function formatActivityDate(iso: string | null): string {
 export function LapComparisonMatrix({
   items,
   metric,
-}: LapComparisonMatrixProps) {
+}: Readonly<LapComparisonMatrixProps>) {
   const matrix = buildComparisonMatrix(items, metric)
   const lapColumns = Array.from({ length: matrix.lapCount }, (_, i) => i + 1)
 

--- a/src/components/garmin/SaveSegmentPopover.tsx
+++ b/src/components/garmin/SaveSegmentPopover.tsx
@@ -46,7 +46,7 @@ export function SaveSegmentPopover({
   sourceLapIndex = null,
   sourceClimbIndex = null,
   sourceLabel,
-}: SaveSegmentPopoverProps) {
+}: Readonly<SaveSegmentPopoverProps>) {
   const { isAuthenticated, login } = useAuth()
   const [open, setOpen] = useState(false)
   const [name, setName] = useState(defaultName)

--- a/src/components/garmin/SegmentEffortsLeaderboard.tsx
+++ b/src/components/garmin/SegmentEffortsLeaderboard.tsx
@@ -31,7 +31,7 @@ interface SegmentEffortsLeaderboardProps {
 
 export function SegmentEffortsLeaderboard({
   efforts,
-}: SegmentEffortsLeaderboardProps) {
+}: Readonly<SegmentEffortsLeaderboardProps>) {
   const [sort, setSort] = useState<EffortSort>('date')
 
   const bestActivityId = useMemo(() => bestEffortActivityId(efforts), [efforts])

--- a/src/components/garmin/SegmentMiniMap.tsx
+++ b/src/components/garmin/SegmentMiniMap.tsx
@@ -24,7 +24,7 @@ export function SegmentMiniMap({
   endLon,
   label,
   route,
-}: SegmentMiniMapProps) {
+}: Readonly<SegmentMiniMapProps>) {
   const mapRef = useRef<HTMLElement>(null)
   const mapInstanceRef = useRef<L.Map | null>(null)
 

--- a/src/components/garmin/SegmentStartEndMap.tsx
+++ b/src/components/garmin/SegmentStartEndMap.tsx
@@ -50,7 +50,7 @@ export function SegmentStartEndMap({
   endLat,
   endLon,
   routePoints = [],
-}: SegmentStartEndMapProps) {
+}: Readonly<SegmentStartEndMapProps>) {
   const mapRef = useRef<HTMLDivElement>(null)
   const mapInstanceRef = useRef<L.Map | null>(null)
 

--- a/src/components/shared/DateRangePicker.tsx
+++ b/src/components/shared/DateRangePicker.tsx
@@ -62,7 +62,7 @@ export function DateRangePicker({
   onRangeChange,
   minDate,
   maxDate = new Date(),
-}: DateRangePickerProps) {
+}: Readonly<DateRangePickerProps>) {
   const hasRange = dateFrom != null || dateTo != null
 
   const selected: DateRange | undefined =

--- a/src/pages/LapComparisonPage.tsx
+++ b/src/pages/LapComparisonPage.tsx
@@ -22,7 +22,7 @@ import { setNRCustomAttribute } from '@/lib/newrelic-browser'
 
 const MAX_ACTIVITIES = 50
 
-function HeatLegend({ metricUnit }: { metricUnit: string }) {
+function HeatLegend({ metricUnit }: Readonly<{ metricUnit: string }>) {
   return (
     <div className="flex flex-wrap items-center gap-4 text-xs text-muted-foreground">
       <div className="flex items-center gap-1">


### PR DESCRIPTION
## Summary

- Marks dashboard component props as readonly for Sonar S6759.
- Marks small Garmin segment and lap comparison component props as readonly.
- Keeps the change limited to TypeScript prop annotations with no runtime behavior changes.

## SonarQube

- Before this branch: 43 open minor code smells.
- After final scan: 31 open minor code smells.
- Remaining issues are 26 readonly-prop warnings and 5 deprecated API warnings.

## Validation

- `npm run format -- src/components/dashboard/GarminActivitiesTable.tsx src/components/dashboard/CyclingInFocus.tsx src/components/dashboard/GarminActivityTotals.tsx src/components/dashboard/GarminDayActivitiesPopover.tsx src/components/garmin/SegmentMiniMap.tsx src/components/garmin/SegmentStartEndMap.tsx src/components/garmin/SaveSegmentPopover.tsx src/components/garmin/DeleteSegmentButton.tsx src/components/garmin/SegmentEffortsLeaderboard.tsx src/components/garmin/LapComparisonMatrix.tsx src/pages/LapComparisonPage.tsx src/components/shared/DateRangePicker.tsx`
- `npm run type-check`
- `npm run test:run -- GarminActivitiesTable CyclingInFocus GarminActivityTotals GarminDayActivitiesPopover SegmentMiniMap SaveSegmentPopover DeleteSegmentButton SegmentEffortsLeaderboard LapComparisonMatrix LapComparisonPage DateRangePicker`
- `npm run lint:all`
- `npm run build`
- `npm run test:run`
- `make sonar`
