### PR TITLE
Resolve deprecated dashboard Sonar warnings

### DIFF
--- a/src/components/dashboard/CyclingInFocus.test.tsx
+++ b/src/components/dashboard/CyclingInFocus.test.tsx
@@ -31,7 +31,7 @@ vi.mock('recharts', () => ({
     return <div data-testid="bar-chart">{children}</div>
   },
   Bar: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
-  Cell: () => null,
+  Rectangle: (props: React.SVGProps<SVGRectElement>) => <rect {...props} />,
   XAxis: (props: Record<string, unknown>) => {
     latestXAxisProps = props
     return null

--- a/src/components/dashboard/CyclingInFocus.tsx
+++ b/src/components/dashboard/CyclingInFocus.tsx
@@ -3,10 +3,11 @@ import { addDays, differenceInCalendarDays, format, subDays } from 'date-fns'
 import {
   Bar,
   BarChart,
-  Cell,
+  Rectangle,
   ResponsiveContainer,
   Tooltip,
   XAxis,
+  type RectangleProps,
 } from 'recharts'
 import { Bike, ChevronLeft, ChevronRight } from 'lucide-react'
 import { useGarminActivitiesQuery } from '@/__generated__/graphql'
@@ -48,6 +49,10 @@ interface DayBucket {
   activities: GarminActivityTableRow[]
 }
 
+type CyclingBarShapeProps = RectangleProps & {
+  payload?: DayBucket
+}
+
 // Recharts tooltip styled to match the Garmin Activity heatmap day popover.
 function ActivityTooltip({
   active,
@@ -80,6 +85,17 @@ function ActivityTooltip({
         </p>
       )}
     </div>
+  )
+}
+
+function CyclingBarShape(props: CyclingBarShapeProps) {
+  const { payload, ...rectangleProps } = props
+  return (
+    <Rectangle
+      {...rectangleProps}
+      fill={BAR_COLOR}
+      fillOpacity={(payload?.distance_mi ?? 0) > 0 ? 1 : 0.2}
+    />
   )
 }
 
@@ -268,15 +284,11 @@ export function CyclingInFocus() {
                     cursor={{ fill: 'transparent' }}
                     content={<ActivityTooltip />}
                   />
-                  <Bar dataKey="distance_mi" radius={[4, 4, 0, 0]}>
-                    {days.map((day) => (
-                      <Cell
-                        key={day.date}
-                        fill={BAR_COLOR}
-                        fillOpacity={day.distance_mi > 0 ? 1 : 0.2}
-                      />
-                    ))}
-                  </Bar>
+                  <Bar
+                    dataKey="distance_mi"
+                    radius={[4, 4, 0, 0]}
+                    shape={CyclingBarShape}
+                  />
                 </BarChart>
               </ResponsiveContainer>
             </div>

--- a/src/components/dashboard/GarminActivityTotals.tsx
+++ b/src/components/dashboard/GarminActivityTotals.tsx
@@ -10,6 +10,7 @@ import {
   YAxis,
 } from 'recharts'
 import { ChevronLeft, ChevronRight, TrendingUp } from 'lucide-react'
+import type { TypedDocumentNode } from '@apollo/client'
 import { useApolloClient } from '@apollo/client/react'
 import {
   GarminActivityTotalsDocument,
@@ -113,6 +114,11 @@ const MONTH_FULL_NAMES = [
 ]
 
 const ACTIVITY_TOTALS_START_YEAR = 2010
+const GARMIN_ACTIVITY_TOTALS_DOCUMENT =
+  GarminActivityTotalsDocument as TypedDocumentNode<
+    GarminActivityTotalsQuery,
+    GarminActivityTotalsQueryVariables
+  >
 
 interface MetricConfig {
   key: Metric
@@ -241,11 +247,8 @@ async function fetchYearWeeklyTotal(
     weekStart.getFullYear() + (year - baseEndYear),
   )
   const we = projectToYear(weekEnd, year)
-  const result = await apolloClient.query<
-    GarminActivityTotalsQuery,
-    GarminActivityTotalsQueryVariables
-  >({
-    query: GarminActivityTotalsDocument,
+  const result = await apolloClient.query({
+    query: GARMIN_ACTIVITY_TOTALS_DOCUMENT,
     variables: {
       period: 'week',
       date_from: format(ws, 'yyyy-MM-dd'),

--- a/src/lib/apollo.test.ts
+++ b/src/lib/apollo.test.ts
@@ -1,9 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const apolloMocks = vi.hoisted(() => {
-  const concatMock = vi.fn(function concat(link: unknown) {
-    return { type: 'combined-link', inner: link }
-  })
   return {
     getConfigMock: vi.fn(),
     HttpLinkMock: vi.fn(function HttpLink(options: unknown) {
@@ -22,8 +19,13 @@ const apolloMocks = vi.hoisted(() => {
         options,
       }
     }),
-    setContextMock: vi.fn(() => ({ type: 'auth-link', concat: concatMock })),
-    concatMock,
+    ApolloLinkFromMock: vi.fn((links: unknown[]) => ({
+      type: 'combined-link',
+      links,
+    })),
+    SetContextLinkMock: vi.fn(function SetContextLink(setter: unknown) {
+      return { type: 'auth-link', setter }
+    }),
     getAccessTokenMock: vi.fn().mockResolvedValue(null),
   }
 })
@@ -34,12 +36,13 @@ vi.mock('@/config/runtime', () => ({
 
 vi.mock('@apollo/client', () => ({
   ApolloClient: apolloMocks.ApolloClientMock,
+  ApolloLink: { from: apolloMocks.ApolloLinkFromMock },
   HttpLink: apolloMocks.HttpLinkMock,
   InMemoryCache: apolloMocks.InMemoryCacheMock,
 }))
 
 vi.mock('@apollo/client/link/context', () => ({
-  setContext: apolloMocks.setContextMock,
+  SetContextLink: apolloMocks.SetContextLinkMock,
 }))
 
 vi.mock('@/services/auth', () => ({
@@ -55,8 +58,8 @@ describe('apollo client', () => {
     apolloMocks.HttpLinkMock.mockClear()
     apolloMocks.InMemoryCacheMock.mockClear()
     apolloMocks.ApolloClientMock.mockClear()
-    apolloMocks.setContextMock.mockClear()
-    apolloMocks.concatMock.mockClear()
+    apolloMocks.ApolloLinkFromMock.mockClear()
+    apolloMocks.SetContextLinkMock.mockClear()
     apolloMocks.getAccessTokenMock.mockReset().mockResolvedValue(null)
     apolloMocks.getConfigMock.mockReturnValue(
       'https://graphql.example.com/query',
@@ -87,8 +90,8 @@ describe('apollo client', () => {
     })
     expect(apolloMocks.InMemoryCacheMock).toHaveBeenCalledTimes(1)
     expect(apolloMocks.ApolloClientMock).toHaveBeenCalledTimes(1)
-    expect(apolloMocks.setContextMock).toHaveBeenCalledTimes(1)
-    expect(apolloMocks.concatMock).toHaveBeenCalledTimes(1)
+    expect(apolloMocks.SetContextLinkMock).toHaveBeenCalledTimes(1)
+    expect(apolloMocks.ApolloLinkFromMock).toHaveBeenCalledTimes(1)
     expect(createdOptions.defaultOptions.watchQuery.fetchPolicy).toBe(
       'cache-and-network',
     )
@@ -99,14 +102,13 @@ describe('apollo client', () => {
     getApolloClient()
 
     const contextFn = (
-      apolloMocks.setContextMock.mock.calls as unknown[][]
-    )[0][0] as (
-      req: unknown,
-      prev: { headers?: Record<string, string> },
-    ) => Promise<{ headers: Record<string, string> }>
+      apolloMocks.SetContextLinkMock.mock.calls as unknown[][]
+    )[0][0] as (prev: {
+      headers?: Record<string, string>
+    }) => Promise<{ headers: Record<string, string> }>
 
     apolloMocks.getAccessTokenMock.mockResolvedValue('my-jwt')
-    const result = await contextFn({}, { headers: { 'X-Custom': 'val' } })
+    const result = await contextFn({ headers: { 'X-Custom': 'val' } })
 
     expect(result.headers).toEqual({
       'X-Custom': 'val',
@@ -119,14 +121,13 @@ describe('apollo client', () => {
     getApolloClient()
 
     const contextFn = (
-      apolloMocks.setContextMock.mock.calls as unknown[][]
-    )[0][0] as (
-      req: unknown,
-      prev: { headers?: Record<string, string> },
-    ) => Promise<{ headers: Record<string, string> }>
+      apolloMocks.SetContextLinkMock.mock.calls as unknown[][]
+    )[0][0] as (prev: {
+      headers?: Record<string, string>
+    }) => Promise<{ headers: Record<string, string> }>
 
     apolloMocks.getAccessTokenMock.mockResolvedValue(null)
-    const result = await contextFn({}, {})
+    const result = await contextFn({})
 
     expect(result.headers).not.toHaveProperty('Authorization')
   })

--- a/src/lib/apollo.test.ts
+++ b/src/lib/apollo.test.ts
@@ -103,12 +103,13 @@ describe('apollo client', () => {
 
     const contextFn = (
       apolloMocks.SetContextLinkMock.mock.calls as unknown[][]
-    )[0][0] as (prev: {
-      headers?: Record<string, string>
-    }) => Promise<{ headers: Record<string, string> }>
+    )[0][0] as (
+      prevContext: { headers?: Record<string, string> },
+      operation: unknown,
+    ) => Promise<{ headers: Record<string, string> }>
 
     apolloMocks.getAccessTokenMock.mockResolvedValue('my-jwt')
-    const result = await contextFn({ headers: { 'X-Custom': 'val' } })
+    const result = await contextFn({ headers: { 'X-Custom': 'val' } }, {})
 
     expect(result.headers).toEqual({
       'X-Custom': 'val',
@@ -122,12 +123,13 @@ describe('apollo client', () => {
 
     const contextFn = (
       apolloMocks.SetContextLinkMock.mock.calls as unknown[][]
-    )[0][0] as (prev: {
-      headers?: Record<string, string>
-    }) => Promise<{ headers: Record<string, string> }>
+    )[0][0] as (
+      prevContext: { headers?: Record<string, string> },
+      operation: unknown,
+    ) => Promise<{ headers: Record<string, string> }>
 
     apolloMocks.getAccessTokenMock.mockResolvedValue(null)
-    const result = await contextFn({})
+    const result = await contextFn({}, {})
 
     expect(result.headers).not.toHaveProperty('Authorization')
   })

--- a/src/lib/apollo.ts
+++ b/src/lib/apollo.ts
@@ -1,5 +1,10 @@
-import { ApolloClient, InMemoryCache, HttpLink } from '@apollo/client'
-import { setContext } from '@apollo/client/link/context'
+import {
+  ApolloClient,
+  ApolloLink,
+  InMemoryCache,
+  HttpLink,
+} from '@apollo/client'
+import { SetContextLink } from '@apollo/client/link/context'
 import { getConfig } from '@/config/runtime'
 import { authService } from '@/services/auth'
 
@@ -17,7 +22,7 @@ export function getApolloClient(): ApolloClient {
     uri: graphqlUrl,
   })
 
-  const authLink = setContext(async (_, { headers }) => {
+  const authLink = new SetContextLink(async ({ headers }) => {
     const token = await authService.getAccessToken()
     return {
       headers: {
@@ -28,7 +33,7 @@ export function getApolloClient(): ApolloClient {
   })
 
   client = new ApolloClient({
-    link: authLink.concat(httpLink),
+    link: ApolloLink.from([authLink, httpLink]),
     cache: new InMemoryCache(),
     defaultOptions: {
       watchQuery: {

--- a/src/pages/DashboardPage.test.tsx
+++ b/src/pages/DashboardPage.test.tsx
@@ -12,6 +12,7 @@ const dashboardHooks = vi.hoisted(() => ({
   useGarminActivitiesQuery: vi.fn(),
   useGarminActivityTotalsQuery: vi.fn(),
   useGarminDateRangeQuery: vi.fn(),
+  GarminActivityTotalsDocument: { kind: 'Document' },
   useTriggerGarminSyncMutation: vi
     .fn()
     .mockReturnValue([vi.fn(), { loading: false }]),
@@ -39,7 +40,9 @@ import { DashboardPage } from './DashboardPage'
 
 describe('DashboardPage', () => {
   beforeEach(() => {
-    Object.values(dashboardHooks).forEach((mock) => mock.mockReset())
+    Object.values(dashboardHooks).forEach((mock) => {
+      if (typeof mock === 'function') mock.mockReset()
+    })
     dashboardHooks.useTriggerGarminSyncMutation.mockReturnValue([
       vi.fn(),
       { loading: false },


### PR DESCRIPTION
## Summary

Refs #<!-- issue number - do NOT use "Closes" or "Fixes" (see below) -->

Replaces the remaining deprecated API usages reported by SonarQube in the dashboard/client code.

- Replaces deprecated Recharts `Cell` usage in `CyclingInFocus` with a custom `Bar` shape.
- Replaces deprecated Apollo `setContext` usage with `SetContextLink` and `ApolloLink.from`.
- Removes deprecated explicit `ApolloClient.query` generics by using a typed document node.
- Updates focused tests and mocks for the new APIs.

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New page / component
- [ ] UI enhancement (non-breaking)
- [ ] GraphQL query / mutation change
- [ ] CI/CD pipeline change
- [ ] Documentation update

## Checklist

- [x] Read `README.md` and relevant docs
- [x] No secrets or credentials committed
- [x] Environment variables use `VITE_` prefix
- [x] Ran `npm run lint:all` locally (hooks passing)
- [x] Ran `npm run test` (tests passing)
- [x] Ran `npm run type-check` (no type errors)

## SonarQube

- Before this branch: 5 open minor code smells, all `typescript:S1874`.
- After scan: 0 open unresolved issues.
- CE task: `39adee7e-dba2-4def-9447-550aab16a90a` completed with `SUCCESS`.

## Deployment

- [ ] Does this need [k8s-gitops](https://github.com/stuartshay/k8s-gitops) manifest changes?

No manifest changes needed.

## Testing

```bash
npm run format -- src/pages/DashboardPage.test.tsx src/components/dashboard/CyclingInFocus.tsx src/components/dashboard/CyclingInFocus.test.tsx src/components/dashboard/GarminActivityTotals.tsx src/lib/apollo.ts src/lib/apollo.test.ts
npm run type-check
npm run test:run -- apollo CyclingInFocus GarminActivityTotals DashboardPage
npm run lint:all
npm run build
npm run test:run
make sonar
```

## Post-Merge Validation

After this PR merges:

### For changes that affect deployed UI (components, pages, GraphQL, config)

- [ ] Docker image built and pushed (CI)
- [ ] k8s-gitops deployment PR created and merged
- [ ] Argo CD synced to cluster
- [ ] Acceptance criteria validated against deployed behavior

### For all PRs

- [ ] Final validation comment posted on the linked issue
- [ ] Issue closed manually after all criteria confirmed
- [ ] If any criterion cannot be validated, reason documented on the issue

## Notes

Scanner reported missing blame for the edited files because they were uncommitted at scan time; the CE task still processed successfully and unresolved issue facets now report zero issues.
