### PR TITLE
test: complete activity lap helper coverage

### DIFF
--- a/src/components/garmin/ActivityLapsTable.test.tsx
+++ b/src/components/garmin/ActivityLapsTable.test.tsx
@@ -292,6 +292,71 @@ describe('ActivityLapsTable', () => {
     expect(summary.avgHeartRate).toBe(150)
   })
 
+  it('uses unit heart-rate weighting and null summary fallbacks without usable totals', () => {
+    const summary = buildLapSummary([
+      lap({
+        duration_seconds: 0,
+        distance_meters: 0,
+        paved_distance_meters: null,
+        unpaved_distance_meters: null,
+        avg_heart_rate: 125,
+        max_heart_rate: 0,
+        total_ascent_meters: 0,
+      }),
+      lap({
+        duration_seconds: null,
+        distance_meters: null,
+        paved_distance_meters: null,
+        unpaved_distance_meters: null,
+        avg_heart_rate: null,
+        max_heart_rate: null,
+        total_ascent_meters: null,
+      }),
+    ])
+
+    expect(summary).toEqual({
+      durationSeconds: null,
+      distanceMeters: null,
+      pavedPercent: null,
+      unpavedPercent: null,
+      avgSpeedMps: null,
+      avgHeartRate: 125,
+      maxHeartRate: null,
+      totalAscentMeters: null,
+    })
+  })
+
+  it('returns no points when a lap has no effective end time', () => {
+    expect(
+      getLapSegmentPoints(
+        lap({
+          start_time: '2026-07-04T19:50:33Z',
+          end_time: null,
+          duration_seconds: 0,
+          distance_meters: null,
+        }),
+        [],
+      ),
+    ).toEqual([])
+  })
+
+  it('returns no points when the target lap is absent from distance context', () => {
+    const target = lap({
+      lap_index: 2,
+      start_time: null,
+      end_time: null,
+      distance_meters: 1000,
+    })
+
+    expect(
+      getLapSegmentPoints(
+        target,
+        [],
+        [lap({ lap_index: 1, distance_meters: 1000 })],
+      ),
+    ).toEqual([])
+  })
+
   it('renders laps in lap order with cumulative time and summary', () => {
     render(
       <ActivityLapsTable


### PR DESCRIPTION
## Summary

- cover unit heart-rate weighting when duration and distance are unavailable
- cover null summary totals and optional metric fallbacks
- cover laps without an effective end time
- cover target laps absent from cumulative distance context
- keep production code unchanged

## Coverage

| Metric | Before | After |
| --- | ---: | ---: |
| Overall coverage | 85.9% | 86.1% |
| Branch coverage | 83.5% | 84.0% |
| Uncovered lines | 374 | 371 |
| Uncovered conditions | 381 | 371 |

`src/components/garmin/ActivityLapsTable.helpers.ts` now has 100% statement, branch, function, and line coverage.

## Validation

- `npx vitest run src/components/garmin/ActivityLapsTable.test.tsx --coverage --coverage.include=src/components/garmin/ActivityLapsTable.helpers.ts` (20 tests passed)
- `npm run lint:all`
- `npm run type-check`
- `npm run build`
- `npm run test:run` before rebase (53 files, 387 tests passed)
- rebased combined coverage suite after PR #388 (53 files, 388 tests passed)
- `make sonar` after rebasing onto merged PR #388 (CE task succeeded; quality gate passed)

Refs #389
