### PR TITLE
feat(garmin): add hourly weather breakdown to the Stats tab

### DIFF
--- a/src/__generated__/graphql.ts
+++ b/src/__generated__/graphql.ts
@@ -452,6 +452,58 @@ export type GarminActivityWeather = {
   wind_speed_kmh?: Maybe<Scalars['Float']['output']>;
 };
 
+/**
+ * Route-sampled, hour-by-hour Open-Meteo weather for an activity. Unlike
+ * GarminActivityWeather (a single "conditions at the start" snapshot), each
+ * row is sampled at the GPS location the athlete was actually at during that
+ * hour.
+ */
+export type GarminActivityWeatherHourly = {
+  __typename?: 'GarminActivityWeatherHourly';
+  /** Parent Garmin activity identifier */
+  activity_id: Scalars['String']['output'];
+  /** Feels-like temperature in degrees C */
+  apparent_temperature_c?: Maybe<Scalars['Float']['output']>;
+  /** Total cloud cover percent */
+  cloud_cover_pct?: Maybe<Scalars['Float']['output']>;
+  /** UTC timestamp when the row was inserted */
+  created_at?: Maybe<Scalars['String']['output']>;
+  /** Zero-based hour offset from the activity start */
+  hour_index: Scalars['Int']['output'];
+  /** True when sourced from the forecast API pending ERA5 archive settlement */
+  is_provisional: Scalars['Boolean']['output'];
+  /** Latitude sampled from the nearest track point for this hour */
+  latitude: Scalars['Float']['output'];
+  /** Longitude sampled from the nearest track point for this hour */
+  longitude: Scalars['Float']['output'];
+  /** UTC hourly bucket the reading was taken from */
+  observed_at: Scalars['String']['output'];
+  /** Total precipitation in millimeters */
+  precipitation_mm?: Maybe<Scalars['Float']['output']>;
+  /** Rainfall in millimeters */
+  rain_mm?: Maybe<Scalars['Float']['output']>;
+  /** Relative humidity percent */
+  relative_humidity_pct?: Maybe<Scalars['Float']['output']>;
+  /** Snowfall in centimeters */
+  snowfall_cm?: Maybe<Scalars['Float']['output']>;
+  /** Open-Meteo API the row came from: archive or forecast */
+  source: Scalars['String']['output'];
+  /** Surface pressure in hPa */
+  surface_pressure_hpa?: Maybe<Scalars['Float']['output']>;
+  /** Air temperature in degrees C */
+  temperature_c?: Maybe<Scalars['Float']['output']>;
+  /** UTC timestamp when the row was last updated */
+  updated_at?: Maybe<Scalars['String']['output']>;
+  /** WMO weather interpretation code */
+  weather_code?: Maybe<Scalars['Int']['output']>;
+  /** Wind direction in degrees */
+  wind_direction_deg?: Maybe<Scalars['Float']['output']>;
+  /** Wind gust speed in km/h */
+  wind_gusts_kmh?: Maybe<Scalars['Float']['output']>;
+  /** Wind speed in km/h */
+  wind_speed_kmh?: Maybe<Scalars['Float']['output']>;
+};
+
 /** Lightweight track point optimised for time-series chart rendering. */
 export type GarminChartPoint = {
   __typename?: 'GarminChartPoint';
@@ -1043,6 +1095,13 @@ export type Query = {
    * Returns null if the activity exists but hasn't been weather-backfilled yet.
    */
   garminActivityWeather?: Maybe<GarminActivityWeather>;
+  /**
+   * Retrieve route-sampled, hour-by-hour Open-Meteo weather for a Garmin activity.
+   * Unlike garminActivityWeather (a single "conditions at the start" snapshot), each
+   * row is sampled at the GPS location the athlete was actually at during that hour.
+   * Returns an empty list if the activity exists but hasn't been hourly-backfilled yet.
+   */
+  garminActivityWeatherHourly: Array<GarminActivityWeatherHourly>;
   /** Retrieve chart-optimised track points for a Garmin activity. */
   garminChartData: Array<GarminChartPoint>;
   /** Get the earliest and latest Garmin activity timestamps. */
@@ -1144,6 +1203,11 @@ export type QueryGarminActivityTotalsArgs = {
 
 
 export type QueryGarminActivityWeatherArgs = {
+  activity_id: Scalars['String']['input'];
+};
+
+
+export type QueryGarminActivityWeatherHourlyArgs = {
   activity_id: Scalars['String']['input'];
 };
 
@@ -1432,6 +1496,13 @@ export type GarminActivityWeatherQueryVariables = Exact<{
 
 
 export type GarminActivityWeatherQuery = { garminActivityWeather: { activity_id: string, observed_at: string, temperature_c: number | null, apparent_temperature_c: number | null, relative_humidity_pct: number | null, precipitation_mm: number | null, rain_mm: number | null, snowfall_cm: number | null, cloud_cover_pct: number | null, wind_speed_kmh: number | null, wind_gusts_kmh: number | null, wind_direction_deg: number | null, weather_code: number | null, source: string, is_provisional: boolean } | null };
+
+export type GarminActivityWeatherHourlyQueryVariables = Exact<{
+  activity_id: string;
+}>;
+
+
+export type GarminActivityWeatherHourlyQuery = { garminActivityWeatherHourly: Array<{ activity_id: string, hour_index: number, observed_at: string, temperature_c: number | null, weather_code: number | null, source: string, is_provisional: boolean }> };
 
 export type GarminLapsComparisonQueryVariables = Exact<{
   sport?: string | null | undefined;
@@ -2306,6 +2377,55 @@ export type GarminActivityWeatherQueryHookResult = ReturnType<typeof useGarminAc
 export type GarminActivityWeatherLazyQueryHookResult = ReturnType<typeof useGarminActivityWeatherLazyQuery>;
 export type GarminActivityWeatherSuspenseQueryHookResult = ReturnType<typeof useGarminActivityWeatherSuspenseQuery>;
 export type GarminActivityWeatherQueryResult = ApolloReactCommon.QueryResult<GarminActivityWeatherQuery, GarminActivityWeatherQueryVariables>;
+export const GarminActivityWeatherHourlyDocument = gql`
+    query GarminActivityWeatherHourly($activity_id: String!) {
+  garminActivityWeatherHourly(activity_id: $activity_id) {
+    activity_id
+    hour_index
+    observed_at
+    temperature_c
+    weather_code
+    source
+    is_provisional
+  }
+}
+    `;
+
+/**
+ * __useGarminActivityWeatherHourlyQuery__
+ *
+ * To run a query within a React component, call `useGarminActivityWeatherHourlyQuery` and pass it any options that fit your needs.
+ * When your component renders, `useGarminActivityWeatherHourlyQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useGarminActivityWeatherHourlyQuery({
+ *   variables: {
+ *      activity_id: // value for 'activity_id'
+ *   },
+ * });
+ */
+export function useGarminActivityWeatherHourlyQuery(baseOptions: ApolloReactHooks.QueryHookOptions<GarminActivityWeatherHourlyQuery, GarminActivityWeatherHourlyQueryVariables> & ({ variables: GarminActivityWeatherHourlyQueryVariables; skip?: boolean; } | { skip: boolean; }) ) {
+        const options = {...defaultOptions, ...baseOptions}
+        return ApolloReactHooks.useQuery<GarminActivityWeatherHourlyQuery, GarminActivityWeatherHourlyQueryVariables>(GarminActivityWeatherHourlyDocument, options);
+      }
+export function useGarminActivityWeatherHourlyLazyQuery(baseOptions?: ApolloReactHooks.LazyQueryHookOptions<GarminActivityWeatherHourlyQuery, GarminActivityWeatherHourlyQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return ApolloReactHooks.useLazyQuery<GarminActivityWeatherHourlyQuery, GarminActivityWeatherHourlyQueryVariables>(GarminActivityWeatherHourlyDocument, options);
+        }
+// @ts-ignore
+export function useGarminActivityWeatherHourlySuspenseQuery(baseOptions?: ApolloReactHooks.SuspenseQueryHookOptions<GarminActivityWeatherHourlyQuery, GarminActivityWeatherHourlyQueryVariables>): ApolloReactHooks.UseSuspenseQueryResult<GarminActivityWeatherHourlyQuery, GarminActivityWeatherHourlyQueryVariables>;
+export function useGarminActivityWeatherHourlySuspenseQuery(baseOptions?: ApolloReactHooks.SkipToken | ApolloReactHooks.SuspenseQueryHookOptions<GarminActivityWeatherHourlyQuery, GarminActivityWeatherHourlyQueryVariables>): ApolloReactHooks.UseSuspenseQueryResult<GarminActivityWeatherHourlyQuery | undefined, GarminActivityWeatherHourlyQueryVariables>;
+export function useGarminActivityWeatherHourlySuspenseQuery(baseOptions?: ApolloReactHooks.SkipToken | ApolloReactHooks.SuspenseQueryHookOptions<GarminActivityWeatherHourlyQuery, GarminActivityWeatherHourlyQueryVariables>) {
+          const options = baseOptions === ApolloReactHooks.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
+          return ApolloReactHooks.useSuspenseQuery<GarminActivityWeatherHourlyQuery, GarminActivityWeatherHourlyQueryVariables>(GarminActivityWeatherHourlyDocument, options);
+        }
+export type GarminActivityWeatherHourlyQueryHookResult = ReturnType<typeof useGarminActivityWeatherHourlyQuery>;
+export type GarminActivityWeatherHourlyLazyQueryHookResult = ReturnType<typeof useGarminActivityWeatherHourlyLazyQuery>;
+export type GarminActivityWeatherHourlySuspenseQueryHookResult = ReturnType<typeof useGarminActivityWeatherHourlySuspenseQuery>;
+export type GarminActivityWeatherHourlyQueryResult = ApolloReactCommon.QueryResult<GarminActivityWeatherHourlyQuery, GarminActivityWeatherHourlyQueryVariables>;
 export const GarminLapsComparisonDocument = gql`
     query GarminLapsComparison($sport: String, $date_from: String, $date_to: String, $limit: Int, $offset: Int) {
   garminLapsComparison(

--- a/src/components/garmin/WeatherHourlyBreakdown.test.tsx
+++ b/src/components/garmin/WeatherHourlyBreakdown.test.tsx
@@ -31,6 +31,8 @@ describe('WeatherHourlyBreakdown', () => {
     // 10C -> 50F, 25C -> 77F
     expect(screen.getByText('50°F')).toBeInTheDocument()
     expect(screen.getByText('77°F')).toBeInTheDocument()
+    expect(screen.getByText('Clear sky')).toHaveClass('sr-only')
+    expect(screen.getByText('Slight rain')).toHaveClass('sr-only')
   })
 
   it('shows the temperature range across the hours', () => {

--- a/src/components/garmin/WeatherHourlyBreakdown.test.tsx
+++ b/src/components/garmin/WeatherHourlyBreakdown.test.tsx
@@ -1,0 +1,76 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import { WeatherHourlyBreakdown } from './WeatherHourlyBreakdown'
+
+describe('WeatherHourlyBreakdown', () => {
+  it('renders nothing when there are fewer than two hours', () => {
+    const { container: empty } = render(
+      <WeatherHourlyBreakdown hours={undefined} />,
+    )
+    expect(empty).toBeEmptyDOMElement()
+
+    const { container: single } = render(
+      <WeatherHourlyBreakdown hours={[{ hour_index: 0, temperature_c: 20 }]} />,
+    )
+    expect(single).toBeEmptyDOMElement()
+  })
+
+  it('renders an hour chip per reading, ordered by hour_index', () => {
+    render(
+      <WeatherHourlyBreakdown
+        hours={[
+          { hour_index: 1, temperature_c: 25, weather_code: 61 },
+          { hour_index: 0, temperature_c: 10, weather_code: 0 },
+        ]}
+      />,
+    )
+
+    expect(screen.getByTestId('weather-hourly-breakdown')).toBeInTheDocument()
+    expect(screen.getByText('Start')).toBeInTheDocument()
+    expect(screen.getByText('+1h')).toBeInTheDocument()
+    // 10C -> 50F, 25C -> 77F
+    expect(screen.getByText('50°F')).toBeInTheDocument()
+    expect(screen.getByText('77°F')).toBeInTheDocument()
+  })
+
+  it('shows the temperature range across the hours', () => {
+    render(
+      <WeatherHourlyBreakdown
+        hours={[
+          { hour_index: 0, temperature_c: 10 },
+          { hour_index: 1, temperature_c: 25 },
+        ]}
+      />,
+    )
+
+    expect(screen.getByText('50°F – 77°F')).toBeInTheDocument()
+  })
+
+  it('flags provisional hours', () => {
+    render(
+      <WeatherHourlyBreakdown
+        hours={[
+          { hour_index: 0, temperature_c: 10, is_provisional: false },
+          { hour_index: 1, temperature_c: 12, is_provisional: true },
+        ]}
+      />,
+    )
+
+    expect(screen.getByText(/preliminary forecast data/i)).toBeInTheDocument()
+  })
+
+  it('does not flag provisional when all hours are finalized', () => {
+    render(
+      <WeatherHourlyBreakdown
+        hours={[
+          { hour_index: 0, temperature_c: 10, is_provisional: false },
+          { hour_index: 1, temperature_c: 12, is_provisional: false },
+        ]}
+      />,
+    )
+
+    expect(
+      screen.queryByText(/preliminary forecast data/i),
+    ).not.toBeInTheDocument()
+  })
+})

--- a/src/components/garmin/WeatherHourlyBreakdown.tsx
+++ b/src/components/garmin/WeatherHourlyBreakdown.tsx
@@ -1,5 +1,6 @@
 import {
   WEATHER_ICONS,
+  describeWeatherCode,
   fmtTemp,
   temperatureRangeF,
   weatherIconKind,
@@ -68,6 +69,9 @@ export function WeatherHourlyBreakdown({
                 className="h-5 w-5 text-muted-foreground"
                 aria-hidden="true"
               />
+              <span className="sr-only">
+                {describeWeatherCode(hour.weather_code)}
+              </span>
               <span className="text-sm font-medium tracking-tight">
                 {fmtTemp(hour.temperature_c)}
               </span>

--- a/src/components/garmin/WeatherHourlyBreakdown.tsx
+++ b/src/components/garmin/WeatherHourlyBreakdown.tsx
@@ -1,0 +1,87 @@
+import {
+  WEATHER_ICONS,
+  fmtTemp,
+  temperatureRangeF,
+  weatherIconKind,
+} from './WeatherPanel.helpers'
+
+export interface WeatherHourlyPoint {
+  hour_index: number
+  temperature_c?: number | null
+  weather_code?: number | null
+  is_provisional?: boolean | null
+}
+
+interface WeatherHourlyBreakdownProps {
+  hours: WeatherHourlyPoint[] | null | undefined
+}
+
+function hourLabel(hourIndex: number): string {
+  return hourIndex === 0 ? 'Start' : `+${hourIndex}h`
+}
+
+/**
+ * Route-sampled, hour-by-hour weather strip for multi-hour activities.
+ *
+ * A single-hour activity's weather is already fully represented by
+ * WeatherPanel's summary card, so this renders nothing unless there are at
+ * least two hours to compare — the whole point is showing how conditions
+ * changed over the course of the activity (and across the route, since
+ * each hour is sampled at wherever the athlete actually was).
+ */
+export function WeatherHourlyBreakdown({
+  hours,
+}: Readonly<WeatherHourlyBreakdownProps>) {
+  if (!hours || hours.length < 2) {
+    return null
+  }
+
+  const sorted = [...hours].sort((a, b) => a.hour_index - b.hour_index)
+  const range = temperatureRangeF(sorted.map((h) => h.temperature_c))
+  const anyProvisional = sorted.some((h) => h.is_provisional)
+
+  return (
+    <div className="space-y-2" data-testid="weather-hourly-breakdown">
+      <div className="flex items-center justify-between">
+        <span className="text-xs font-medium text-muted-foreground uppercase tracking-wider">
+          Over the activity
+        </span>
+        {range && (
+          <span className="text-xs text-muted-foreground">
+            {range.minF}°F – {range.maxF}°F
+          </span>
+        )}
+      </div>
+
+      <div className="flex gap-3 overflow-x-auto pb-1">
+        {sorted.map((hour) => {
+          const Icon = WEATHER_ICONS[weatherIconKind(hour.weather_code)]
+          return (
+            <div
+              key={hour.hour_index}
+              className="flex flex-col items-center gap-1 shrink-0 min-w-14"
+            >
+              <span className="text-[11px] text-muted-foreground">
+                {hourLabel(hour.hour_index)}
+              </span>
+              <Icon
+                className="h-5 w-5 text-muted-foreground"
+                aria-hidden="true"
+              />
+              <span className="text-sm font-medium tracking-tight">
+                {fmtTemp(hour.temperature_c)}
+              </span>
+            </div>
+          )
+        })}
+      </div>
+
+      {anyProvisional && (
+        <p className="text-[11px] text-muted-foreground italic">
+          Some hours are preliminary forecast data pending ERA5 archive
+          settlement.
+        </p>
+      )}
+    </div>
+  )
+}

--- a/src/components/garmin/WeatherPanel.helpers.test.ts
+++ b/src/components/garmin/WeatherPanel.helpers.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest'
-import { describeWeatherCode, weatherIconKind } from './WeatherPanel.helpers'
+import {
+  describeWeatherCode,
+  temperatureRangeF,
+  weatherIconKind,
+} from './WeatherPanel.helpers'
 
 describe('describeWeatherCode', () => {
   it('maps known WMO codes to descriptions', () => {
@@ -33,5 +37,28 @@ describe('weatherIconKind', () => {
     expect(weatherIconKind(null)).toBe('unknown')
     expect(weatherIconKind(undefined)).toBe('unknown')
     expect(weatherIconKind(12345)).toBe('unknown')
+  })
+})
+
+describe('temperatureRangeF', () => {
+  it('converts and returns the min/max across known readings', () => {
+    // 10C -> 50F, 25C -> 77F
+    expect(temperatureRangeF([10, 25])).toEqual({ minF: 50, maxF: 77 })
+  })
+
+  it('ignores null/undefined readings', () => {
+    expect(temperatureRangeF([10, null, undefined, 25])).toEqual({
+      minF: 50,
+      maxF: 77,
+    })
+  })
+
+  it('returns a single-value range when there is only one reading', () => {
+    expect(temperatureRangeF([20])).toEqual({ minF: 68, maxF: 68 })
+  })
+
+  it('returns null when no readings have a temperature', () => {
+    expect(temperatureRangeF([null, undefined])).toBeNull()
+    expect(temperatureRangeF([])).toBeNull()
   })
 })

--- a/src/components/garmin/WeatherPanel.helpers.ts
+++ b/src/components/garmin/WeatherPanel.helpers.ts
@@ -1,3 +1,14 @@
+import {
+  Cloud,
+  CloudDrizzle,
+  CloudFog,
+  CloudLightning,
+  CloudRain,
+  CloudSnow,
+  Sun,
+} from 'lucide-react'
+import { celsiusToFahrenheit } from '@/lib/units'
+
 // WMO weather interpretation codes as returned by Open-Meteo.
 // https://open-meteo.com/en/docs (see "WMO Weather interpretation codes")
 const WMO_DESCRIPTIONS: Record<number, string> = {
@@ -58,4 +69,38 @@ export function weatherIconKind(
   if ((code >= 71 && code <= 77) || code === 85 || code === 86) return 'snow'
   if (code >= 95 && code <= 99) return 'thunderstorm'
   return 'unknown'
+}
+
+export const WEATHER_ICONS = {
+  clear: Sun,
+  cloud: Cloud,
+  fog: CloudFog,
+  drizzle: CloudDrizzle,
+  rain: CloudRain,
+  snow: CloudSnow,
+  thunderstorm: CloudLightning,
+  unknown: Cloud,
+} as const
+
+export function fmtTemp(celsius: number | null | undefined): string {
+  return celsius != null ? `${Math.round(celsiusToFahrenheit(celsius))}°F` : '—'
+}
+
+export interface TemperatureRange {
+  minF: number
+  maxF: number
+}
+
+/** Min/max temperature (°F) across a set of readings, or null if none have a temperature. */
+export function temperatureRangeF(
+  temperaturesC: Array<number | null | undefined>,
+): TemperatureRange | null {
+  const known = temperaturesC
+    .filter((c): c is number => c != null)
+    .map(celsiusToFahrenheit)
+  if (known.length === 0) return null
+  return {
+    minF: Math.round(Math.min(...known)),
+    maxF: Math.round(Math.max(...known)),
+  }
 }

--- a/src/components/garmin/WeatherPanel.test.tsx
+++ b/src/components/garmin/WeatherPanel.test.tsx
@@ -71,4 +71,39 @@ describe('WeatherPanel', () => {
     expect(screen.getAllByText('—').length).toBeGreaterThan(0)
     expect(screen.getByText(/Unknown conditions/)).toBeInTheDocument()
   })
+
+  it('renders the hourly breakdown when multi-hour data is provided', () => {
+    render(
+      <WeatherPanel
+        weather={{
+          temperature_c: 18.4,
+          weather_code: 0,
+          is_provisional: false,
+        }}
+        hourly={[
+          { hour_index: 0, temperature_c: 18.4, weather_code: 0 },
+          { hour_index: 1, temperature_c: 15.0, weather_code: 61 },
+        ]}
+      />,
+    )
+
+    expect(screen.getByTestId('weather-hourly-breakdown')).toBeInTheDocument()
+  })
+
+  it('omits the hourly breakdown for a single-hour activity', () => {
+    render(
+      <WeatherPanel
+        weather={{
+          temperature_c: 18.4,
+          weather_code: 0,
+          is_provisional: false,
+        }}
+        hourly={[{ hour_index: 0, temperature_c: 18.4, weather_code: 0 }]}
+      />,
+    )
+
+    expect(
+      screen.queryByTestId('weather-hourly-breakdown'),
+    ).not.toBeInTheDocument()
+  })
 })

--- a/src/components/garmin/WeatherPanel.tsx
+++ b/src/components/garmin/WeatherPanel.tsx
@@ -1,17 +1,16 @@
-import {
-  Cloud,
-  CloudDrizzle,
-  CloudFog,
-  CloudLightning,
-  CloudRain,
-  CloudSnow,
-  Loader2,
-  Sun,
-  Wind,
-} from 'lucide-react'
+import { Loader2, Wind } from 'lucide-react'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
-import { celsiusToFahrenheit, kmhToMph, mmToInches } from '@/lib/units'
-import { describeWeatherCode, weatherIconKind } from './WeatherPanel.helpers'
+import { kmhToMph, mmToInches } from '@/lib/units'
+import {
+  WEATHER_ICONS,
+  describeWeatherCode,
+  fmtTemp,
+  weatherIconKind,
+} from './WeatherPanel.helpers'
+import {
+  WeatherHourlyBreakdown,
+  type WeatherHourlyPoint,
+} from './WeatherHourlyBreakdown'
 
 export interface WeatherPanelData {
   temperature_c?: number | null
@@ -29,21 +28,7 @@ interface WeatherPanelProps {
   weather: WeatherPanelData | null | undefined
   loading?: boolean
   error?: string | null
-}
-
-const WEATHER_ICONS = {
-  clear: Sun,
-  cloud: Cloud,
-  fog: CloudFog,
-  drizzle: CloudDrizzle,
-  rain: CloudRain,
-  snow: CloudSnow,
-  thunderstorm: CloudLightning,
-  unknown: Cloud,
-} as const
-
-function fmtTemp(celsius: number | null | undefined): string {
-  return celsius != null ? `${Math.round(celsiusToFahrenheit(celsius))}°F` : '—'
+  hourly?: WeatherHourlyPoint[] | null
 }
 
 function fmtWind(kmh: number | null | undefined): string {
@@ -71,6 +56,7 @@ export function WeatherPanel({
   weather,
   loading,
   error,
+  hourly,
 }: Readonly<WeatherPanelProps>) {
   return (
     <Card data-testid="weather-panel">
@@ -141,6 +127,8 @@ export function WeatherPanel({
                 Gusts up to {fmtWind(weather.wind_gusts_kmh)}
               </div>
             )}
+
+            <WeatherHourlyBreakdown hours={hourly} />
 
             {weather.is_provisional && (
               <p className="text-xs text-muted-foreground italic">

--- a/src/graphql/garmin.ts
+++ b/src/graphql/garmin.ts
@@ -297,6 +297,20 @@ export const GARMIN_ACTIVITY_WEATHER_QUERY = gql`
   }
 `
 
+export const GARMIN_ACTIVITY_WEATHER_HOURLY_QUERY = gql`
+  query GarminActivityWeatherHourly($activity_id: String!) {
+    garminActivityWeatherHourly(activity_id: $activity_id) {
+      activity_id
+      hour_index
+      observed_at
+      temperature_c
+      weather_code
+      source
+      is_provisional
+    }
+  }
+`
+
 export const GARMIN_LAPS_COMPARISON_QUERY = gql`
   query GarminLapsComparison(
     $sport: String

--- a/src/pages/GarminDetailPage.test.tsx
+++ b/src/pages/GarminDetailPage.test.tsx
@@ -11,6 +11,7 @@ const garminDetailHooks = vi.hoisted(() => ({
   useGarminActivityClimbsQuery: vi.fn(),
   useGarminActivityLapsQuery: vi.fn(),
   useGarminActivityWeatherQuery: vi.fn(),
+  useGarminActivityWeatherHourlyQuery: vi.fn(),
   useGarminExportPointsLazyQuery: vi.fn(),
 }))
 const toastMocks = vi.hoisted(() => ({
@@ -187,6 +188,7 @@ describe('GarminDetailPage', () => {
     garminDetailHooks.useGarminActivityClimbsQuery.mockReset()
     garminDetailHooks.useGarminActivityLapsQuery.mockReset()
     garminDetailHooks.useGarminActivityWeatherQuery.mockReset()
+    garminDetailHooks.useGarminActivityWeatherHourlyQuery.mockReset()
     garminDetailHooks.useGarminExportPointsLazyQuery.mockReset()
     toastMocks.error.mockReset()
     toastMocks.warning.mockReset()
@@ -209,6 +211,11 @@ describe('GarminDetailPage', () => {
     garminDetailHooks.useGarminActivityWeatherQuery.mockReturnValue({
       loading: false,
       data: { garminActivityWeather: null },
+      error: undefined,
+    })
+    garminDetailHooks.useGarminActivityWeatherHourlyQuery.mockReturnValue({
+      loading: false,
+      data: { garminActivityWeatherHourly: [] },
       error: undefined,
     })
   })

--- a/src/pages/GarminDetailPage.tsx
+++ b/src/pages/GarminDetailPage.tsx
@@ -8,6 +8,7 @@ import {
   useGarminChartDataQuery,
   useGarminActivityClimbsQuery,
   useGarminActivityLapsQuery,
+  useGarminActivityWeatherHourlyQuery,
   useGarminActivityWeatherQuery,
   useGarminExportPointsLazyQuery,
   type GarminActivityClimbsQuery,
@@ -671,6 +672,10 @@ export function GarminDetailPage() {
     variables: { activity_id: activityId ?? '' },
     skip: !activityId,
   })
+  const { data: weatherHourlyData } = useGarminActivityWeatherHourlyQuery({
+    variables: { activity_id: activityId ?? '' },
+    skip: !activityId,
+  })
   // Resolve map clicks against the *full-resolution* track series (not the
   // downsampled chart series) so the selected point is the true nearest
   // location, then convert it into the chart/display shape using the same
@@ -803,6 +808,7 @@ export function GarminDetailPage() {
             weather={weatherData?.garminActivityWeather}
             loading={weatherLoading}
             error={weatherError?.message}
+            hourly={weatherHourlyData?.garminActivityWeatherHourly}
           />
         </TabsContent>
 


### PR DESCRIPTION
## Summary

Phase 5 (final) of the hourly weather feature:
- Phase 1: [homelab-database-migrations#62](https://github.com/stuartshay/homelab-database-migrations/pull/62)
- Phase 2: [otel-agents#158](https://github.com/stuartshay/otel-agents/pull/158)
- Phase 3: [otel-data-api#221](https://github.com/stuartshay/otel-data-api/pull/221)
- Phase 4: [otel-data-gateway#198](https://github.com/stuartshay/otel-data-gateway/pull/198)

`WeatherPanel` currently shows a single "conditions at the start" snapshot for the whole activity — accurate for a 20-minute activity, misleading for a 3-hour ride that starts in Central Park and ends in New Jersey. This adds a `WeatherHourlyBreakdown` shown inside the same card for multi-hour activities:

- Temperature range across the activity (e.g. "50°F – 77°F")
- A horizontal strip of per-hour readings (relative hour label, condition icon, temperature) — each hour sampled at the GPS location the athlete was actually at, not the start point repeated
- Flags hours still sourced from the provisional forecast API (pending ERA5 archive settlement)
- Renders nothing for single-hour activities — the existing summary card already fully represents those, so there's no redundant UI

Also moved `fmtTemp` and `WEATHER_ICONS` out of `WeatherPanel.tsx` into `WeatherPanel.helpers.ts` so both components can share them without a circular import between the two files.

## Test plan
- [x] `npx vitest run` — 451 passed (full suite), including new `WeatherHourlyBreakdown` tests, `temperatureRangeF` helper tests, and `WeatherPanel`/`GarminDetailPage` integration coverage
- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` / `format:check` / `lint:spell` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)