### PR TITLE
Resolve remaining Garmin readonly Sonar warnings

### DIFF
--- a/src/components/garmin/ActivityStatsPanel.tsx
+++ b/src/components/garmin/ActivityStatsPanel.tsx
@@ -140,11 +140,11 @@ function TrainingEffectGauge({
   label,
   value,
   markerClassName,
-}: {
+}: Readonly<{
   label: string
   value: number | null | undefined
   markerClassName: string
-}) {
+}>) {
   const safeValue = hasTrainingEffect(value) ? value : null
   const markerPosition = safeValue != null ? (safeValue / 5) * 100 : null
 
@@ -187,10 +187,10 @@ function TrainingEffectGauge({
 function TrainingEffectGraphic({
   aerobic,
   anaerobic,
-}: {
+}: Readonly<{
   aerobic: number | null | undefined
   anaerobic: number | null | undefined
-}) {
+}>) {
   if (!hasTrainingEffect(aerobic) && !hasTrainingEffect(anaerobic)) {
     return null
   }
@@ -254,9 +254,9 @@ function formatObservedRange(
 
 function HeartRateZoneBreakdown({
   summaries,
-}: {
+}: Readonly<{
   summaries: HeartRateZoneSummary[]
-}) {
+}>) {
   const hasZoneTime = summaries.some((summary) => summary.seconds > 0)
   if (!hasZoneTime) return null
 
@@ -550,7 +550,7 @@ function buildStatSections(
 export function ActivityStatsPanel({
   activity: a,
   heartRateZonePoints = [],
-}: ActivityStatsPanelProps) {
+}: Readonly<ActivityStatsPanelProps>) {
   const hasHeartRateSamples = heartRateZonePoints.some((point) =>
     isValidHeartRate(point.heart_rate),
   )

--- a/src/components/garmin/ClimbDetailsPanel.tsx
+++ b/src/components/garmin/ClimbDetailsPanel.tsx
@@ -154,7 +154,10 @@ function axisTicks(min: number, max: number, count: number): number[] {
   return Array.from({ length: count }, (_, index) => min + step * index)
 }
 
-function ClimbStat({ label, value }: { label: string; value: string }) {
+function ClimbStat({
+  label,
+  value,
+}: Readonly<{ label: string; value: string }>) {
   return (
     <div>
       <div className="text-2xl font-semibold leading-none">{value}</div>
@@ -363,7 +366,9 @@ const METRIC_OPTIONS: ClimbMapMetricOption[] = [
   },
 ]
 
-function ClimbElevationGradeChart({ points }: { points: ClimbGraphPoint[] }) {
+function ClimbElevationGradeChart({
+  points,
+}: Readonly<{ points: ClimbGraphPoint[] }>) {
   if (points.length < 2) {
     return (
       <div className="rounded-md border border-dashed p-6 text-sm text-muted-foreground">
@@ -519,7 +524,7 @@ function ClimbElevationGradeChart({ points }: { points: ClimbGraphPoint[] }) {
   )
 }
 
-function ClimbSegmentMap({ points }: { points: ClimbMapPoint[] }) {
+function ClimbSegmentMap({ points }: Readonly<{ points: ClimbMapPoint[] }>) {
   const mapRef = useRef<HTMLDivElement>(null)
   const mapInstanceRef = useRef<L.Map | null>(null)
   const routeLayerRef = useRef<L.LayerGroup | null>(null)
@@ -695,7 +700,7 @@ export function ClimbDetailsPanel({
   canPrevious,
   canNext,
   sport,
-}: ClimbDetailsPanelProps) {
+}: Readonly<ClimbDetailsPanelProps>) {
   const segmentPoints = useMemo(
     () => getClimbSegmentPoints(climb, chartPoints),
     [climb, chartPoints],

--- a/src/components/shared/UnifiedGpsMap.tsx
+++ b/src/components/shared/UnifiedGpsMap.tsx
@@ -117,7 +117,7 @@ export function UnifiedGpsMap({
   colorBy = 'source',
   focusKey,
   onMarkerClick,
-}: UnifiedGpsMapProps) {
+}: Readonly<UnifiedGpsMapProps>) {
   const mapInstanceRef = useRef<L.Map | null>(null)
   const cleanupRef = useRef<(() => void) | null>(null)
   const markersRef = useRef<Map<string, L.CircleMarker>>(new Map())

--- a/src/pages/GarminDetailPage.tsx
+++ b/src/pages/GarminDetailPage.tsx
@@ -189,11 +189,11 @@ function ActivityClimbsTable({
   climbs,
   selectedClimbId,
   onSelectClimb,
-}: {
+}: Readonly<{
   climbs: ActivityClimb[]
   selectedClimbId: number | null
   onSelectClimb: (climbId: number) => void
-}) {
+}>) {
   if (climbs.length === 0) {
     return (
       <div className="rounded-md border border-dashed p-6 text-sm text-muted-foreground">


### PR DESCRIPTION
## Summary

- Marks remaining Garmin/detail map component props as readonly for Sonar S6759.
- Covers ActivityStatsPanel, ClimbDetailsPanel, GarminDetailPage, and UnifiedGpsMap.
- Keeps the change limited to TypeScript prop annotations with no runtime behavior changes.

## SonarQube

- Before this branch: 22 open minor code smells.
- After final scan: 12 open minor code smells.
- Remaining issues are 7 readonly-prop warnings and 5 deprecated API warnings.

## Validation

- `npm run format -- src/components/garmin/ActivityStatsPanel.tsx src/pages/GarminDetailPage.tsx src/components/shared/UnifiedGpsMap.tsx src/components/garmin/ClimbDetailsPanel.tsx`
- `npm run type-check`
- `npm run test:run -- ActivityStatsPanel ClimbDetailsPanel GarminDetailPage MapPage`
- `npm run lint:all`
- `npm run build`
- `npm run test:run`
- `make sonar`
