### PR TITLE
test: complete spatial tools page coverage

### DIFF
--- a/src/pages/SpatialPage.test.tsx
+++ b/src/pages/SpatialPage.test.tsx
@@ -137,4 +137,64 @@ describe('SpatialPage', () => {
       skip: false,
     })
   })
+
+  it('uses updated coordinates for both spatial queries', async () => {
+    const user = userEvent.setup()
+    render(<SpatialPage />)
+
+    const inputs = screen.getAllByRole('textbox')
+    const updates = [
+      [0, '41.1'],
+      [1, '-72.2'],
+      [4, '-71.4'],
+      [5, '42.5'],
+      [6, '-70.6'],
+    ] as const
+    for (const [index, value] of updates) {
+      await user.clear(inputs[index])
+      await user.type(inputs[index], value)
+    }
+
+    await user.click(screen.getByRole('button', { name: 'Search' }))
+    await user.click(screen.getByRole('button', { name: 'Calculate' }))
+
+    await waitFor(() => {
+      expect(spatialHooks.useNearbyPointsQuery).toHaveBeenLastCalledWith({
+        variables: {
+          lat: 41.1,
+          lon: -72.2,
+          radius_meters: 500,
+          limit: 20,
+        },
+        skip: false,
+      })
+      expect(spatialHooks.useCalculateDistanceQuery).toHaveBeenLastCalledWith({
+        variables: {
+          from_lat: 40.736097,
+          from_lon: -71.4,
+          to_lat: 42.5,
+          to_lon: -70.6,
+        },
+        skip: false,
+      })
+    })
+  })
+
+  it('disables both actions while their queries are loading', () => {
+    spatialHooks.useNearbyPointsQuery.mockReturnValue({
+      data: undefined,
+      loading: true,
+    })
+    spatialHooks.useCalculateDistanceQuery.mockReturnValue({
+      data: undefined,
+      loading: true,
+    })
+
+    render(<SpatialPage />)
+
+    expect(screen.getByRole('button', { name: 'Searching...' })).toBeDisabled()
+    expect(
+      screen.getByRole('button', { name: 'Calculating...' }),
+    ).toBeDisabled()
+  })
 })

--- a/src/pages/SpatialPage.tsx
+++ b/src/pages/SpatialPage.tsx
@@ -141,7 +141,7 @@ export function SpatialPage() {
                         </TableRow>
                       </TableHeader>
                       <TableBody>
-                        {(nearbyData.nearbyPoints ?? []).map((p) => (
+                        {nearbyData.nearbyPoints.map((p) => (
                           <TableRow key={`${p.source}-${p.id}`}>
                             <TableCell>
                               <Badge variant="outline">{p.source}</Badge>


### PR DESCRIPTION
## Summary

- cover every remaining nearby-search and distance-calculator input callback
- cover both query loading labels and disabled action states
- remove a redundant null fallback inside a block already guarded by `nearbyPoints`
- preserve rendered behavior while making the remaining branch reachable set explicit

## Coverage

| Metric | Before | After |
| --- | ---: | ---: |
| Overall coverage | 85.6% | 85.7% |
| Line coverage | 87.3% | 87.5% |
| Branch coverage | 83.3% | 83.4% |
| Uncovered lines | 383 | 378 |
| Uncovered conditions | 389 | 386 |

`src/pages/SpatialPage.tsx` now has 100% statement, branch, function, and line coverage.

## Validation

- `npx vitest run src/pages/SpatialPage.test.tsx --coverage --coverage.include=src/pages/SpatialPage.tsx` (5 tests passed)
- `npm run lint:all`
- `npm run type-check`
- `npm run build`
- `npm run test:run` (53 files, 382 tests passed)
- `make sonar` (CE task succeeded; quality gate passed)

Refs #383
