### PR TITLE
test: complete Garmin activity heatmap coverage

### DIFF
--- a/src/components/dashboard/GarminActivityHeatmap.test.tsx
+++ b/src/components/dashboard/GarminActivityHeatmap.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react'
+import { fireEvent, render, screen } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Hoisted mocks for the generated graphql hook so we can drive different
@@ -20,17 +20,38 @@ vi.mock('@/__generated__/graphql', () => hooks)
 // with a lightweight stub that exposes the values prop for assertions so the
 // tests can verify what the component derived from the GraphQL response.
 let latestHeatmapValues: Array<{ date: string; count: number }> = []
+let latestHeatmapProps: Record<string, unknown> = {}
+let latestPopoverProps: Record<string, unknown> = {}
 
 vi.mock('react-calendar-heatmap', () => ({
-  default: ({ values }: { values: Array<{ date: string; count: number }> }) => {
+  default: (props: {
+    values: Array<{ date: string; count: number }>
+    classForValue: (value?: { date: string; count?: number }) => string
+    titleForValue: (value?: { date: string; count?: number }) => string
+    onClick: (value?: { date: string; count?: number }) => void
+  }) => {
+    const { values } = props
     latestHeatmapValues = values
+    latestHeatmapProps = props
     return (
       <svg data-testid="heatmap-stub">
         {values.map((v) => (
-          <rect key={v.date} data-date={v.date} data-count={v.count} />
+          <rect
+            key={v.date}
+            data-date={v.date}
+            data-count={v.count}
+            onClick={() => props.onClick(v)}
+          />
         ))}
       </svg>
     )
+  },
+}))
+
+vi.mock('./GarminDayActivitiesPopover', () => ({
+  GarminDayActivitiesPopover: (props: Record<string, unknown>) => {
+    latestPopoverProps = props
+    return <div data-testid="activities-popover" />
   },
 }))
 
@@ -39,6 +60,8 @@ import { GarminActivityHeatmap } from './GarminActivityHeatmap'
 describe('GarminActivityHeatmap', () => {
   beforeEach(() => {
     latestHeatmapValues = []
+    latestHeatmapProps = {}
+    latestPopoverProps = {}
     hooks.useDailySummaryQuery.mockReset()
   })
 
@@ -133,5 +156,110 @@ describe('GarminActivityHeatmap', () => {
 
     expect(screen.getByText(/0 activities over 0 days/i)).toBeInTheDocument()
     expect(latestHeatmapValues).toEqual([])
+  })
+
+  it('aggregates duplicate dates and ignores incomplete summaries', () => {
+    hooks.useDailySummaryQuery.mockReturnValue({
+      data: {
+        dailySummary: {
+          items: [
+            { activity_date: '2026-04-15', garmin_activities: 1 },
+            { activity_date: '2026-04-15', garmin_activities: 3 },
+            { activity_date: null, garmin_activities: 2 },
+            { activity_date: '2026-04-16', garmin_activities: 0 },
+          ],
+        },
+      },
+      loading: false,
+      error: undefined,
+    })
+
+    render(<GarminActivityHeatmap />)
+
+    expect(latestHeatmapValues).toEqual([{ date: '2026-04-15', count: 4 }])
+    expect(screen.getByText(/4 activities over 1 day/i)).toBeInTheDocument()
+  })
+
+  it('formats heatmap color classes and titles for every count band', () => {
+    hooks.useDailySummaryQuery.mockReturnValue({
+      data: { dailySummary: { items: [] } },
+      loading: false,
+      error: undefined,
+    })
+    render(<GarminActivityHeatmap />)
+
+    const classForValue = latestHeatmapProps.classForValue as (value?: {
+      date: string
+      count?: number
+    }) => string
+    const titleForValue = latestHeatmapProps.titleForValue as (value?: {
+      date: string
+      count?: number
+    }) => string
+
+    expect(classForValue()).toBe('color-empty')
+    expect(classForValue({ date: 'd', count: 1 })).toBe('color-scale-1')
+    expect(classForValue({ date: 'd', count: 2 })).toBe('color-scale-2')
+    expect(classForValue({ date: 'd', count: 3 })).toBe('color-scale-3')
+    expect(classForValue({ date: 'd', count: 4 })).toBe('color-scale-4')
+    expect(titleForValue()).toBe('No activities')
+    expect(titleForValue({ date: '2026-01-01', count: 0 })).toBe(
+      'No activities on 2026-01-01',
+    )
+    expect(titleForValue({ date: '2026-01-01', count: 1 })).toBe(
+      '1 activity on 2026-01-01',
+    )
+    expect(titleForValue({ date: '2026-01-01', count: 2 })).toBe(
+      '2 activities on 2026-01-01',
+    )
+  })
+
+  it('opens the activities popover at the clicked heatmap cell', () => {
+    hooks.useDailySummaryQuery.mockReturnValue({
+      data: {
+        dailySummary: {
+          items: [{ activity_date: '2026-04-15', garmin_activities: 2 }],
+        },
+      },
+      loading: false,
+      error: undefined,
+    })
+    render(<GarminActivityHeatmap />)
+
+    const cell = document.querySelector('rect')!
+    vi.spyOn(cell, 'getBoundingClientRect').mockReturnValue({
+      left: 10,
+      top: 20,
+      width: 8,
+      height: 6,
+    } as DOMRect)
+    fireEvent.click(cell)
+
+    expect(latestPopoverProps).toEqual(
+      expect.objectContaining({
+        date: '2026-04-15',
+        open: true,
+        anchorPos: { x: 14, y: 23 },
+      }),
+    )
+  })
+
+  it('ignores heatmap clicks without a date or activity count', () => {
+    hooks.useDailySummaryQuery.mockReturnValue({
+      data: { dailySummary: { items: [] } },
+      loading: false,
+      error: undefined,
+    })
+    render(<GarminActivityHeatmap />)
+
+    const onClick = latestHeatmapProps.onClick as (value?: {
+      date: string
+      count?: number
+    }) => void
+    onClick()
+    onClick({ date: '2026-01-01', count: 0 })
+    expect(latestPopoverProps).toEqual(
+      expect.objectContaining({ date: null, open: false }),
+    )
   })
 })


### PR DESCRIPTION
## Summary

- covers heatmap aggregation guards, duplicate dates, color/title callbacks, click anchoring, popover state, and ignored clicks
- leaves production behavior unchanged

## Coverage evidence

| Metric | Baseline | Batch 5 |
| --- | ---: | ---: |
| Sonar overall | 81.8% | 82.4% |
| Sonar line coverage | 84.4% | 84.9% |
| Sonar branch coverage | 78.4% | 79.1% |
| Uncovered lines | 471 | 456 |
| Uncovered conditions | 504 | 487 |

`GarminActivityHeatmap` reaches 98.03% lines and 92.5% branches. The remaining line is the Radix Select callback, whose pointer-capture behavior is not reliably supported by JSDOM.

## Validation

- lint, type-check, and build
- full suite: 338 tests
- `make sonar` with successful CE processing

Refs #363
