### PR TITLE
test: complete ClimbDetailsPanel coverage

### DIFF
--- a/src/components/garmin/ClimbDetailsPanel.test.tsx
+++ b/src/components/garmin/ClimbDetailsPanel.test.tsx
@@ -1,12 +1,54 @@
 import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest'
+import type { GarminActivityClimbsQuery } from '@/__generated__/graphql'
 import { ClimbDetailsPanel } from './ClimbDetailsPanel'
 import {
   getClimbSegmentPoints,
   getGradeBucket,
 } from './ClimbDetailsPanel.helpers'
 import type { ActivityChartTrackPoint } from './ActivityChartData'
+
+type ActivityClimb = GarminActivityClimbsQuery['garminActivityClimbs'][number]
+
+const pointerCaptureMethodNames = [
+  'hasPointerCapture',
+  'releasePointerCapture',
+  'setPointerCapture',
+] as const
+const pointerCaptureDescriptors = Object.fromEntries(
+  pointerCaptureMethodNames.map((name) => [
+    name,
+    Object.getOwnPropertyDescriptor(HTMLElement.prototype, name),
+  ]),
+)
+
+beforeAll(() => {
+  Object.defineProperties(HTMLElement.prototype, {
+    hasPointerCapture: { configurable: true, value: vi.fn(() => false) },
+    releasePointerCapture: { configurable: true, value: vi.fn() },
+    setPointerCapture: { configurable: true, value: vi.fn() },
+  })
+})
+
+afterAll(() => {
+  for (const name of pointerCaptureMethodNames) {
+    const descriptor = pointerCaptureDescriptors[name]
+    if (descriptor) {
+      Object.defineProperty(HTMLElement.prototype, name, descriptor)
+    } else {
+      Reflect.deleteProperty(HTMLElement.prototype, name)
+    }
+  }
+})
 
 const leafletMocks = vi.hoisted(() => {
   const mapInstance = {
@@ -40,7 +82,11 @@ const leafletMocks = vi.hoisted(() => {
     map: vi.fn(() => mapInstance),
     tileLayer: vi.fn(() => layer),
     layerGroup: vi.fn(() => routeLayer),
-    polyline: vi.fn(() => layer),
+    polyline: vi.fn((points: unknown, options?: { color?: string }) => {
+      void points
+      void options
+      return layer
+    }),
     circleMarker: vi.fn(() => marker),
     latLngBounds: vi.fn(() => bounds),
   }
@@ -242,6 +288,272 @@ describe('ClimbDetailsPanel', () => {
     await user.click(screen.getByRole('button', { name: 'Previous climb' }))
     expect(onPrevious).toHaveBeenCalledTimes(1)
     expect(screen.getByRole('button', { name: 'Next climb' })).toBeDisabled()
+
+    await user.click(screen.getByRole('button', { name: 'Next climb' }))
+    expect(onNext).not.toHaveBeenCalled()
+  })
+
+  it('calls the next handler when another climb is available', async () => {
+    const user = userEvent.setup()
+    const onNext = vi.fn()
+
+    render(
+      <ClimbDetailsPanel
+        climb={mockClimb({ climb_pro_difficulty: 'Category 3' })}
+        climbIndex={0}
+        totalClimbs={2}
+        chartPoints={mockChartPoints()}
+        onPrevious={vi.fn()}
+        onNext={onNext}
+        canPrevious={false}
+        canNext
+      />,
+    )
+
+    await user.click(screen.getByRole('button', { name: 'Next climb' }))
+    expect(onNext).toHaveBeenCalledTimes(1)
+    expect(screen.getByText('Category 3')).toBeInTheDocument()
+  })
+
+  it('formats missing climb stats and rejects non-finite segment coordinates', () => {
+    render(
+      <ClimbDetailsPanel
+        climb={mockClimb({
+          average_grade_percent: null,
+          max_grade_percent: null,
+          elevation_gain_meters: null,
+          distance_meters: null,
+          duration_seconds: null,
+          climb_pro_difficulty: '   ',
+          start_latitude: Number.NaN,
+        })}
+        climbIndex={0}
+        totalClimbs={1}
+        chartPoints={mockChartPoints()}
+        onPrevious={vi.fn()}
+        onNext={vi.fn()}
+        canPrevious={false}
+        canNext={false}
+      />,
+    )
+
+    expect(screen.getAllByText('-')).toHaveLength(4)
+    expect(screen.getByText('—')).toBeInTheDocument()
+    expect(screen.getByText('None')).toBeInTheDocument()
+    expect(screen.queryByTestId('save-segment-trigger')).not.toBeInTheDocument()
+  })
+
+  it('switches among every available map metric with boundary and fallback values', async () => {
+    const user = userEvent.setup()
+    render(
+      <ClimbDetailsPanel
+        climb={mockClimb({ end_time: '2026-03-14T09:11:00Z' })}
+        climbIndex={0}
+        totalClimbs={1}
+        chartPoints={mockChartPointsWithMetricBuckets()}
+        onPrevious={vi.fn()}
+        onNext={vi.fn()}
+        canPrevious={false}
+        canNext={false}
+      />,
+    )
+
+    await waitFor(() => expect(leafletMocks.map).toHaveBeenCalledTimes(1))
+
+    const cases = [
+      {
+        name: 'Route',
+        colors: Array(6).fill('#2563eb'),
+        firstTooltip: 'Climb segment',
+        lastTooltip: 'Climb segment',
+      },
+      {
+        name: 'HR zone',
+        colors: [
+          '#9ca3af',
+          '#3b82f6',
+          '#22c55e',
+          '#facc15',
+          '#f97316',
+          '#ef4444',
+        ],
+        firstTooltip: 'HR zone -',
+        lastTooltip: 'HR zone 5',
+      },
+      {
+        name: 'Heart rate',
+        colors: [
+          '#6b7280',
+          '#3b82f6',
+          '#22c55e',
+          '#facc15',
+          '#f97316',
+          '#ef4444',
+        ],
+        firstTooltip: 'Heart rate -',
+        lastTooltip: 'Heart rate 175 bpm',
+      },
+      {
+        name: 'Respiration',
+        colors: [
+          '#6b7280',
+          '#3b82f6',
+          '#22c55e',
+          '#facc15',
+          '#f97316',
+          '#ef4444',
+        ],
+        firstTooltip: 'Respiration -',
+        lastTooltip: 'Respiration 32 br/min',
+      },
+      {
+        name: 'Speed',
+        colors: [
+          '#6b7280',
+          '#3b82f6',
+          '#22c55e',
+          '#facc15',
+          '#f97316',
+          '#ef4444',
+        ],
+        firstTooltip: 'Speed -',
+        lastTooltip: 'Speed 34 km/h',
+      },
+      {
+        name: 'Temperature',
+        colors: [
+          '#6b7280',
+          '#2563eb',
+          '#06b6d4',
+          '#22c55e',
+          '#f97316',
+          '#ef4444',
+        ],
+        firstTooltip: 'Temperature -',
+        lastTooltip: 'Temperature 30 C',
+      },
+    ]
+
+    for (const metric of cases) {
+      leafletMocks.polyline.mockClear()
+      leafletMocks.layer.bindTooltip.mockClear()
+
+      await user.click(
+        screen.getByRole('combobox', {
+          name: 'Color climb map route by metric',
+        }),
+      )
+      await user.click(screen.getByRole('option', { name: metric.name }))
+
+      await waitFor(() =>
+        expect(leafletMocks.polyline).toHaveBeenCalledTimes(6),
+      )
+      expect(
+        leafletMocks.polyline.mock.calls.map((call) => call[1]?.color),
+      ).toEqual(metric.colors)
+      expect(leafletMocks.layer.bindTooltip).toHaveBeenNthCalledWith(
+        1,
+        metric.firstTooltip,
+      )
+      expect(leafletMocks.layer.bindTooltip).toHaveBeenLastCalledWith(
+        metric.lastTooltip,
+      )
+    }
+  })
+
+  it('uses grade fallbacks when only some map segments have grade data', async () => {
+    render(
+      <ClimbDetailsPanel
+        climb={mockClimb()}
+        climbIndex={0}
+        totalClimbs={1}
+        chartPoints={mockChartPointsWithPartialGradeData()}
+        onPrevious={vi.fn()}
+        onNext={vi.fn()}
+        canPrevious={false}
+        canNext={false}
+      />,
+    )
+
+    await waitFor(() => expect(leafletMocks.polyline).toHaveBeenCalledTimes(2))
+    expect(leafletMocks.polyline.mock.calls[0]?.[1]?.color).toBe('#6b7280')
+    expect(leafletMocks.layer.bindTooltip).toHaveBeenNthCalledWith(1, 'Grade -')
+    expect(leafletMocks.layer.bindTooltip).toHaveBeenNthCalledWith(
+      2,
+      expect.stringMatching(/^Grade -?\d+\.\d%$/),
+    )
+  })
+
+  it('shows route-only and chart fallbacks for coordinate-only points', async () => {
+    render(
+      <ClimbDetailsPanel
+        climb={mockClimb()}
+        climbIndex={0}
+        totalClimbs={1}
+        chartPoints={mockCoordinateOnlyPoints()}
+        onPrevious={vi.fn()}
+        onNext={vi.fn()}
+        canPrevious={false}
+        canNext={false}
+      />,
+    )
+
+    expect(
+      screen.getByText(
+        'No elevation and distance chart data available for this climb.',
+      ),
+    ).toBeInTheDocument()
+    expect(screen.getAllByText('Route')).toHaveLength(2)
+    expect(
+      screen.queryByRole('combobox', {
+        name: 'Color climb map route by metric',
+      }),
+    ).not.toBeInTheDocument()
+    await waitFor(() => expect(leafletMocks.polyline).toHaveBeenCalledTimes(1))
+    expect(leafletMocks.polyline.mock.calls[0]?.[1]?.color).toBe('#2563eb')
+  })
+
+  it('renders equal-distance chart points without invalid SVG coordinates', () => {
+    render(
+      <ClimbDetailsPanel
+        climb={mockClimb()}
+        climbIndex={0}
+        totalClimbs={1}
+        chartPoints={mockEqualDistancePoints()}
+        onPrevious={vi.fn()}
+        onNext={vi.fn()}
+        canPrevious={false}
+        canNext={false}
+      />,
+    )
+
+    const chart = screen.getByRole('img', {
+      name: 'Elevation and grade over climb distance',
+    })
+    expect(chart.innerHTML).not.toContain('NaN')
+    expect(chart.querySelectorAll('polygon')).toHaveLength(1)
+  })
+
+  it('skips map fitting for invalid bounds and removes the map on unmount', async () => {
+    leafletMocks.bounds.isValid.mockReturnValue(false)
+    const { unmount } = render(
+      <ClimbDetailsPanel
+        climb={mockClimb()}
+        climbIndex={0}
+        totalClimbs={1}
+        chartPoints={mockChartPoints()}
+        onPrevious={vi.fn()}
+        onNext={vi.fn()}
+        canPrevious={false}
+        canNext={false}
+      />,
+    )
+
+    await waitFor(() => expect(leafletMocks.map).toHaveBeenCalledTimes(1))
+    expect(leafletMocks.mapInstance.fitBounds).not.toHaveBeenCalled()
+
+    unmount()
+    expect(leafletMocks.mapInstance.remove).toHaveBeenCalledTimes(1)
   })
 
   it('shows a chart-point empty state when the selected climb has no points', () => {
@@ -323,20 +635,15 @@ describe('ClimbDetailsPanel', () => {
   })
 })
 
-function mockClimb(
-  overrides: Partial<{
-    start_time: string
-    end_time: string
-  }> = {},
-) {
+function mockClimb(overrides: Partial<ActivityClimb> = {}): ActivityClimb {
   return {
     id: 1,
     activity_id: '42',
     source_split_index: 0,
     message_index: null,
     climb_type: 'CLIMB_PRO_CYCLING_CLIMB',
-    start_time: overrides.start_time ?? '2026-03-14T09:05:00Z',
-    end_time: overrides.end_time ?? '2026-03-14T09:10:00Z',
+    start_time: '2026-03-14T09:05:00Z',
+    end_time: '2026-03-14T09:10:00Z',
     duration_seconds: 122,
     elapsed_duration_seconds: 122,
     moving_duration_seconds: 122,
@@ -353,6 +660,7 @@ function mockClimb(
     end_latitude: 40.3,
     end_longitude: -73.3,
     climb_pro_difficulty: null,
+    ...overrides,
   }
 }
 
@@ -427,4 +735,85 @@ function mockChartPointsWithoutSensorMetrics(): ActivityChartTrackPoint[] {
     latitude: point.latitude,
     longitude: point.longitude,
   }))
+}
+
+function mockChartPointsWithMetricBuckets(): ActivityChartTrackPoint[] {
+  const heartRateZones = [null, 1, 2, 3, 4, 5, 6]
+  const heartRates = [null, 119, 120, 140, 160, 175, 180]
+  const respirationRates = [null, 19, 20, 24, 28, 32, 35]
+  const speeds = [null, 9, 10, 18, 26, 34, 40]
+  const temperatures = [null, 4, 5, 15, 24, 30, 35]
+
+  return heartRateZones.map((hrZone, index) => ({
+    timestamp: `2026-03-14T09:${String(index + 5).padStart(2, '0')}:00Z`,
+    altitude: 20 + index,
+    distance_from_start_km: 10 + index * 0.1,
+    latitude: 40 + index * 0.01,
+    longitude: -73 - index * 0.01,
+    hr_zone: hrZone,
+    heart_rate: heartRates[index],
+    respiration_rate: respirationRates[index],
+    speed_kmh: speeds[index],
+    temperature_c: temperatures[index],
+  }))
+}
+
+function mockChartPointsWithPartialGradeData(): ActivityChartTrackPoint[] {
+  return [
+    {
+      timestamp: '2026-03-14T09:05:00Z',
+      altitude: null,
+      distance_from_start_km: null,
+      latitude: 40.1,
+      longitude: -73.1,
+    },
+    {
+      timestamp: '2026-03-14T09:07:00Z',
+      altitude: 30,
+      distance_from_start_km: 10,
+      latitude: 40.2,
+      longitude: -73.2,
+    },
+    {
+      timestamp: '2026-03-14T09:10:00Z',
+      altitude: 35,
+      distance_from_start_km: 10.1,
+      latitude: 40.3,
+      longitude: -73.3,
+    },
+  ]
+}
+
+function mockCoordinateOnlyPoints(): ActivityChartTrackPoint[] {
+  return [
+    {
+      timestamp: '2026-03-14T09:05:00Z',
+      latitude: 40.1,
+      longitude: -73.1,
+    },
+    {
+      timestamp: '2026-03-14T09:10:00Z',
+      latitude: 40.2,
+      longitude: -73.2,
+    },
+  ]
+}
+
+function mockEqualDistancePoints(): ActivityChartTrackPoint[] {
+  return [
+    {
+      timestamp: '2026-03-14T09:05:00Z',
+      altitude: 30,
+      distance_from_start_km: 10,
+      latitude: 40.1,
+      longitude: -73.1,
+    },
+    {
+      timestamp: '2026-03-14T09:10:00Z',
+      altitude: 30,
+      distance_from_start_km: 10,
+      latitude: 40.2,
+      longitude: -73.2,
+    },
+  ]
 }


### PR DESCRIPTION
## Summary

Refs #405

Completes the meaningful unit coverage for `ClimbDetailsPanel` through public rendering, selection, navigation, and Leaflet lifecycle behavior. No production code or coverage exclusions changed.

### Behaviors covered

- Every climb-map metric selection, legend, bucket boundary, and tooltip fallback
- Missing and non-finite climb values and save-segment coordinate validation
- Partial grade data, coordinate-only routes, and chart/map fallback states
- Equal-distance SVG rendering without invalid coordinates
- Invalid map bounds and unmount cleanup
- Enabled and disabled climb navigation callbacks

## Type of Change

- [ ] Bug fix (non-breaking change fixing an issue)
- [ ] New page / component
- [x] UI enhancement (non-breaking)
- [ ] GraphQL query / mutation change
- [ ] CI/CD pipeline change
- [ ] Documentation update

## Coverage

| Metric | Baseline | Final | Delta |
| --- | ---: | ---: | ---: |
| Statements | 94.25% (2526/2680) | 95.07% (2548/2680) | +22 covered, +0.82 pp |
| Branches | 87.03% (2021/2322) | 88.45% (2054/2322) | +33 covered, +1.42 pp |
| Functions | 94.75% (723/763) | 96.72% (738/763) | +15 covered, +1.97 pp |
| Lines | 96.07% (2301/2395) | 96.82% (2319/2395) | +18 covered, +0.75 pp |

Target `ClimbDetailsPanel.tsx` moved from 85.22% statements, 66.66% branches, 78.57% functions, and 87.26% lines to 97.72%, 92.85%, 100%, and 98.72%, respectively.

The two remaining uncovered lines and nine branches are defensive fallbacks made unreachable by prior type/runtime filters, fixed chart tick counts, `points.length >= 2`, or React effect cleanup.

## SonarQube

- CE task: `3a51f343-9469-4a6b-b22c-8dd74b656648` — SUCCESS
- Quality gate: OK
- Overall coverage: 88.4% → 89.4%
- Line coverage: 89.4% → 90.1%
- Branch coverage: 87.0% → 88.5%
- Uncovered lines: 321 → 300
- Uncovered conditions: 301 → 268

## Checklist

- [x] Read `README.md` and relevant docs
- [x] No secrets or credentials committed
- [x] Environment variables use `VITE_` prefix or N/A
- [x] Ran `npm run lint:all` locally
- [x] Ran `npm run test:run` locally
- [x] Ran `npm run type-check`
- [x] Ran `npm run build`
- [x] Ran full `npm run test:coverage`
- [x] SonarQube CE processing and quality gate passed

## Deployment

- [x] This requires the normal generated k8s-gitops version PR after merge.
- [x] No manual manifest changes are required.

## Testing

```bash
npx vitest run src/components/garmin/ClimbDetailsPanel.test.tsx
npm run lint:all
npm run type-check
npm run build
npm run test:run
npm run test:coverage -- --coverage.reporter=json-summary --coverage.reporter=lcov --coverage.reporter=text
npx sonar ... -Dsonar.javascript.lcov.reportPaths=coverage/lcov.info
```

Focused result: 17 tests passed.
Full result: 57 files and 419 tests passed.

## Post-Merge Validation

- [ ] Docker image built and pushed
- [ ] Generated k8s-gitops deployment PR created and merged
- [ ] Argo CD synced to the exact GitOps merge revision
- [ ] Kubernetes rollout and public `config.js` version verified
- [ ] Focused `e2e/garmin-climbs.spec.ts` production acceptance passed
- [ ] Final validation posted to issue #405 and issue closed manually

## Next Batch

The next high-value candidates are a behavior-specific slice of `DailySummaryDetailPage`, followed by `GarminActivityTotals`.