### PR TITLE
test: complete Garmin activities page coverage

### DIFF
--- a/src/pages/GarminPage.test.tsx
+++ b/src/pages/GarminPage.test.tsx
@@ -13,6 +13,28 @@ const garminHooks = vi.hoisted(() => ({
 
 vi.mock('@/__generated__/graphql', () => garminHooks)
 
+vi.mock('@/components/shared/DateRangePicker', () => ({
+  DateRangePicker: ({
+    onRangeChange,
+  }: {
+    onRangeChange: (from?: Date, to?: Date) => void
+  }) => (
+    <div>
+      <button
+        type="button"
+        onClick={() =>
+          onRangeChange(new Date(2026, 0, 2), new Date(2026, 1, 3))
+        }
+      >
+        Set date range
+      </button>
+      <button type="button" onClick={() => onRangeChange()}>
+        Clear date range
+      </button>
+    </div>
+  ),
+}))
+
 import { GarminPage } from './GarminPage'
 
 describe('GarminPage', () => {
@@ -161,6 +183,151 @@ describe('GarminPage', () => {
     await waitFor(() =>
       expect(screen.getByTestId('location-display')).toHaveTextContent(
         '/garmin',
+      ),
+    )
+  })
+
+  it('shows the loading state and retries a query error', async () => {
+    const user = userEvent.setup()
+    garminHooks.useGarminActivitiesQuery.mockReturnValueOnce({
+      data: undefined,
+      loading: true,
+      error: undefined,
+      refetch: vi.fn(),
+    })
+
+    const { unmount } = renderPage()
+    expect(screen.getByText('Loading activities...')).toBeInTheDocument()
+    unmount()
+
+    const refetch = vi.fn()
+    garminHooks.useGarminActivitiesQuery.mockReturnValue({
+      data: undefined,
+      loading: false,
+      error: new Error('activities unavailable'),
+      refetch,
+    })
+    renderPage()
+
+    expect(screen.getByText('activities unavailable')).toBeInTheDocument()
+    await user.click(screen.getByRole('button', { name: 'Retry' }))
+    expect(refetch).toHaveBeenCalledTimes(1)
+  })
+
+  it('renders and clears an active sport filter', async () => {
+    const user = userEvent.setup()
+    renderPage('/garmin?page=2&sport=cycling')
+
+    await user.click(screen.getByRole('button', { name: 'All' }))
+
+    await waitFor(() =>
+      expect(screen.getByTestId('location-display')).toHaveTextContent(
+        '/garmin',
+      ),
+    )
+  })
+
+  it('updates and clears date range filters', async () => {
+    const user = userEvent.setup()
+    renderPage('/garmin?page=2&sport=running')
+
+    await user.click(screen.getByRole('button', { name: 'Set date range' }))
+    await waitFor(() =>
+      expect(screen.getByTestId('location-display')).toHaveTextContent(
+        '/garmin?sport=running&date_from=2026-01-02&date_to=2026-02-03',
+      ),
+    )
+
+    await user.click(screen.getByRole('button', { name: 'Clear date range' }))
+    await waitFor(() =>
+      expect(screen.getByTestId('location-display')).toHaveTextContent(
+        '/garmin?sport=running',
+      ),
+    )
+  })
+
+  it('renders filtered empty state and clears every filter', async () => {
+    const user = userEvent.setup()
+    garminHooks.useGarminActivitiesQuery.mockReturnValue({
+      data: { garminActivities: { total: 0, items: [] } },
+      loading: false,
+      error: undefined,
+      refetch: vi.fn(),
+    })
+    renderPage(
+      '/garmin?page=3&sport=cycling&date_from=2026-01-01&date_to=2026-01-31',
+    )
+
+    expect(
+      screen.getByText(/No Garmin activities match the selected filters/),
+    ).toBeInTheDocument()
+    await user.click(screen.getByRole('button', { name: 'Clear filters' }))
+
+    await waitFor(() =>
+      expect(screen.getByTestId('location-display')).toHaveTextContent(
+        '/garmin',
+      ),
+    )
+  })
+
+  it('renders the unfiltered empty state without a reset action', () => {
+    garminHooks.useGarminDateRangeQuery.mockReturnValue({ data: undefined })
+    garminHooks.useGarminSportsQuery.mockReturnValue({ data: undefined })
+    garminHooks.useGarminActivitiesQuery.mockReturnValue({
+      data: undefined,
+      loading: false,
+      error: undefined,
+      refetch: vi.fn(),
+    })
+
+    renderPage()
+
+    expect(
+      screen.getByText('No Garmin activities have been recorded yet.'),
+    ).toBeInTheDocument()
+    expect(
+      screen.queryByRole('button', { name: 'Clear filters' }),
+    ).not.toBeInTheDocument()
+  })
+
+  it('renders fallback values for incomplete activities', () => {
+    garminHooks.useGarminActivitiesQuery.mockReturnValue({
+      data: {
+        garminActivities: {
+          total: 1,
+          items: [
+            {
+              activity_id: 'incomplete-1',
+              sport: 'running',
+              distance_km: null,
+              duration_seconds: null,
+              avg_heart_rate: null,
+              calories: null,
+              track_point_count: null,
+              start_time: null,
+            },
+          ],
+        },
+      },
+      loading: false,
+      error: undefined,
+      refetch: vi.fn(),
+    })
+
+    renderPage()
+
+    expect(screen.getAllByText('—')).toHaveLength(6)
+  })
+
+  it('keeps the previous page number when navigating back beyond page two', async () => {
+    const user = userEvent.setup()
+    renderPage('/garmin?page=4')
+
+    await user.click(screen.getByRole('button', { name: /Prev/i }))
+
+    await waitFor(() =>
+      expect(screen.getByTestId('location-display')).toHaveTextContent(
+        '/garmin?page=3',
       ),
     )
   })

--- a/src/pages/GarminPage.test.tsx
+++ b/src/pages/GarminPage.test.tsx
@@ -1,4 +1,4 @@
-import { screen, waitFor } from '@testing-library/react'
+import { screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { Route, Routes } from 'react-router-dom'
@@ -316,7 +316,11 @@ describe('GarminPage', () => {
 
     renderPage()
 
-    expect(screen.getAllByText('—')).toHaveLength(6)
+    const activityRow = screen
+      .getByRole('link', { name: 'running' })
+      .closest('tr')
+    expect(activityRow).not.toBeNull()
+    expect(within(activityRow!).getAllByText('—')).toHaveLength(6)
   })
 
   it('keeps the previous page number when navigating back beyond page two', async () => {


### PR DESCRIPTION
## Summary

- completes `GarminPage` coverage for query states, filters, empty states, field fallbacks, and pagination
- adds deterministic date-range interactions through a focused component mock
- leaves production behavior unchanged

## Coverage evidence

| Metric | Deployed baseline | Batch 3 |
| --- | ---: | ---: |
| SonarQube overall coverage | 80.1% | 81.0% |
| SonarQube line coverage | 83.1% | 83.8% |
| SonarQube branch coverage | 76.1% | 77.3% |
| SonarQube uncovered lines | 512 | 491 |
| SonarQube uncovered conditions | 556 | 528 |
| Local Vitest statements | 85.95% | 86.81% |
| Local Vitest lines | 88.40% | 89.19% |
| Local Vitest branches | 76.13% | 77.33% |

`GarminPage` now has 100% statement, branch, function, and line coverage.

## Validation

- `npm run lint:all`
- `npm run type-check`
- `npm run build`
- `npm run test:coverage` (52 files, 327 tests)
- `make sonar` (CE task succeeded; quality gate OK)

Refs #359
