### PR TITLE
fix(garmin): support multiple laps per activity on segment leaderboards

### DIFF
--- a/src/components/garmin/SegmentEffortsLeaderboard.test.tsx
+++ b/src/components/garmin/SegmentEffortsLeaderboard.test.tsx
@@ -105,4 +105,30 @@ describe('SegmentEffortsLeaderboard', () => {
 
     expect(screen.getByText('Jul 4, 2026')).toBeVisible()
   })
+
+  it('marks only the fastest lap as PR when one activity has multiple laps', () => {
+    // A single ride that laps the segment twice shares an activity_id; only
+    // its faster lap should get the PR badge, not every row for that ride.
+    renderLeaderboard([
+      effort({
+        activity_id: 'multi-lap',
+        activity_start_time: '2026-07-09T22:44:46Z',
+        effort_start: '2026-07-09T22:44:46Z',
+        elapsed_seconds: 1199,
+      }),
+      effort({
+        activity_id: 'multi-lap',
+        activity_start_time: '2026-07-09T22:03:21Z',
+        effort_start: '2026-07-09T22:03:21Z',
+        elapsed_seconds: 1098,
+      }),
+    ])
+
+    const rows = screen.getAllByTestId('segment-effort-row')
+    expect(rows).toHaveLength(2)
+    expect(
+      within(rows[0]).queryByTestId('segment-effort-pr'),
+    ).not.toBeInTheDocument()
+    expect(within(rows[1]).getByTestId('segment-effort-pr')).toBeVisible()
+  })
 })

--- a/src/components/garmin/SegmentEffortsLeaderboard.tsx
+++ b/src/components/garmin/SegmentEffortsLeaderboard.tsx
@@ -14,7 +14,8 @@ import {
 import { cn } from '@/lib/utils'
 import {
   EFFORT_SORTS,
-  bestEffortActivityId,
+  bestEffortKey,
+  effortKey,
   formatDistanceMi,
   formatEffortDate,
   formatElapsed,
@@ -34,7 +35,7 @@ export function SegmentEffortsLeaderboard({
 }: Readonly<SegmentEffortsLeaderboardProps>) {
   const [sort, setSort] = useState<EffortSort>('date')
 
-  const bestActivityId = useMemo(() => bestEffortActivityId(efforts), [efforts])
+  const bestKey = useMemo(() => bestEffortKey(efforts), [efforts])
   const sorted = useMemo(() => sortEfforts(efforts, sort), [efforts, sort])
 
   return (
@@ -71,10 +72,10 @@ export function SegmentEffortsLeaderboard({
           </TableHeader>
           <TableBody>
             {sorted.map((effort, index) => {
-              const isPR = effort.activity_id === bestActivityId
+              const isPR = effortKey(effort) === bestKey
               return (
                 <TableRow
-                  key={`${effort.activity_id}-${effort.effort_start}`}
+                  key={effortKey(effort)}
                   className={cn(isPR && 'bg-primary/5')}
                   data-testid="segment-effort-row"
                 >

--- a/src/components/garmin/segmentEfforts.test.ts
+++ b/src/components/garmin/segmentEfforts.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import {
-  bestEffortActivityId,
+  bestEffortKey,
+  effortKey,
   formatDistanceMi,
   formatElapsed,
   formatSpeedMph,
@@ -73,17 +74,36 @@ describe('sortEfforts', () => {
   })
 })
 
-describe('bestEffortActivityId', () => {
-  it('returns the activity id with the lowest elapsed time', () => {
+describe('bestEffortKey', () => {
+  it('returns the key of the effort with the lowest elapsed time', () => {
     const efforts = [
       effort({ activity_id: 'a', elapsed_seconds: 82 }),
       effort({ activity_id: 'b', elapsed_seconds: 79 }),
     ]
-    expect(bestEffortActivityId(efforts)).toBe('b')
+    expect(bestEffortKey(efforts)).toBe(effortKey(efforts[1]))
   })
 
   it('returns null for an empty list', () => {
-    expect(bestEffortActivityId([])).toBeNull()
+    expect(bestEffortKey([])).toBeNull()
+  })
+
+  it('picks the fastest lap, not every lap, when one activity has several', () => {
+    // A single ride that laps the segment twice shares one activity_id --
+    // only its faster lap should be the PR, not both.
+    const efforts = [
+      effort({
+        activity_id: 'multi-lap-ride',
+        effort_start: '2026-07-09T22:03:21Z',
+        elapsed_seconds: 1098,
+      }),
+      effort({
+        activity_id: 'multi-lap-ride',
+        effort_start: '2026-07-09T22:44:46Z',
+        elapsed_seconds: 1199,
+      }),
+    ]
+    expect(bestEffortKey(efforts)).toBe(effortKey(efforts[0]))
+    expect(bestEffortKey(efforts)).not.toBe(effortKey(efforts[1]))
   })
 })
 

--- a/src/components/garmin/segmentEfforts.ts
+++ b/src/components/garmin/segmentEfforts.ts
@@ -59,8 +59,8 @@ export function effortKey(
 }
 
 /**
- * The key of the personal-best (fastest) effort, or null when there are fewer
- * than one efforts. Ties resolve to the first-seen fastest.
+ * The key of the personal-best (fastest) effort, or null when there are no
+ * efforts. Ties resolve to the first-seen fastest.
  */
 export function bestEffortKey(
   efforts: readonly SegmentEffort[],

--- a/src/components/garmin/segmentEfforts.ts
+++ b/src/components/garmin/segmentEfforts.ts
@@ -48,10 +48,21 @@ export function sortEfforts(
 }
 
 /**
- * The activity_id of the personal-best (fastest) effort, or null when there are
- * fewer than one efforts. Ties resolve to the first-seen fastest.
+ * Identifies one effort row. An activity can appear more than once (each lap
+ * of a loop segment ridden in a single activity is its own effort), so
+ * activity_id alone isn't a unique key.
  */
-export function bestEffortActivityId(
+export function effortKey(
+  effort: Pick<SegmentEffort, 'activity_id' | 'effort_start'>,
+): string {
+  return `${effort.activity_id}-${effort.effort_start}`
+}
+
+/**
+ * The key of the personal-best (fastest) effort, or null when there are fewer
+ * than one efforts. Ties resolve to the first-seen fastest.
+ */
+export function bestEffortKey(
   efforts: readonly SegmentEffort[],
 ): string | null {
   let best: SegmentEffort | null = null
@@ -60,7 +71,7 @@ export function bestEffortActivityId(
       best = e
     }
   }
-  return best?.activity_id ?? null
+  return best ? effortKey(best) : null
 }
 
 export function formatElapsed(seconds: number | null | undefined): string {

--- a/src/pages/GarminSegmentDetailPage.test.tsx
+++ b/src/pages/GarminSegmentDetailPage.test.tsx
@@ -199,7 +199,7 @@ describe('GarminSegmentDetailPage', () => {
     )
     expect(segmentHooks.useGarminSegmentEffortsQuery).toHaveBeenCalledWith(
       expect.objectContaining({
-        variables: expect.objectContaining({ id: Number.NaN, limit: 100 }),
+        variables: expect.objectContaining({ id: Number.NaN, limit: 500 }),
         skip: true,
       }),
     )

--- a/src/pages/GarminSegmentDetailPage.tsx
+++ b/src/pages/GarminSegmentDetailPage.tsx
@@ -22,7 +22,10 @@ import {
 import { getSegmentRoutePoints } from '@/components/garmin/segmentRoute'
 import { setNRCustomAttribute } from '@/lib/newrelic-browser'
 
-const EFFORTS_LIMIT = 100
+// 500 is the otel-data-api's max; an activity that laps a loop segment
+// several times now yields one effort per lap instead of just its fastest,
+// so a popular segment can have well over 100 total efforts.
+const EFFORTS_LIMIT = 500
 
 export function GarminSegmentDetailPage() {
   const { segmentId } = useParams<{ segmentId: string }>()


### PR DESCRIPTION
## Summary
- Companion frontend fix for [stuartshay/otel-data-api#214](https://github.com/stuartshay/otel-data-api/pull/214), which now returns one effort per lap of a loop segment instead of collapsing an activity down to its single fastest lap (e.g. activity `23541736805` rode Liberty State Park Loop 4 times back-to-back; the leaderboard only ever showed 1).
- **PR badge bug**: `bestEffortActivityId` keyed only on `activity_id`, so once an activity could have multiple effort rows, every lap belonging to the activity containing the single fastest lap would get marked PR, not just that lap. Replaced with `bestEffortKey`/`effortKey`, keyed on `activity_id` + `effort_start` (the same composite key already used for row identity).
- **Truncated history**: `EFFORTS_LIMIT` was hardcoded to 100. Now that laps aren't collapsed, a popular loop segment can have well over 100 total efforts (Liberty State Park Loop has 383). Raised to 500, the API's max, so the leaderboard isn't silently missing recent/slower laps.

## Test plan
- [x] `vitest run` — 430 passed
- [x] `tsc --noEmit` / `eslint` — clean
- [x] Added tests: PR badge only marks the fastest of two laps sharing an `activity_id`, `bestEffortKey` unit tests for the multi-lap case, and updated the `EFFORTS_LIMIT` assertion

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>