### PR TITLE
test: complete popover primitive coverage

### DIFF
--- a/src/components/ui/popover.test.tsx
+++ b/src/components/ui/popover.test.tsx
@@ -1,0 +1,57 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import {
+  Popover,
+  PopoverAnchor,
+  PopoverContent,
+  PopoverDescription,
+  PopoverHeader,
+  PopoverTitle,
+  PopoverTrigger,
+} from './popover'
+
+describe('Popover primitives', () => {
+  it('renders the composed popover with custom content props', () => {
+    render(
+      <Popover defaultOpen>
+        <PopoverTrigger>Open details</PopoverTrigger>
+        <PopoverAnchor data-testid="popover-anchor" />
+        <PopoverContent className="custom-content" align="start" sideOffset={8}>
+          <PopoverHeader className="custom-header">
+            <PopoverTitle>Activity details</PopoverTitle>
+            <PopoverDescription>Selected activity summary</PopoverDescription>
+          </PopoverHeader>
+        </PopoverContent>
+      </Popover>,
+    )
+
+    expect(
+      screen.getByRole('button', { name: 'Open details' }),
+    ).toHaveAttribute('data-slot', 'popover-trigger')
+    expect(screen.getByTestId('popover-anchor')).toHaveAttribute(
+      'data-slot',
+      'popover-anchor',
+    )
+    expect(screen.getByRole('dialog')).toHaveClass('custom-content')
+    expect(screen.getByText('Activity details')).toHaveAttribute(
+      'data-slot',
+      'popover-title',
+    )
+    expect(screen.getByText('Selected activity summary')).toHaveAttribute(
+      'data-slot',
+      'popover-description',
+    )
+    expect(screen.getByText('Activity details').parentElement).toHaveClass(
+      'custom-header',
+    )
+  })
+
+  it.each([null, false, ''])(
+    'omits a title when children are %p',
+    (children) => {
+      const { container } = render(<PopoverTitle>{children}</PopoverTitle>)
+
+      expect(container).toBeEmptyDOMElement()
+    },
+  )
+})


### PR DESCRIPTION
## Summary

- add focused tests for every shared popover primitive
- verify custom content and header props are forwarded correctly
- cover title omission for null, false, and empty children

## Impact

This batch adds test coverage only and does not change production behavior.

## Coverage

- `src/components/ui/popover.tsx`: 100% statements, branches, functions, and lines
- overall SonarQube coverage: 86.2% → 86.4%
- line coverage: 87.8% → 88.0%
- branch coverage: 84.2% → 84.4%
- uncovered lines: 368 → 364
- uncovered conditions: 368 → 363
- SonarQube quality gate: passed (85.4% new-code coverage)

## Validation

- `npm run lint:all`
- `npm run type-check`
- `npm run build`
- `npm run test:run` (54 files, 393 tests)
- `make sonar`

Refs #393
