### PR TITLE
test: complete authentication service coverage

### DIFF
--- a/src/services/auth.test.ts
+++ b/src/services/auth.test.ts
@@ -140,6 +140,7 @@ describe('authService', () => {
     await authService.handleCallback()
 
     expect(replaceStateSpy).toHaveBeenCalledWith({}, document.title, '/')
+    replaceStateSpy.mockRestore()
   })
 
   it('derives auth state, access token, and profile from the current user', async () => {
@@ -190,7 +191,17 @@ describe('authService', () => {
     await expect(authService.getUserProfile()).resolves.toBeNull()
   })
 
-  it('removes the current user before redirecting to Cognito logout', async () => {
+  it('rejects profile access when an existing user has no profile', async () => {
+    const { authService } = await import('./auth')
+    authMocks.userManager.getUser.mockResolvedValue({
+      expired: false,
+      profile: undefined,
+    })
+
+    await expect(authService.getUserProfile()).rejects.toThrow(TypeError)
+  })
+
+  it('removes the current user during logout', async () => {
     const { authService } = await import('./auth')
     authMocks.userManager.removeUser.mockResolvedValue(undefined)
 

--- a/src/services/auth.test.ts
+++ b/src/services/auth.test.ts
@@ -130,6 +130,18 @@ describe('authService', () => {
     )
   })
 
+  it('falls back to the home route when callback state is not a string', async () => {
+    const replaceStateSpy = vi.spyOn(window.history, 'replaceState')
+    const { authService } = await import('./auth')
+    authMocks.userManager.signinRedirectCallback.mockResolvedValue({
+      state: { unexpected: true },
+    })
+
+    await authService.handleCallback()
+
+    expect(replaceStateSpy).toHaveBeenCalledWith({}, document.title, '/')
+  })
+
   it('derives auth state, access token, and profile from the current user', async () => {
     const { authService } = await import('./auth')
     authMocks.userManager.getUser.mockResolvedValue({
@@ -149,6 +161,42 @@ describe('authService', () => {
       name: 'Runner',
       sub: 'sub-123',
     })
+  })
+
+  it('rejects expired users and missing access tokens', async () => {
+    const { authService } = await import('./auth')
+    authMocks.userManager.getUser.mockResolvedValue({
+      expired: true,
+      access_token: 'expired-token',
+    })
+
+    await expect(authService.isAuthenticated()).resolves.toBe(false)
+    await expect(authService.getAccessToken()).resolves.toBeNull()
+
+    authMocks.userManager.getUser.mockResolvedValue({
+      expired: false,
+      access_token: '',
+    })
+    await expect(authService.getAccessToken()).resolves.toBeNull()
+  })
+
+  it('returns null authentication data when there is no current user', async () => {
+    const { authService } = await import('./auth')
+    authMocks.userManager.getUser.mockResolvedValue(null)
+
+    await expect(authService.getUser()).resolves.toBeNull()
+    await expect(authService.isAuthenticated()).resolves.toBe(false)
+    await expect(authService.getAccessToken()).resolves.toBeNull()
+    await expect(authService.getUserProfile()).resolves.toBeNull()
+  })
+
+  it('removes the current user before redirecting to Cognito logout', async () => {
+    const { authService } = await import('./auth')
+    authMocks.userManager.removeUser.mockResolvedValue(undefined)
+
+    await authService.logout()
+
+    expect(authMocks.userManager.removeUser).toHaveBeenCalledTimes(1)
   })
 
   it('registers token event handlers that trigger logout on terminal failures', async () => {


### PR DESCRIPTION
## Summary

- covers callback-state fallback, expired and missing users, empty access tokens, missing profiles, and logout cleanup
- leaves production authentication behavior unchanged

## Coverage evidence

| Metric | Baseline | Batch 6 |
| --- | ---: | ---: |
| Sonar overall | 82.4% | 82.6% |
| Sonar line coverage | 84.9% | 85.1% |
| Sonar branch coverage | 79.1% | 79.4% |
| Uncovered lines | 456 | 452 |
| Uncovered conditions | 487 | 481 |

`authService` reaches 92.85% line coverage and 85% branch coverage. The remaining lines are server-side `window` guards that cannot execute in the repository's JSDOM environment.

## Validation

- `npm run lint:all`
- `npm run type-check`
- `npm run build`
- full suite: 52 files, 342 tests
- `make sonar` with successful CE processing and quality gate

Refs #365
