### PR TITLE
Resolve Garmin detail readonly Sonar warnings

### DIFF
--- a/src/components/garmin/ActivityHeader.tsx
+++ b/src/components/garmin/ActivityHeader.tsx
@@ -37,7 +37,7 @@ export function ActivityHeader({
   deviceManufacturer,
   device,
   backTo = '/garmin',
-}: ActivityHeaderProps) {
+}: Readonly<ActivityHeaderProps>) {
   const icon = sportIcons[sport] ?? <Activity className="h-6 w-6" />
 
   const deviceModel = device?.model

--- a/src/components/garmin/ActivityHoverDetails.tsx
+++ b/src/components/garmin/ActivityHoverDetails.tsx
@@ -54,7 +54,7 @@ export function ActivityHoverDetails({
   point,
   isSaved = false,
   onToggleSave,
-}: ActivityHoverDetailsProps) {
+}: Readonly<ActivityHoverDetailsProps>) {
   const target = useMemo(() => coordKey(point), [point])
   const [pendingState, setPendingState] = useState<{
     key: string
@@ -220,7 +220,7 @@ function formatHoverDistance(point: ChartDataPoint): string {
   return `${point.distance.toFixed(2)} mi${km}`
 }
 
-function Field({ label, value }: { label: string; value: string }) {
+function Field({ label, value }: Readonly<{ label: string; value: string }>) {
   return (
     <div className="flex flex-col">
       <span className="text-muted-foreground">{label}</span>

--- a/src/components/garmin/ActivityLapsTable.tsx
+++ b/src/components/garmin/ActivityLapsTable.tsx
@@ -95,7 +95,7 @@ function surfacePercent(
   return (surfaceMeters / distanceMeters) * 100
 }
 
-function LapStat({ label, value }: { label: string; value: string }) {
+function LapStat({ label, value }: Readonly<{ label: string; value: string }>) {
   return (
     <div>
       <div className="text-xl font-semibold leading-none">{value}</div>
@@ -109,12 +109,12 @@ function ActivityLapDetailsPanel({
   laps,
   chartPoints,
   sport,
-}: {
+}: Readonly<{
   lap: ActivityLap
   laps: ActivityLap[]
   chartPoints: ActivityChartTrackPoint[]
   sport?: string | null
-}) {
+}>) {
   const segmentPoints = useMemo(
     () => getLapSegmentPoints(lap, chartPoints, laps),
     [lap, chartPoints, laps],
@@ -231,7 +231,7 @@ export function ActivityLapsTable({
   laps,
   chartPoints = [],
   sport,
-}: ActivityLapsTableProps) {
+}: Readonly<ActivityLapsTableProps>) {
   const [selectedLapIndex, setSelectedLapIndex] = useState<number | null>(null)
   const orderedLaps = useMemo(
     () => [...laps].sort((a, b) => a.lap_index - b.lap_index),

--- a/src/components/garmin/ActivityRouteMap.tsx
+++ b/src/components/garmin/ActivityRouteMap.tsx
@@ -55,7 +55,7 @@ export function ActivityRouteMap({
   savedPoints = [],
   onSavedPointRemove,
   onMapPointSelect,
-}: ActivityRouteMapProps) {
+}: Readonly<ActivityRouteMapProps>) {
   const mapRef = useRef<HTMLDivElement>(null)
   const mapInstanceRef = useRef<L.Map | null>(null)
   const hoverMarkerRef = useRef<L.CircleMarker | null>(null)

--- a/src/components/garmin/SavedPointsList.tsx
+++ b/src/components/garmin/SavedPointsList.tsx
@@ -18,7 +18,7 @@ export function SavedPointsList({
   points,
   onRemove,
   onClear,
-}: SavedPointsListProps) {
+}: Readonly<SavedPointsListProps>) {
   if (points.length === 0) return null
 
   return (

--- a/src/components/garmin/SegmentAnalysis.tsx
+++ b/src/components/garmin/SegmentAnalysis.tsx
@@ -60,7 +60,7 @@ export function SegmentAnalysis({
   points,
   activityId,
   sport,
-}: SegmentAnalysisProps) {
+}: Readonly<SegmentAnalysisProps>) {
   const segments = buildSavedSegments(points)
   if (segments.length === 0) return null
 


### PR DESCRIPTION
## Summary

- Marks Garmin detail component props as readonly for Sonar S6759.
- Covers activity header, hover details, laps table, route map, saved points, and segment analysis components.
- Keeps the change limited to TypeScript prop annotations with no runtime behavior changes.

## SonarQube

- Before this branch: 31 open minor code smells.
- After final scan: 22 open minor code smells.
- Remaining issues are 17 readonly-prop warnings and 5 deprecated API warnings.

## Validation

- `npm run format -- src/components/garmin/SegmentAnalysis.tsx src/components/garmin/ActivityHeader.tsx src/components/garmin/ActivityRouteMap.tsx src/components/garmin/SavedPointsList.tsx src/components/garmin/ActivityHoverDetails.tsx src/components/garmin/ActivityLapsTable.tsx`
- `npm run type-check`
- `npm run test:run -- SegmentAnalysis ActivityHeader ActivityHoverDetails ActivityLapsTable SavedPointsList GarminDetailPage`
- `npm run lint:all`
- `npm run build`
- `npm run test:run`
- `make sonar`
