### PR TITLE
test: complete activity totals chart presentation coverage

### DIFF
--- a/src/components/dashboard/GarminActivityTotals.test.tsx
+++ b/src/components/dashboard/GarminActivityTotals.test.tsx
@@ -1,11 +1,51 @@
 import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { format, subDays } from 'date-fns'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest'
 
 // Freeze the system clock so weekly-mode tests that derive labels and query
 // variables from `new Date()` are deterministic regardless of when CI runs.
 const FROZEN_NOW = new Date('2026-04-15T12:00:00Z')
+
+const pointerCaptureMethodNames = [
+  'hasPointerCapture',
+  'releasePointerCapture',
+  'setPointerCapture',
+] as const
+const pointerCaptureDescriptors = Object.fromEntries(
+  pointerCaptureMethodNames.map((name) => [
+    name,
+    Object.getOwnPropertyDescriptor(HTMLElement.prototype, name),
+  ]),
+)
+
+beforeAll(() => {
+  Object.defineProperties(HTMLElement.prototype, {
+    hasPointerCapture: { configurable: true, value: vi.fn(() => false) },
+    releasePointerCapture: { configurable: true, value: vi.fn() },
+    setPointerCapture: { configurable: true, value: vi.fn() },
+  })
+})
+
+afterAll(() => {
+  for (const name of pointerCaptureMethodNames) {
+    const descriptor = pointerCaptureDescriptors[name]
+    if (descriptor) {
+      Object.defineProperty(HTMLElement.prototype, name, descriptor)
+    } else {
+      Reflect.deleteProperty(HTMLElement.prototype, name)
+    }
+  }
+})
 
 let latestBarChartData: Array<Record<string, unknown>> = []
 
@@ -42,8 +82,43 @@ vi.mock('recharts', () => ({
   },
   CartesianGrid: () => null,
   XAxis: () => null,
-  YAxis: () => null,
-  Tooltip: () => null,
+  YAxis: ({ tickFormatter }: { tickFormatter?: (value: number) => string }) => (
+    <div data-testid="activity-totals-axis-value">
+      {tickFormatter?.(12.345)}
+    </div>
+  ),
+  Tooltip: ({
+    formatter,
+    labelFormatter,
+  }: {
+    formatter?: (value: number | string) => [string, string]
+    labelFormatter?: (
+      label: string,
+      payload?: Array<{ payload?: { activity_count?: number } }>,
+    ) => string
+  }) => {
+    const numericValue = formatter?.(12.345)
+    const stringValue = formatter?.('6.789')
+    return (
+      <div>
+        <div data-testid="activity-totals-tooltip-number">
+          {numericValue?.join(' ')}
+        </div>
+        <div data-testid="activity-totals-tooltip-string">
+          {stringValue?.join(' ')}
+        </div>
+        <div data-testid="activity-totals-tooltip-singular">
+          {labelFormatter?.('2025', [{ payload: { activity_count: 1 } }])}
+        </div>
+        <div data-testid="activity-totals-tooltip-plural">
+          {labelFormatter?.('2026', [{ payload: { activity_count: 2 } }])}
+        </div>
+        <div data-testid="activity-totals-tooltip-empty">
+          {labelFormatter?.('2024')}
+        </div>
+      </div>
+    )
+  },
   Bar: () => null,
 }))
 
@@ -295,6 +370,92 @@ describe('GarminActivityTotals', () => {
         }),
       ]),
     )
+  })
+
+  it('updates the visible month and full-history query range', async () => {
+    const user = userEvent.setup()
+    hooks.useGarminActivityTotalsQuery.mockReturnValue({
+      data: {
+        garminActivityTotals: [
+          {
+            period_start: '2026-01-01',
+            activity_count: 1,
+            total_distance_km: 10,
+            total_duration_seconds: 3600,
+            total_ascent_m: 100,
+            total_calories: 500,
+          },
+        ],
+      },
+      loading: false,
+      error: undefined,
+      refetch: vi.fn(),
+    })
+
+    render(<GarminActivityTotals />)
+
+    await user.click(screen.getByRole('combobox', { name: /select month/i }))
+    await user.click(screen.getByRole('option', { name: 'Jan' }))
+
+    expect(screen.getByText(/January by year/i)).toBeInTheDocument()
+    const lastCall = hooks.useGarminActivityTotalsQuery.mock.calls.at(-1)?.[0]
+    expect(lastCall?.variables).toEqual(
+      expect.objectContaining({
+        date_from: '2010-01-01',
+        date_to: '2026-01-31',
+      }),
+    )
+  })
+
+  it('formats chart values and activity counts for the selected metric', async () => {
+    const user = userEvent.setup()
+    hooks.useGarminActivityTotalsQuery.mockReturnValue({
+      data: {
+        garminActivityTotals: [
+          {
+            period_start: '2026-04-01',
+            activity_count: 2,
+            total_distance_km: 12.345,
+            total_duration_seconds: 3600,
+            total_ascent_m: 100,
+            total_calories: 500,
+          },
+        ],
+      },
+      loading: false,
+      error: undefined,
+      refetch: vi.fn(),
+    })
+
+    render(<GarminActivityTotals />)
+
+    expect(screen.getByTestId('activity-totals-axis-value')).toHaveTextContent(
+      '12.3',
+    )
+    expect(
+      screen.getByTestId('activity-totals-tooltip-number'),
+    ).toHaveTextContent('12.3 km Distance')
+    expect(
+      screen.getByTestId('activity-totals-tooltip-string'),
+    ).toHaveTextContent('6.8 km Distance')
+    expect(
+      screen.getByTestId('activity-totals-tooltip-singular'),
+    ).toHaveTextContent('2025 — 1 activity')
+    expect(
+      screen.getByTestId('activity-totals-tooltip-plural'),
+    ).toHaveTextContent('2026 — 2 activities')
+    expect(
+      screen.getByTestId('activity-totals-tooltip-empty'),
+    ).toHaveTextContent('2024 — 0 activities')
+
+    await user.click(screen.getByRole('radio', { name: 'Calories' }))
+
+    expect(screen.getByTestId('activity-totals-axis-value')).toHaveTextContent(
+      '12',
+    )
+    expect(
+      screen.getByTestId('activity-totals-tooltip-number'),
+    ).toHaveTextContent('12 kcal Calories')
   })
 
   it('omits empty years before the earliest returned activity bucket', () => {


### PR DESCRIPTION
## Summary

Refs #438

Complete behavior-focused unit coverage for Activity Totals chart presentation without changing production code.

- select January through the accessible month control and assert the visible heading plus full-history query dates;
- render Recharts formatter seams and assert distance/calorie precision and units;
- verify tooltip labels distinguish one, multiple, and missing activity counts;
- raise `GarminActivityTotals.tsx` function coverage to 100% and improve all aggregate metrics.

## Type of Change

- [x] UI enhancement (non-breaking)

## Coverage

| Metric | Before | After | Delta |
| --- | ---: | ---: | ---: |
| Statements | 95.80% (2605/2719) | 96.06% (2612/2719) | +0.26 pp |
| Branches | 89.87% (2148/2390) | 90.16% (2155/2390) | +0.29 pp |
| Functions | 97.41% (753/773) | 97.93% (757/773) | +0.52 pp |
| Lines | 97.52% (2362/2422) | 97.81% (2369/2422) | +0.29 pp |

Target `GarminActivityTotals.tsx`: 91.30% statements (168/184), 76.22% branches (93/122), 100% functions (49/49), and 93.45% lines (157/168).

## Checklist

- [x] Read `README.md` and relevant docs
- [x] No secrets or credentials committed
- [x] Environment variables use `VITE_` prefix (N/A; no runtime changes)
- [x] Ran `npm run lint:all` locally
- [x] Ran `npm run test:run` (442 tests passing)
- [x] Ran `npm run type-check` (no type errors)
- [x] Ran `npm run build`
- [x] Ran authoritative `npm run test:coverage -- --coverage.reporter=text --coverage.reporter=json-summary --coverage.reporter=lcov`
- [x] Sonar CE task `6292e89d-dd62-4359-9ed4-a38e295db1df` succeeded and quality gate is OK (90.8% new coverage, 0.0% duplication, 0 new violations)

## Deployment

- [x] This needs the normal generated k8s-gitops version PR after merge so the exact reviewed image can be validated in production.

## Testing

```bash
npm run test:run -- src/components/dashboard/GarminActivityTotals.test.tsx
npm run lint:all
npm run type-check
npm run build
npm run test:run
npm run test:coverage -- --coverage.reporter=text --coverage.reporter=json-summary --coverage.reporter=lcov
npx sonar ... -Dsonar.javascript.lcov.reportPaths=coverage/lcov.info
```

The committed `e2e/dashboard-activity-totals.spec.ts` month-selection and metric-toggle scenarios are the production acceptance tests for this batch.

## Post-Merge Validation

- [ ] Docker image built and pushed
- [ ] Exact generated k8s-gitops deployment PR reviewed and merged
- [ ] Argo CD synced and healthy on the GitOps merge revision
- [ ] Committed Activity Totals Playwright scenarios passed against production
- [ ] Final validation evidence posted and issue #438 closed manually

## Notes

No production source, coverage configuration, threshold, exclusion, or public contract changed. The next high-value coherent candidate is Activity Totals weekly error and retry behavior (`GarminActivityTotals.tsx` lines 561-567 and 599-603), followed by `ActivityLapsTable.tsx` with 15 uncovered branches.