### PR TITLE
test: complete Activity Totals weekly error and retry coverage

### DIFF
--- a/src/components/dashboard/GarminActivityTotals.test.tsx
+++ b/src/components/dashboard/GarminActivityTotals.test.tsx
@@ -726,11 +726,11 @@ describe('GarminActivityTotals', () => {
     expect(refetch).not.toHaveBeenCalled()
     expect(apolloMocks.query.mock.calls.slice(failedAttemptCallCount)).toEqual(
       expect.arrayContaining([
-        [
+        expect.arrayContaining([
           expect.objectContaining({
             variables: expect.objectContaining({ period: 'week' }),
           }),
-        ],
+        ]),
       ]),
     )
   })

--- a/src/components/dashboard/GarminActivityTotals.test.tsx
+++ b/src/components/dashboard/GarminActivityTotals.test.tsx
@@ -695,6 +695,65 @@ describe('GarminActivityTotals', () => {
     )
   })
 
+  it('weekly mode renders query errors and retries the weekly requests', async () => {
+    const refetch = vi.fn()
+    hooks.useGarminActivityTotalsQuery.mockReturnValue({
+      data: undefined,
+      loading: false,
+      error: undefined,
+      refetch,
+    })
+    apolloMocks.query.mockRejectedValueOnce(new Error('weekly totals failed'))
+
+    const user = userEvent.setup()
+    render(<GarminActivityTotals />)
+
+    await user.click(screen.getByRole('radio', { name: 'Weekly' }))
+
+    expect(await screen.findByText('weekly totals failed')).toBeInTheDocument()
+    const failedAttemptCallCount = apolloMocks.query.mock.calls.length
+
+    await user.click(screen.getByRole('button', { name: /retry/i }))
+
+    await waitFor(() => {
+      expect(apolloMocks.query.mock.calls.length).toBeGreaterThan(
+        failedAttemptCallCount,
+      )
+    })
+    await waitFor(() => {
+      expect(screen.queryByText('weekly totals failed')).not.toBeInTheDocument()
+    })
+    expect(refetch).not.toHaveBeenCalled()
+    expect(apolloMocks.query.mock.calls.slice(failedAttemptCallCount)).toEqual(
+      expect.arrayContaining([
+        [
+          expect.objectContaining({
+            variables: expect.objectContaining({ period: 'week' }),
+          }),
+        ],
+      ]),
+    )
+  })
+
+  it('weekly mode renders a safe message for non-error rejections', async () => {
+    hooks.useGarminActivityTotalsQuery.mockReturnValue({
+      data: undefined,
+      loading: false,
+      error: undefined,
+      refetch: vi.fn(),
+    })
+    apolloMocks.query.mockRejectedValueOnce('gateway unavailable')
+
+    const user = userEvent.setup()
+    render(<GarminActivityTotals />)
+
+    await user.click(screen.getByRole('radio', { name: 'Weekly' }))
+
+    expect(
+      await screen.findByText('Failed to load weekly totals'),
+    ).toBeInTheDocument()
+  })
+
   it('weekly mode pages backward and forward by 7 days', async () => {
     hooks.useGarminActivityTotalsQuery.mockReturnValue({
       data: undefined,


### PR DESCRIPTION
## Summary

Refs #441

Complete behavior-focused unit coverage for Activity Totals weekly-query reliability without changing production code.

- surface the original `Error` message when a per-year weekly query fails;
- retry through the visible Retry control and verify fresh weekly requests run;
- verify weekly Retry never invokes the skipped main-query refetch;
- render the safe fallback message for a non-`Error` rejection.

## Type of Change

- [x] UI enhancement (non-breaking, test-only behavior coverage)

## Coverage

| Metric | Before | After | Delta |
| --- | ---: | ---: | ---: |
| Statements | 96.06% (2612/2719) | 96.21% (2616/2719) | +0.15 pp |
| Branches | 90.16% (2155/2390) | 90.33% (2159/2390) | +0.17 pp |
| Functions | 97.93% (757/773) | 97.93% (757/773) | +0.00 pp |
| Lines | 97.81% (2369/2422) | 97.97% (2373/2422) | +0.16 pp |

Target `GarminActivityTotals.tsx`: 93.47% statements (172/184), 79.50% branches (97/122), 100% functions (49/49), and 95.83% lines (161/168).

## Checklist

- [x] Read `README.md` and relevant docs
- [x] No secrets or credentials committed
- [x] Environment variables use `VITE_` prefix (N/A; no runtime changes)
- [x] Ran `npm run lint:all` locally
- [x] Ran `npm run test:run` (444 tests passing)
- [x] Ran `npm run type-check` (no type errors)
- [x] Ran `npm run build`
- [x] Ran authoritative `npm run test:coverage -- --coverage.reporter=text --coverage.reporter=json-summary --coverage.reporter=lcov`
- [x] Sonar CE task `aee85c1b-78db-4895-8ac2-13d4cf0ecab6` succeeded and quality gate is OK (91.5% new coverage, 0.0% duplication, 0 new violations)

## Deployment

- [x] This needs the normal generated k8s-gitops version PR after merge so the exact reviewed image can be validated in production.

## Testing

```bash
npm run test:run -- src/components/dashboard/GarminActivityTotals.test.tsx
npm run lint:all
npm run type-check
npm run build
npm run test:run
npm run test:coverage -- --coverage.reporter=text --coverage.reporter=json-summary --coverage.reporter=lcov
npx sonar ... -Dsonar.javascript.lcov.reportPaths=coverage/lcov.info
```

The committed `e2e/dashboard-activity-totals.spec.ts` scenarios are the closest production acceptance for this test-only batch. They validate the deployed Activity Totals controls and data-bearing interactions but cannot safely induce a production backend failure, so they are representative rather than direct error-path coverage.

## Post-Merge Validation

- [ ] Docker image built and pushed
- [ ] Exact generated k8s-gitops deployment PR reviewed and merged
- [ ] Argo CD synced and healthy on the GitOps merge revision
- [ ] Closest committed Activity Totals Playwright scenarios passed against production
- [ ] Final validation evidence posted and issue #441 closed manually

## Notes

No production source, coverage configuration, threshold, exclusion, or public contract changed. The next high-value coherent candidate is `ActivityLapsTable.tsx`, currently at 76.19% branch coverage with 15 uncovered branches.