### PR TITLE
test: complete CyclingInFocus component coverage

### DIFF
--- a/src/components/dashboard/CyclingInFocus.test.tsx
+++ b/src/components/dashboard/CyclingInFocus.test.tsx
@@ -1,4 +1,10 @@
 import { render, screen, waitFor } from '@testing-library/react'
+import {
+  cloneElement,
+  createElement,
+  type ElementType,
+  type ReactElement,
+} from 'react'
 import userEvent from '@testing-library/user-event'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -8,6 +14,13 @@ const FROZEN_NOW = new Date('2026-06-23T12:00:00Z')
 
 let latestBarChartData: Array<Record<string, unknown>> = []
 let latestXAxisProps: Record<string, unknown> = {}
+type TooltipContentProps = {
+  active?: boolean
+  payload?: Array<{ payload: unknown }>
+}
+
+let latestTooltipContent: ReactElement<TooltipContentProps> | null = null
+let latestBarShape: ElementType | null = null
 
 const hooks = vi.hoisted(() => ({
   useGarminActivitiesQuery: vi.fn(),
@@ -30,13 +43,25 @@ vi.mock('recharts', () => ({
     latestBarChartData = data ?? []
     return <div data-testid="bar-chart">{children}</div>
   },
-  Bar: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+  Bar: ({
+    children,
+    shape,
+  }: {
+    children?: React.ReactNode
+    shape?: ElementType
+  }) => {
+    latestBarShape = shape ?? null
+    return <div>{children}</div>
+  },
   Rectangle: (props: React.SVGProps<SVGRectElement>) => <rect {...props} />,
   XAxis: (props: Record<string, unknown>) => {
     latestXAxisProps = props
     return null
   },
-  Tooltip: () => null,
+  Tooltip: ({ content }: { content?: ReactElement<TooltipContentProps> }) => {
+    latestTooltipContent = content ?? null
+    return null
+  },
 }))
 
 import { CyclingInFocus } from './CyclingInFocus'
@@ -76,6 +101,8 @@ describe('CyclingInFocus', () => {
     })
     latestBarChartData = []
     latestXAxisProps = {}
+    latestTooltipContent = null
+    latestBarShape = null
     hooks.useGarminActivitiesQuery.mockReset()
   })
 
@@ -185,7 +212,165 @@ describe('CyclingInFocus', () => {
     expect(tickFormatter('2026-06-18', 0)).toBe('W')
     expect(tickFormatter('2026-06-18', 1)).toBe('T')
     expect(tickFormatter('2026-06-21', 4)).toBe('S')
+    expect(tickFormatter('missing', 99)).toBe('')
     expect(new Set(latestBarChartData.map((d) => d.date)).size).toBe(7)
+  })
+
+  it('renders populated and empty tooltip states with correct pluralization', () => {
+    mockActivities(SAMPLE_ITEMS)
+
+    render(<CyclingInFocus />)
+
+    expect(latestTooltipContent).not.toBeNull()
+    const populatedDay = latestBarChartData.find(
+      (day) => day.date === '2026-06-18',
+    )
+    const emptyDay = latestBarChartData.find((day) => day.date === '2026-06-17')
+
+    const populatedTooltip = render(
+      cloneElement(latestTooltipContent!, {
+        active: true,
+        payload: [{ payload: populatedDay }],
+      }),
+    )
+    expect(populatedTooltip.getByText('Thu, Jun 18, 2026')).toBeInTheDocument()
+    expect(populatedTooltip.getByText('1 activity')).toBeInTheDocument()
+    expect(populatedTooltip.getByText('31.07 mi')).toBeInTheDocument()
+    populatedTooltip.unmount()
+
+    const emptyTooltip = render(
+      cloneElement(latestTooltipContent!, {
+        active: true,
+        payload: [{ payload: emptyDay }],
+      }),
+    )
+    expect(emptyTooltip.getByText('0 activities')).toBeInTheDocument()
+    expect(emptyTooltip.getByText('No activities.')).toBeInTheDocument()
+  })
+
+  it('does not render an inactive tooltip or one without a day', () => {
+    mockActivities(SAMPLE_ITEMS)
+
+    render(<CyclingInFocus />)
+
+    const inactive = render(
+      cloneElement(latestTooltipContent!, { active: false }),
+    )
+    expect(inactive.container).toBeEmptyDOMElement()
+    inactive.unmount()
+
+    const missingDay = render(
+      cloneElement(latestTooltipContent!, { active: true, payload: [] }),
+    )
+    expect(missingDay.container).toBeEmptyDOMElement()
+  })
+
+  it('uses full opacity for active bars and muted opacity for empty bars', () => {
+    mockActivities(SAMPLE_ITEMS)
+
+    render(<CyclingInFocus />)
+
+    expect(latestBarShape).not.toBeNull()
+    const activeBar = render(
+      createElement(latestBarShape!, {
+        payload: { distance_mi: 10 },
+      }),
+    )
+    expect(activeBar.container.querySelector('rect')).toHaveAttribute(
+      'fill-opacity',
+      '1',
+    )
+    activeBar.unmount()
+
+    const emptyBar = render(createElement(latestBarShape!, {}))
+    expect(emptyBar.container.querySelector('rect')).toHaveAttribute(
+      'fill-opacity',
+      '0.2',
+    )
+  })
+
+  it('ignores undated and out-of-window activities and defaults missing totals', () => {
+    hooks.useGarminActivitiesQuery.mockImplementation(
+      ({ variables }: { variables: { date_from: string } }) => {
+        const items =
+          variables.date_from === '2026-06-17'
+            ? [
+                {
+                  activity_id: 'undated',
+                  sport: 'cycling',
+                  start_time: null,
+                  distance_km: 99,
+                  duration_seconds: 99,
+                },
+                {
+                  activity_id: 'outside',
+                  sport: 'cycling',
+                  start_time: '2026-06-16T08:00:00',
+                  distance_km: 99,
+                  duration_seconds: 99,
+                },
+                {
+                  activity_id: 'missing-totals',
+                  sport: 'cycling',
+                  start_time: '2026-06-18T08:00:00',
+                  distance_km: null,
+                  duration_seconds: null,
+                },
+              ]
+            : []
+        return {
+          data: { garminActivities: { items, total: items.length } },
+          loading: false,
+          error: undefined,
+          refetch: vi.fn(),
+        }
+      },
+    )
+
+    render(<CyclingInFocus />)
+
+    expect(screen.getByTestId('in-focus-total-distance')).toHaveTextContent(
+      '0.00',
+    )
+    expect(screen.getByText('0:00')).toBeInTheDocument()
+    const jun18 = latestBarChartData.find((day) => day.date === '2026-06-18')
+    expect(jun18).toMatchObject({
+      count: 1,
+      distance_mi: 0,
+      duration_seconds: 0,
+    })
+  })
+
+  it('shows recent loading, zero rides, and a singular ride label', () => {
+    let recentLoading = true
+    let recentItems: typeof SAMPLE_ITEMS = []
+    hooks.useGarminActivitiesQuery.mockImplementation(
+      ({ variables }: { variables: { date_from: string } }) => {
+        const isRecent = variables.date_from === '2026-05-27'
+        const items = isRecent ? recentItems : []
+        return {
+          data: { garminActivities: { items, total: items.length } },
+          loading: isRecent && recentLoading,
+          error: undefined,
+          refetch: vi.fn(),
+        }
+      },
+    )
+
+    const view = render(<CyclingInFocus />)
+    expect(screen.getByText('Loading…')).toBeInTheDocument()
+
+    recentLoading = false
+    view.rerender(<CyclingInFocus />)
+    expect(screen.getByText('Last 4w · 0 rides')).toBeInTheDocument()
+
+    recentItems = [SAMPLE_ITEMS[0]]
+    view.rerender(<CyclingInFocus />)
+    expect(screen.getByText('Last 4w · 1 ride')).toBeInTheDocument()
+    expect(screen.getByTestId('in-focus-activity-strip')).toHaveAttribute(
+      'aria-label',
+      '1 ride in the last 4 weeks',
+    )
   })
 
   it('navigates to the previous week and re-queries', async () => {
@@ -244,5 +429,21 @@ describe('CyclingInFocus', () => {
         screen.getByRole('button', { name: 'Next week' }),
       ).not.toBeDisabled()
     })
+
+    await user.click(screen.getByRole('button', { name: 'Next week' }))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('in-focus-week-range')).toHaveTextContent(
+        'Jun 17 – Jun 23',
+      )
+    })
+    expect(hooks.useGarminActivitiesQuery).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        variables: expect.objectContaining({
+          date_from: '2026-06-17',
+          date_to: '2026-06-23',
+        }),
+      }),
+    )
   })
 })


### PR DESCRIPTION
## Summary

Refs #401

Complete the remaining meaningful `CyclingInFocus` unit-test behaviors without changing production code:

- render populated, singular, inactive, missing-day, and empty tooltip states
- verify active and empty chart-bar opacity
- ignore undated and out-of-window activities while defaulting missing totals
- cover recent loading, zero-ride, and singular-ride labels
- verify previous and next week navigation and the axis fallback

## Type of Change

- [ ] Bug fix (non-breaking change fixing an issue)
- [ ] New page / component
- [x] UI enhancement (non-breaking)
- [ ] GraphQL query / mutation change
- [ ] CI/CD pipeline change
- [ ] Documentation update

## Coverage

| Metric | Baseline | Final | Delta |
| --- | ---: | ---: | ---: |
| Statements | 92.61% (2482/2680) | 92.98% (2492/2680) | +10 / +0.37 pp |
| Branches | 84.75% (1968/2322) | 85.57% (1987/2322) | +19 / +0.82 pp |
| Functions | 93.31% (712/763) | 93.84% (716/763) | +4 / +0.53 pp |
| Lines | 94.65% (2267/2395) | 94.94% (2274/2395) | +7 / +0.29 pp |

`CyclingInFocus.tsx` now reports 98.66% statements, 97.22% branches, and 100% functions/lines.

SonarQube CE task `72aff4be-dd67-45a7-ae75-4162f0864a8b` completed successfully:

- overall coverage: 86.7% → 87.2%
- line coverage: 88.2% → 88.5%
- branch coverage: 84.8% → 85.6%
- uncovered lines: 358 → 348
- uncovered conditions: 354 → 335

## Checklist

- [x] Read `README.md` and relevant docs
- [x] No secrets or credentials committed
- [x] Environment variables use `VITE_` prefix (not applicable)
- [x] Ran `npm run lint:all` locally
- [x] Ran `npm run test:run` (401 tests passing)
- [x] Ran `npm run type-check`
- [x] Ran `npm run build`
- [x] Ran `npm run test:coverage`
- [x] Ran `make sonar` and waited for CE success

## Deployment

- [x] This test-only release will use the normal generated `k8s-gitops` version PR and Argo CD rollout.

## Post-Merge Validation

- [ ] Docker image built and pushed
- [ ] k8s-gitops deployment PR created and merged
- [ ] Argo CD synced to cluster
- [ ] Production acceptance test passed
- [ ] Final validation posted on #401 and issue closed

## Notes

`UnifiedGpsMap` remains the recommended next coverage batch because it requires a separate Leaflet lifecycle mock harness.