### PR TITLE
test: complete Garmin segments page coverage

### DIFF
--- a/src/pages/GarminSegmentsPage.test.tsx
+++ b/src/pages/GarminSegmentsPage.test.tsx
@@ -1,4 +1,5 @@
 import { screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { renderWithRouter } from '@/test/renderWithRouter'
 import { GarminSegmentsPage } from './GarminSegmentsPage'
@@ -83,5 +84,58 @@ describe('GarminSegmentsPage', () => {
     renderWithRouter(<GarminSegmentsPage />)
 
     expect(screen.getByText('Loading segments...')).toBeVisible()
+  })
+
+  it('renders a query error and retries', async () => {
+    const user = userEvent.setup()
+    const refetch = vi.fn()
+    segmentHooks.useGarminSegmentsQuery.mockReturnValue({
+      data: undefined,
+      loading: false,
+      error: { message: 'segments failed' },
+      refetch,
+    })
+
+    renderWithRouter(<GarminSegmentsPage />)
+    await user.click(screen.getByRole('button', { name: 'Retry' }))
+
+    expect(screen.getByText('segments failed')).toBeVisible()
+    expect(refetch).toHaveBeenCalledOnce()
+  })
+
+  it('renders fallbacks for optional segment metadata', () => {
+    segmentHooks.useGarminSegmentsQuery.mockReturnValue({
+      data: {
+        garminSegments: [
+          {
+            id: 2,
+            name: 'Unclassified Route',
+            sport: null,
+            start_latitude: 40.79,
+            start_longitude: -73.96,
+            end_latitude: 40.8,
+            end_longitude: -73.97,
+            distance_meters: null,
+            match_tolerance_meters: 20,
+            source_activity_id: null,
+            source_lap_index: null,
+            source_climb_index: null,
+            created_at: '2026-07-07T05:00:11Z',
+            updated_at: '2026-07-07T05:00:11Z',
+          },
+        ],
+      },
+      loading: false,
+      error: undefined,
+      refetch: vi.fn(),
+    })
+
+    renderWithRouter(<GarminSegmentsPage />)
+
+    expect(screen.getByText('Unclassified Route')).toBeVisible()
+    expect(screen.queryByText('cycling')).not.toBeInTheDocument()
+    expect(screen.getByText('Distance').nextElementSibling).toHaveTextContent(
+      '—',
+    )
   })
 })

--- a/src/pages/GarminSegmentsPage.test.tsx
+++ b/src/pages/GarminSegmentsPage.test.tsx
@@ -97,9 +97,9 @@ describe('GarminSegmentsPage', () => {
     })
 
     renderWithRouter(<GarminSegmentsPage />)
-    await user.click(screen.getByRole('button', { name: 'Retry' }))
-
     expect(screen.getByText('segments failed')).toBeVisible()
+
+    await user.click(screen.getByRole('button', { name: 'Retry' }))
     expect(refetch).toHaveBeenCalledOnce()
   })
 


### PR DESCRIPTION
## Summary

- cover saved-segment query error rendering and retry behavior
- cover cards without optional sport metadata
- cover missing distance fallback formatting
- keep production code unchanged

## Coverage

| Metric | Before | After |
| --- | ---: | ---: |
| Overall coverage | 85.7% | 85.8% |
| Line coverage | 87.5% | 87.6% |
| Branch coverage | 83.4% | 83.5% |
| Uncovered lines | 378 | 376 |
| Uncovered conditions | 386 | 384 |

`src/pages/GarminSegmentsPage.tsx` now has 100% statement, branch, function, and line coverage.

## Validation

- `npx vitest run src/pages/GarminSegmentsPage.test.tsx --coverage --coverage.include=src/pages/GarminSegmentsPage.tsx` (5 tests passed)
- `npm run lint:all`
- `npm run type-check`
- `npm run build`
- `npm run test:run` (53 files, 384 tests passed)
- `make sonar` (CE task succeeded; quality gate passed)

Refs #385
