### PR TITLE
test: cover daily summary detail exports

### DIFF
--- a/src/pages/DailySummaryDetailPage.test.tsx
+++ b/src/pages/DailySummaryDetailPage.test.tsx
@@ -11,6 +11,10 @@ const graphqlHooks = vi.hoisted(() => ({
   useDailySummaryDateRangeQuery: vi.fn(),
 }))
 
+const exportMocks = vi.hoisted(() => ({
+  triggerDownload: vi.fn(),
+}))
+
 const leafletMocks = vi.hoisted(() => {
   class CircleMarkerMock {
     bindPopup = vi.fn()
@@ -54,6 +58,11 @@ const leafletMocks = vi.hoisted(() => {
 })
 
 vi.mock('@/__generated__/graphql', () => graphqlHooks)
+
+vi.mock('@/lib/export', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/lib/export')>()),
+  triggerDownload: exportMocks.triggerDownload,
+}))
 
 vi.mock('leaflet', () => ({
   default: {
@@ -102,6 +111,7 @@ describe('DailySummaryDetailPage', () => {
     graphqlHooks.useUnifiedGpsLazyQuery.mockReset()
     graphqlHooks.useDailySummaryQuery.mockReset()
     graphqlHooks.useDailySummaryDateRangeQuery.mockReset()
+    exportMocks.triggerDownload.mockReset()
 
     // Sensible defaults for the supporting queries so tests can override only
     // the main useUnifiedGpsQuery as needed.
@@ -698,6 +708,12 @@ describe('DailySummaryDetailPage', () => {
     renderDetail()
 
     expect(screen.getByText('No points available')).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: 'Download points as CSV' }),
+    ).toBeDisabled()
+    expect(
+      screen.getByRole('button', { name: 'Download points as GeoJSON' }),
+    ).toBeDisabled()
   })
 
   it('downloads a CSV via the lazy query when Export CSV is clicked', async () => {
@@ -758,16 +774,6 @@ describe('DailySummaryDetailPage', () => {
       },
     )
 
-    const createObjectURL = vi.fn(() => 'blob:mock')
-    const revokeObjectURL = vi.fn()
-    const originalCreate = URL.createObjectURL
-    const originalRevoke = URL.revokeObjectURL
-    URL.createObjectURL = createObjectURL
-    URL.revokeObjectURL = revokeObjectURL
-
-    const originalClick = HTMLAnchorElement.prototype.click
-    HTMLAnchorElement.prototype.click = vi.fn()
-
     renderDetail()
 
     await user.click(
@@ -784,11 +790,205 @@ describe('DailySummaryDetailPage', () => {
         }),
       }),
     )
-    expect(createObjectURL).toHaveBeenCalled()
+    expect(exportMocks.triggerDownload).toHaveBeenCalledWith(
+      [
+        'source,identifier,latitude,longitude,timestamp,battery,speed_kmh,heart_rate,accuracy',
+        'owntracks,phone,40.736,-74.039,2026-03-14T09:00:00Z,88,,,5',
+      ].join('\n'),
+      'text/csv;charset=utf-8',
+      'daily-summary-2026-03-14.csv',
+    )
+  })
 
-    HTMLAnchorElement.prototype.click = originalClick
-    URL.createObjectURL = originalCreate
-    URL.revokeObjectURL = originalRevoke
+  it('downloads source-filtered GeoJSON with coordinates and null metric fallbacks', async () => {
+    const user = userEvent.setup()
+    const lazyFetch = vi.fn().mockResolvedValue({
+      data: {
+        unifiedGps: {
+          total: 2,
+          items: [
+            {
+              source: 'garmin',
+              identifier: 'activity-1',
+              latitude: 40.736,
+              longitude: -74.039,
+              timestamp: '2026-03-14T09:00:00Z',
+              battery: null,
+              speed_kmh: null,
+              heart_rate: null,
+              accuracy: null,
+            },
+            {
+              source: 'garmin',
+              identifier: 'activity-2',
+              latitude: 40.737,
+              longitude: -74.04,
+              timestamp: '2026-03-14T10:00:00Z',
+              battery: 75,
+              speed_kmh: 12.5,
+              heart_rate: 148,
+              accuracy: 3,
+            },
+          ],
+        },
+      },
+    })
+    graphqlHooks.useUnifiedGpsLazyQuery.mockReturnValue([
+      lazyFetch,
+      { loading: false, called: false },
+    ])
+    graphqlHooks.useUnifiedGpsQuery.mockImplementation(
+      ({ variables }: { variables: { source?: string; limit?: number } }) => ({
+        data: {
+          unifiedGps: {
+            total: variables.limit === 1 ? 0 : 1,
+            items:
+              variables.limit === 1
+                ? []
+                : [
+                    {
+                      source: 'garmin',
+                      identifier: 'activity-1',
+                      latitude: 40.736,
+                      longitude: -74.039,
+                      timestamp: '2026-03-14T09:00:00Z',
+                    },
+                  ],
+          },
+        },
+        loading: false,
+        error: undefined,
+        refetch: vi.fn(),
+      }),
+    )
+
+    renderDetail('/daily-summary/2026-03-14?source=garmin&order=asc')
+
+    await user.click(
+      screen.getByRole('button', { name: 'Download points as GeoJSON' }),
+    )
+
+    await waitFor(() => expect(lazyFetch).toHaveBeenCalledTimes(1))
+    expect(lazyFetch).toHaveBeenCalledWith({
+      variables: {
+        source: 'garmin',
+        date_from: '2026-03-14',
+        date_to: '2026-03-14',
+        limit: 10000,
+        offset: 0,
+        order: 'asc',
+      },
+    })
+    const [content, mime, filename] = exportMocks.triggerDownload.mock.calls[0]!
+    expect(JSON.parse(content as string)).toEqual({
+      type: 'FeatureCollection',
+      features: [
+        {
+          type: 'Feature',
+          geometry: { type: 'Point', coordinates: [-74.039, 40.736] },
+          properties: {
+            source: 'garmin',
+            identifier: 'activity-1',
+            timestamp: '2026-03-14T09:00:00Z',
+            battery: null,
+            speed_kmh: null,
+            heart_rate: null,
+            accuracy: null,
+          },
+        },
+        {
+          type: 'Feature',
+          geometry: { type: 'Point', coordinates: [-74.04, 40.737] },
+          properties: {
+            source: 'garmin',
+            identifier: 'activity-2',
+            timestamp: '2026-03-14T10:00:00Z',
+            battery: 75,
+            speed_kmh: 12.5,
+            heart_rate: 148,
+            accuracy: 3,
+          },
+        },
+      ],
+    })
+    expect(mime).toBe('application/geo+json')
+    expect(filename).toBe('daily-summary-2026-03-14-garmin.geojson')
+  })
+
+  it('exports an empty GeoJSON collection when the lazy query has no data', async () => {
+    const user = userEvent.setup()
+    const lazyFetch = vi.fn().mockResolvedValue({ data: undefined })
+    graphqlHooks.useUnifiedGpsLazyQuery.mockReturnValue([
+      lazyFetch,
+      { loading: false, called: false },
+    ])
+    graphqlHooks.useUnifiedGpsQuery.mockReturnValue({
+      data: {
+        unifiedGps: {
+          total: 1,
+          items: [
+            {
+              source: 'owntracks',
+              identifier: 'phone',
+              latitude: 40.736,
+              longitude: -74.039,
+              timestamp: '2026-03-14T09:00:00Z',
+            },
+          ],
+        },
+      },
+      loading: false,
+      error: undefined,
+      refetch: vi.fn(),
+    })
+
+    renderDetail()
+
+    await user.click(
+      screen.getByRole('button', { name: 'Download points as GeoJSON' }),
+    )
+
+    await waitFor(() => expect(exportMocks.triggerDownload).toHaveBeenCalled())
+    const [content] = exportMocks.triggerDownload.mock.calls[0]!
+    expect(JSON.parse(content as string)).toEqual({
+      type: 'FeatureCollection',
+      features: [],
+    })
+  })
+
+  it('disables export controls while an export query is loading', () => {
+    graphqlHooks.useUnifiedGpsLazyQuery.mockReturnValue([
+      vi.fn(),
+      { loading: true, called: true },
+    ])
+    graphqlHooks.useUnifiedGpsQuery.mockReturnValue({
+      data: {
+        unifiedGps: {
+          total: 1,
+          items: [
+            {
+              source: 'owntracks',
+              identifier: 'phone',
+              latitude: 40.736,
+              longitude: -74.039,
+              timestamp: '2026-03-14T09:00:00Z',
+            },
+          ],
+        },
+      },
+      loading: false,
+      error: undefined,
+      refetch: vi.fn(),
+    })
+
+    renderDetail()
+
+    expect(
+      screen.getByRole('button', { name: 'Download points as CSV' }),
+    ).toBeDisabled()
+    expect(
+      screen.getByRole('button', { name: 'Download points as GeoJSON' }),
+    ).toBeDisabled()
   })
 
   it('handles invalid route dates by skipping the query', () => {

--- a/src/pages/DailySummaryDetailPage.test.tsx
+++ b/src/pages/DailySummaryDetailPage.test.tsx
@@ -790,6 +790,9 @@ describe('DailySummaryDetailPage', () => {
         }),
       }),
     )
+    await waitFor(() =>
+      expect(exportMocks.triggerDownload).toHaveBeenCalledTimes(1),
+    )
     expect(exportMocks.triggerDownload).toHaveBeenCalledWith(
       [
         'source,identifier,latitude,longitude,timestamp,battery,speed_kmh,heart_rate,accuracy',
@@ -879,6 +882,9 @@ describe('DailySummaryDetailPage', () => {
         order: 'asc',
       },
     })
+    await waitFor(() =>
+      expect(exportMocks.triggerDownload).toHaveBeenCalledTimes(1),
+    )
     const [content, mime, filename] = exportMocks.triggerDownload.mock.calls[0]!
     expect(JSON.parse(content as string)).toEqual({
       type: 'FeatureCollection',


### PR DESCRIPTION
## Summary

Refs #407

Adds behavior-focused unit coverage for the Daily Summary detail export contract through the existing accessible controls and download seam. No production code, coverage exclusion, or threshold changed.

### Behaviors covered

- CSV content, MIME type, and filename at the shared download boundary
- GeoJSON FeatureCollection coordinates and populated/null point properties
- Garmin source-filtered query variables, ascending order, and filename suffix
- Empty lazy-query results as a valid empty FeatureCollection
- Disabled CSV and GeoJSON controls for empty and export-loading states

## Type of Change

- [ ] Bug fix (non-breaking change fixing an issue)
- [ ] New page / component
- [x] UI enhancement (non-breaking)
- [ ] GraphQL query / mutation change
- [ ] CI/CD pipeline change
- [ ] Documentation update

## Coverage

| Metric | Baseline | Final | Delta |
| --- | ---: | ---: | ---: |
| Statements | 95.07% (2548/2680) | 95.26% (2553/2680) | +5 covered, +0.19 pp |
| Branches | 88.45% (2054/2322) | 88.93% (2065/2322) | +11 covered, +0.48 pp |
| Functions | 96.72% (738/763) | 97.11% (741/763) | +3 covered, +0.39 pp |
| Lines | 96.82% (2319/2395) | 97.03% (2324/2395) | +5 covered, +0.21 pp |

Target `DailySummaryDetailPage.tsx` moved from 80.95% statements, 73.52% branches, 77.19% functions, and 81.92% lines to 83.59%, 78.92%, 82.45%, and 84.93%, respectively.

## SonarQube

- CE task: `26bea61b-46dd-47d7-9883-79ed94518681` — SUCCESS on `aa26765c65896e15abe2cc541cf82767b1cbd42e`
- Quality gate: OK
- Overall coverage: 89.4% → 89.7%
- Line coverage: 90.1% → 90.4%
- Branch coverage: 88.5% → 88.9%
- Uncovered lines: 300 → 291
- Uncovered conditions: 268 → 257

## Checklist

- [x] Read `README.md` and relevant docs
- [x] No secrets or credentials committed
- [x] Environment variables use `VITE_` prefix or N/A
- [x] Ran `npm run lint:all` locally
- [x] Ran `npm run test:run` locally
- [x] Ran `npm run type-check`
- [x] Ran `npm run build`
- [x] Ran full `npm run test:coverage`
- [x] SonarQube CE processing and quality gate passed

## Deployment

- [x] This requires the normal generated k8s-gitops version PR after merge.
- [x] No manual manifest changes are required.

## Testing

```bash
npx vitest run src/pages/DailySummaryDetailPage.test.tsx
npm run lint:all
npm run type-check
npm run build
npm run test:run
npm run test:coverage -- --coverage.reporter=json-summary --coverage.reporter=lcov --coverage.reporter=text
npx sonar ... -Dsonar.javascript.lcov.reportPaths=coverage/lcov.info
```

Focused result: 20 tests passed.
Full result: 57 files and 422 tests passed.

## Post-Merge Validation

- [ ] Docker image built and pushed
- [ ] Generated k8s-gitops deployment PR created and merged
- [ ] Argo CD synced to the exact GitOps merge revision
- [ ] Kubernetes rollout and public `config.js` version verified
- [ ] Committed production Playwright acceptance passed
- [ ] Final validation posted to issue #407 and issue closed manually

## Next Batch

The next high-value candidates are the Daily Summary keyboard-navigation slice and `GarminActivityTotals`.