### PR TITLE
test: complete saved segment action coverage

### DIFF
--- a/src/components/garmin/DeleteSegmentButton.test.tsx
+++ b/src/components/garmin/DeleteSegmentButton.test.tsx
@@ -103,4 +103,68 @@ describe('DeleteSegmentButton', () => {
     expect(toastMocks.error).toHaveBeenCalled()
     expect(toastMocks.success).not.toHaveBeenCalled()
   })
+
+  it('handles successful and failed mutation callbacks', () => {
+    const onDeleted = vi.fn()
+    render(
+      <DeleteSegmentButton
+        segmentId={1}
+        segmentName="Harlem Hill"
+        onDeleted={onDeleted}
+      />,
+    )
+
+    const options =
+      graphqlMocks.useDeleteGarminSegmentMutation.mock.calls[0]?.[0]
+    expect(options).toBeDefined()
+    options!.onCompleted({ deleteGarminSegment: true })
+    expect(toastMocks.success).toHaveBeenCalledWith('Segment deleted', {
+      description:
+        '"Harlem Hill" was removed and will be cleared from Garmin Connect shortly.',
+    })
+    expect(onDeleted).toHaveBeenCalledTimes(1)
+
+    options!.onError(new Error('delete failed'))
+    expect(toastMocks.error).toHaveBeenCalledWith('Could not delete segment', {
+      description: 'delete failed',
+    })
+  })
+
+  it('disables confirmation controls while deletion is running', async () => {
+    const user = userEvent.setup()
+    graphqlMocks.useDeleteGarminSegmentMutation.mockReturnValue([
+      deleteSegment,
+      { loading: true },
+    ])
+    render(
+      <DeleteSegmentButton
+        segmentId={1}
+        segmentName="Harlem Hill"
+        onDeleted={onDeleted}
+      />,
+    )
+    await user.click(screen.getByTestId('delete-segment-trigger'))
+
+    expect(screen.getByRole('button', { name: 'Cancel' })).toBeDisabled()
+    expect(screen.getByTestId('delete-segment-confirm')).toBeDisabled()
+    expect(screen.getByTestId('delete-segment-confirm')).toHaveTextContent(
+      'Deleting…',
+    )
+  })
+
+  it('closes the confirmation without deleting when cancelled', async () => {
+    const user = userEvent.setup()
+    render(
+      <DeleteSegmentButton
+        segmentId={1}
+        segmentName="Harlem Hill"
+        onDeleted={onDeleted}
+      />,
+    )
+    await user.click(screen.getByTestId('delete-segment-trigger'))
+    await user.click(screen.getByRole('button', { name: 'Cancel' }))
+
+    expect(screen.queryByText('Delete “Harlem Hill”?')).not.toBeInTheDocument()
+    expect(deleteSegment).not.toHaveBeenCalled()
+  })
 })

--- a/src/components/garmin/SaveSegmentPopover.test.tsx
+++ b/src/components/garmin/SaveSegmentPopover.test.tsx
@@ -154,4 +154,83 @@ describe('SaveSegmentPopover', () => {
 
     expect(screen.getByTestId('save-segment-submit')).toBeDisabled()
   })
+
+  it('validates tolerance boundaries before submitting', async () => {
+    const user = userEvent.setup()
+    render(<SaveSegmentPopover {...baseProps} defaultName="Hill" />)
+    await user.click(screen.getByTestId('save-segment-trigger'))
+
+    const tolerance = screen.getByTestId('save-segment-tolerance')
+    await user.clear(tolerance)
+    await user.type(tolerance, '4')
+    expect(screen.getByTestId('save-segment-submit')).toBeDisabled()
+
+    await user.clear(tolerance)
+    await user.type(tolerance, '201')
+    expect(screen.getByTestId('save-segment-submit')).toBeDisabled()
+
+    await user.clear(tolerance)
+    await user.type(tolerance, '5')
+    expect(screen.getByTestId('save-segment-submit')).toBeEnabled()
+  })
+
+  it('handles mutation success and error callbacks', () => {
+    render(<SaveSegmentPopover {...baseProps} />)
+
+    const options =
+      graphqlMocks.useCreateGarminSegmentMutation.mock.calls[0]?.[0]
+    expect(options).toBeDefined()
+    options!.onCompleted({ createGarminSegment: { name: 'Harlem Hill' } })
+    expect(toastMocks.success).toHaveBeenCalledWith('Segment saved', {
+      description: '"Harlem Hill" is now tracking efforts.',
+    })
+
+    options!.onError(new Error('save failed'))
+    expect(toastMocks.error).toHaveBeenCalledWith('Could not save segment', {
+      description: 'save failed',
+    })
+  })
+
+  it('uses nullable defaults and a climb login label', async () => {
+    const user = userEvent.setup()
+    authMocks.useAuth.mockReturnValue({ isAuthenticated: false, login })
+    const { unmount } = render(
+      <SaveSegmentPopover
+        startLatitude={1}
+        startLongitude={2}
+        endLatitude={3}
+        endLongitude={4}
+        sourceClimbIndex={0}
+      />,
+    )
+    await user.click(screen.getByTestId('save-segment-trigger'))
+    expect(
+      screen.getByText('Log in to save this climb as a named segment.'),
+    ).toBeVisible()
+    unmount()
+
+    authMocks.useAuth.mockReturnValue({ isAuthenticated: true, login })
+    render(
+      <SaveSegmentPopover
+        startLatitude={1}
+        startLongitude={2}
+        endLatitude={3}
+        endLongitude={4}
+        defaultName="Climb"
+      />,
+    )
+    await user.click(screen.getByTestId('save-segment-trigger'))
+    await user.click(screen.getByTestId('save-segment-submit'))
+    expect(createSegment).toHaveBeenCalledWith({
+      variables: {
+        input: expect.objectContaining({
+          sport: null,
+          distance_meters: null,
+          source_activity_id: null,
+          source_lap_index: null,
+          source_climb_index: null,
+        }),
+      },
+    })
+  })
 })


### PR DESCRIPTION
## Summary

- completes saved-segment create/delete success, error, loading, cancel, validation, label, and nullable-input coverage
- leaves production behavior unchanged

## Coverage evidence

- Sonar overall: 82.9% to 83.2%
- Sonar line coverage: 85.3% to 85.6%
- Sonar branch coverage: 79.8% to 80.0%
- Uncovered lines: 446 to 436
- Uncovered conditions: 471 to 466

## Validation

- focused suite: 14 tests
- full suite: 53 files, 354 tests
- lint, type-check, build, and Sonar CE processing passed

Refs #369
