### PR TITLE
feat(garmin): add segment elevation profile

### DIFF
--- a/e2e/garmin-segment-route-map.spec.ts
+++ b/e2e/garmin-segment-route-map.spec.ts
@@ -4,6 +4,7 @@ test.describe('Garmin segment route map', () => {
   test('renders the source activity points for the saved segment route', async ({
     page,
   }) => {
+    await page.emulateMedia({ colorScheme: 'dark' })
     const chartDataResponse = page.waitForResponse(async (response) => {
       if (response.request().method() !== 'POST') return false
 
@@ -12,6 +13,7 @@ test.describe('Garmin segment route map', () => {
     })
 
     await page.goto('/garmin/segments/6')
+    await expect(page.locator('html')).toHaveClass(/dark/)
     await expect(
       page.getByRole('heading', { name: 'Central Park 2' }),
     ).toBeVisible({ timeout: 15_000 })
@@ -38,5 +40,17 @@ test.describe('Garmin segment route map', () => {
       ),
     )
     expect(strokeColors.length).toBeGreaterThan(1)
+
+    const elevationProfile = page.getByTestId('segment-elevation-profile')
+    await expect(elevationProfile).toBeVisible()
+    await expect(
+      elevationProfile.getByRole('heading', { name: 'Elevation' }),
+    ).toBeVisible()
+    await expect(
+      elevationProfile.getByRole('img', {
+        name: /elevation profile from .* at the segment start/i,
+      }),
+    ).toBeVisible()
+    await expect(elevationProfile.getByText('Start to finish')).toBeVisible()
   })
 })

--- a/src/components/garmin/SegmentElevationProfile.helpers.ts
+++ b/src/components/garmin/SegmentElevationProfile.helpers.ts
@@ -1,0 +1,66 @@
+import type { ActivityChartTrackPoint } from '@/components/garmin/ActivityChartData'
+import { kmToMi, metersToFeet } from '@/lib/units'
+
+interface SegmentElevationChartPoint {
+  distanceMiles: number
+  elevationFeet: number
+}
+
+export interface SegmentElevationProfileData {
+  points: SegmentElevationChartPoint[]
+  startElevationFeet: number
+  finishElevationFeet: number
+  elevationGainFeet: number
+  distanceMiles: number
+  yDomain: [number, number]
+}
+
+function isFiniteNumber(value: number | null | undefined): value is number {
+  return typeof value === 'number' && Number.isFinite(value)
+}
+
+export function buildSegmentElevationProfile(
+  routePoints: readonly ActivityChartTrackPoint[],
+): SegmentElevationProfileData | null {
+  const usable = routePoints.filter(
+    (point) =>
+      isFiniteNumber(point.distance_from_start_km) &&
+      isFiniteNumber(point.altitude),
+  )
+  if (usable.length < 2) return null
+
+  const startDistanceKm = usable[0].distance_from_start_km as number
+  const points = usable.map((point) => ({
+    distanceMiles: kmToMi(
+      Math.max(0, (point.distance_from_start_km as number) - startDistanceKm),
+    ),
+    elevationFeet: metersToFeet(point.altitude as number),
+  }))
+  const lastPoint = points[points.length - 1]
+  const distanceMiles = lastPoint.distanceMiles
+  if (distanceMiles <= 0) return null
+
+  let elevationGainMeters = 0
+  for (let index = 1; index < usable.length; index++) {
+    const previousAltitude = usable[index - 1].altitude as number
+    const altitude = usable[index].altitude as number
+    elevationGainMeters += Math.max(0, altitude - previousAltitude)
+  }
+
+  const elevations = points.map((point) => point.elevationFeet)
+  const minElevation = Math.min(...elevations)
+  const maxElevation = Math.max(...elevations)
+  const padding = Math.max(10, (maxElevation - minElevation) * 0.15)
+
+  return {
+    points,
+    startElevationFeet: points[0].elevationFeet,
+    finishElevationFeet: lastPoint.elevationFeet,
+    elevationGainFeet: metersToFeet(elevationGainMeters),
+    distanceMiles,
+    yDomain: [
+      Math.floor(minElevation - padding),
+      Math.ceil(maxElevation + padding),
+    ],
+  }
+}

--- a/src/components/garmin/SegmentElevationProfile.helpers.ts
+++ b/src/components/garmin/SegmentElevationProfile.helpers.ts
@@ -47,9 +47,13 @@ export function buildSegmentElevationProfile(
     elevationGainMeters += Math.max(0, altitude - previousAltitude)
   }
 
-  const elevations = points.map((point) => point.elevationFeet)
-  const minElevation = Math.min(...elevations)
-  const maxElevation = Math.max(...elevations)
+  let minElevation = points[0].elevationFeet
+  let maxElevation = minElevation
+  for (let index = 1; index < points.length; index++) {
+    const elevation = points[index].elevationFeet
+    minElevation = Math.min(minElevation, elevation)
+    maxElevation = Math.max(maxElevation, elevation)
+  }
   const padding = Math.max(10, (maxElevation - minElevation) * 0.15)
 
   return {

--- a/src/components/garmin/SegmentElevationProfile.test.tsx
+++ b/src/components/garmin/SegmentElevationProfile.test.tsx
@@ -95,6 +95,21 @@ describe('buildSegmentElevationProfile', () => {
       ]),
     ).toBeNull()
   })
+
+  it('calculates the elevation domain for a large route without spreading point data', () => {
+    const largeRoute = Array.from({ length: 150_000 }, (_, index) => ({
+      timestamp: '2026-07-18T12:00:00Z',
+      distance_from_start_km: index / 1_000,
+      altitude: 10 + (index % 20),
+    }))
+
+    const profile = buildSegmentElevationProfile(largeRoute)
+
+    expect(profile?.points).toHaveLength(150_000)
+    expect(profile?.startElevationFeet).toBeCloseTo(32.81, 2)
+    expect(profile?.finishElevationFeet).toBeCloseTo(95.14, 2)
+    expect(profile?.yDomain).toEqual([22, 106])
+  })
 })
 
 describe('SegmentElevationProfile', () => {

--- a/src/components/garmin/SegmentElevationProfile.test.tsx
+++ b/src/components/garmin/SegmentElevationProfile.test.tsx
@@ -1,0 +1,142 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import { SegmentElevationProfile } from './SegmentElevationProfile'
+import { buildSegmentElevationProfile } from './SegmentElevationProfile.helpers'
+
+vi.mock('recharts', () => ({
+  ResponsiveContainer: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="responsive-chart">{children}</div>
+  ),
+  AreaChart: ({
+    children,
+    data,
+  }: {
+    children: React.ReactNode
+    data: unknown[]
+  }) => (
+    <div data-testid="elevation-area-chart" data-point-count={data.length}>
+      {children}
+    </div>
+  ),
+  Area: () => null,
+  CartesianGrid: () => null,
+  Tooltip: ({
+    formatter,
+    labelFormatter,
+  }: {
+    formatter: (value: number) => [string, string]
+    labelFormatter: (value: number) => string
+  }) => (
+    <div data-testid="elevation-tooltip-formatters">
+      {formatter(100)[0]} at {labelFormatter(0.12)}
+    </div>
+  ),
+  XAxis: ({ tickFormatter }: { tickFormatter: (value: number) => string }) => (
+    <div data-testid="elevation-x-tick">{tickFormatter(0.12)}</div>
+  ),
+  YAxis: ({ tickFormatter }: { tickFormatter: (value: number) => string }) => (
+    <div data-testid="elevation-y-tick">{tickFormatter(100.4)}</div>
+  ),
+}))
+
+const routePoints = [
+  {
+    timestamp: '2026-07-18T12:00:00Z',
+    distance_from_start_km: 10,
+    altitude: 10,
+  },
+  {
+    timestamp: '2026-07-18T12:00:30Z',
+    distance_from_start_km: 10.1,
+    altitude: 12,
+  },
+  {
+    timestamp: '2026-07-18T12:01:00Z',
+    distance_from_start_km: 10.2,
+    altitude: 11,
+  },
+]
+
+describe('buildSegmentElevationProfile', () => {
+  it('normalizes distance and calculates start, finish, and cumulative gain', () => {
+    const profile = buildSegmentElevationProfile(routePoints)
+
+    expect(profile).not.toBeNull()
+    expect(profile?.points[0].distanceMiles).toBe(0)
+    expect(profile?.distanceMiles).toBeCloseTo(0.124, 3)
+    expect(profile?.startElevationFeet).toBeCloseTo(32.81, 2)
+    expect(profile?.finishElevationFeet).toBeCloseTo(36.09, 2)
+    expect(profile?.elevationGainFeet).toBeCloseTo(6.56, 2)
+  })
+
+  it('returns null without at least two valid distance and altitude readings', () => {
+    expect(
+      buildSegmentElevationProfile([
+        { timestamp: '2026-07-18T12:00:00Z', altitude: 10 },
+        {
+          timestamp: '2026-07-18T12:01:00Z',
+          distance_from_start_km: 1,
+          altitude: null,
+        },
+      ]),
+    ).toBeNull()
+    expect(
+      buildSegmentElevationProfile([
+        {
+          timestamp: '2026-07-18T12:00:00Z',
+          distance_from_start_km: 1,
+          altitude: 10,
+        },
+        {
+          timestamp: '2026-07-18T12:01:00Z',
+          distance_from_start_km: 1,
+          altitude: 12,
+        },
+      ]),
+    ).toBeNull()
+  })
+})
+
+describe('SegmentElevationProfile', () => {
+  it('renders a loading state while source track data is being fetched', () => {
+    render(<SegmentElevationProfile routePoints={[]} loading />)
+
+    expect(screen.getByRole('status')).toHaveTextContent(
+      'Loading elevation profile...',
+    )
+  })
+
+  it('renders the profile, summary statistics, and accessible description', () => {
+    render(<SegmentElevationProfile routePoints={routePoints} />)
+
+    expect(screen.getByRole('heading', { name: 'Elevation' })).toBeVisible()
+    expect(screen.getByText('Start to finish')).toBeVisible()
+    expect(screen.getByText('33 ft')).toBeVisible()
+    expect(screen.getByText('36 ft')).toBeVisible()
+    expect(screen.getByText('7 ft')).toBeVisible()
+    expect(screen.getByTestId('elevation-area-chart')).toHaveAttribute(
+      'data-point-count',
+      '3',
+    )
+    expect(screen.getByTestId('elevation-x-tick')).toHaveTextContent('0.12')
+    expect(screen.getByTestId('elevation-y-tick')).toHaveTextContent('100')
+    expect(
+      screen.getByTestId('elevation-tooltip-formatters'),
+    ).toHaveTextContent('100 ft at 0.12 mi')
+    expect(
+      screen.getByRole('img', { name: /elevation profile from 33 ft/i }),
+    ).toBeVisible()
+  })
+
+  it('renders a clear fallback when elevation data is unavailable', () => {
+    render(
+      <SegmentElevationProfile
+        routePoints={[{ timestamp: '2026-07-18T12:00:00Z' }]}
+      />,
+    )
+
+    expect(
+      screen.getByText('Elevation profile unavailable for this segment.'),
+    ).toBeVisible()
+  })
+})

--- a/src/components/garmin/SegmentElevationProfile.tsx
+++ b/src/components/garmin/SegmentElevationProfile.tsx
@@ -1,0 +1,149 @@
+import {
+  Area,
+  AreaChart,
+  CartesianGrid,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts'
+import type { ActivityChartTrackPoint } from '@/components/garmin/ActivityChartData'
+import { buildSegmentElevationProfile } from './SegmentElevationProfile.helpers'
+
+function formatFeet(value: number): string {
+  return `${Math.round(value).toLocaleString()} ft`
+}
+
+function ElevationStat({
+  label,
+  value,
+}: Readonly<{ label: string; value: string }>) {
+  return (
+    <div>
+      <dt className="text-[11px] text-muted-foreground uppercase tracking-wide">
+        {label}
+      </dt>
+      <dd className="mt-0.5 text-sm font-medium tabular-nums">{value}</dd>
+    </div>
+  )
+}
+
+export function SegmentElevationProfile({
+  routePoints,
+  loading = false,
+}: Readonly<{
+  routePoints: readonly ActivityChartTrackPoint[]
+  loading?: boolean
+}>) {
+  if (loading) {
+    return (
+      <div
+        role="status"
+        className="rounded-md border px-4 py-5 text-sm text-muted-foreground"
+      >
+        Loading elevation profile...
+      </div>
+    )
+  }
+
+  const profile = buildSegmentElevationProfile(routePoints)
+
+  if (!profile) {
+    return (
+      <div
+        data-testid="segment-elevation-profile-empty"
+        className="rounded-md border border-dashed px-4 py-5 text-sm text-muted-foreground"
+      >
+        Elevation profile unavailable for this segment.
+      </div>
+    )
+  }
+
+  const accessibleSummary = `Elevation profile from ${formatFeet(profile.startElevationFeet)} at the segment start to ${formatFeet(profile.finishElevationFeet)} at the finish, with ${formatFeet(profile.elevationGainFeet)} of elevation gain over ${profile.distanceMiles.toFixed(2)} miles.`
+
+  return (
+    <section
+      data-testid="segment-elevation-profile"
+      className="rounded-md border bg-muted/20 p-4"
+      aria-labelledby="segment-elevation-heading"
+    >
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <h3 id="segment-elevation-heading" className="text-sm font-semibold">
+            Elevation
+          </h3>
+          <p className="text-xs text-muted-foreground">Start to finish</p>
+        </div>
+        <dl className="grid grid-cols-3 gap-x-5">
+          <ElevationStat
+            label="Start"
+            value={formatFeet(profile.startElevationFeet)}
+          />
+          <ElevationStat
+            label="Finish"
+            value={formatFeet(profile.finishElevationFeet)}
+          />
+          <ElevationStat
+            label="Gain"
+            value={formatFeet(profile.elevationGainFeet)}
+          />
+        </dl>
+      </div>
+
+      <div
+        role="img"
+        aria-label={accessibleSummary}
+        className="mt-3 h-44 w-full"
+      >
+        <ResponsiveContainer width="100%" height="100%">
+          <AreaChart
+            data={profile.points}
+            margin={{ top: 8, right: 8, bottom: 4, left: 0 }}
+          >
+            <defs>
+              <linearGradient
+                id="segmentElevationFill"
+                x1="0"
+                y1="0"
+                x2="0"
+                y2="1"
+              >
+                <stop offset="5%" stopColor="#22c55e" stopOpacity={0.7} />
+                <stop offset="95%" stopColor="#22c55e" stopOpacity={0.08} />
+              </linearGradient>
+            </defs>
+            <CartesianGrid strokeDasharray="3 3" className="stroke-muted" />
+            <XAxis
+              dataKey="distanceMiles"
+              type="number"
+              domain={[0, profile.distanceMiles]}
+              tickFormatter={(value: number) => value.toFixed(2)}
+              label={{ value: 'Distance (mi)', position: 'insideBottomRight' }}
+              className="text-xs"
+            />
+            <YAxis
+              domain={profile.yDomain}
+              tickFormatter={(value: number) => Math.round(value).toString()}
+              width={46}
+              unit=" ft"
+              className="text-xs"
+            />
+            <Tooltip
+              formatter={(value) => [formatFeet(Number(value)), 'Elevation']}
+              labelFormatter={(value) => `${Number(value).toFixed(2)} mi`}
+            />
+            <Area
+              type="monotone"
+              dataKey="elevationFeet"
+              stroke="#16a34a"
+              strokeWidth={2}
+              fill="url(#segmentElevationFill)"
+              dot={false}
+              activeDot={{ r: 4 }}
+            />
+          </AreaChart>
+        </ResponsiveContainer>
+      </div>
+    </section>
+  )
+}

--- a/src/pages/GarminSegmentDetailPage.test.tsx
+++ b/src/pages/GarminSegmentDetailPage.test.tsx
@@ -18,6 +18,17 @@ vi.mock('@/components/garmin/SegmentStartEndMap', () => ({
     <div data-testid="segment-map">map points: {routePoints.length}</div>
   ),
 }))
+vi.mock('@/components/garmin/SegmentElevationProfile', () => ({
+  SegmentElevationProfile: ({
+    routePoints = [],
+  }: {
+    routePoints?: unknown[]
+  }) => (
+    <div data-testid="segment-elevation-profile">
+      elevation points: {routePoints.length}
+    </div>
+  ),
+}))
 vi.mock('@/components/garmin/DeleteSegmentButton', () => ({
   DeleteSegmentButton: ({ onDeleted }: { onDeleted: () => void }) => (
     <button data-testid="delete-segment-trigger" onClick={onDeleted}>
@@ -136,21 +147,29 @@ describe('GarminSegmentDetailPage', () => {
             latitude: 40.78,
             longitude: -73.95,
             timestamp: '2025-07-04T11:59:00Z',
+            distance_from_start_km: 0,
+            altitude: 4,
           },
           {
             latitude: 40.79,
             longitude: -73.96,
             timestamp: '2025-07-04T12:00:00Z',
+            distance_from_start_km: 0.1,
+            altitude: 5,
           },
           {
             latitude: 40.795,
             longitude: -73.965,
             timestamp: '2025-07-04T12:00:30Z',
+            distance_from_start_km: 0.35,
+            altitude: 10,
           },
           {
             latitude: 40.8,
             longitude: -73.97,
             timestamp: '2025-07-04T12:01:00Z',
+            distance_from_start_km: 0.6,
+            altitude: 8,
           },
         ],
       },
@@ -163,6 +182,9 @@ describe('GarminSegmentDetailPage', () => {
     expect(screen.getByRole('heading', { name: 'Harlem Hill' })).toBeVisible()
     expect(screen.getByText('2 matching efforts')).toBeVisible()
     expect(screen.getByTestId('segment-map')).toHaveTextContent('map points: 3')
+    expect(screen.getByTestId('segment-elevation-profile')).toHaveTextContent(
+      'elevation points: 3',
+    )
     expect(screen.getAllByTestId('segment-effort-row')).toHaveLength(2)
     // Exactly one PR badge, on the fastest effort.
     expect(screen.getAllByTestId('segment-effort-pr')).toHaveLength(1)

--- a/src/pages/GarminSegmentDetailPage.tsx
+++ b/src/pages/GarminSegmentDetailPage.tsx
@@ -12,6 +12,7 @@ import { EmptyState } from '@/components/shared/EmptyState'
 import { Badge } from '@/components/ui/badge'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { SegmentStartEndMap } from '@/components/garmin/SegmentStartEndMap'
+import { SegmentElevationProfile } from '@/components/garmin/SegmentElevationProfile'
 import { SegmentEffortsLeaderboard } from '@/components/garmin/SegmentEffortsLeaderboard'
 import { DeleteSegmentButton } from '@/components/garmin/DeleteSegmentButton'
 import {
@@ -56,11 +57,12 @@ export function GarminSegmentDetailPage() {
 
   const segment = segmentData?.garminSegment
 
-  const { data: sourceTrackData } = useGarminChartDataQuery({
-    variables: { activity_id: segment?.source_activity_id ?? '' },
-    skip: !segment?.source_activity_id,
-    fetchPolicy: 'no-cache',
-  })
+  const { data: sourceTrackData, loading: sourceTrackLoading } =
+    useGarminChartDataQuery({
+      variables: { activity_id: segment?.source_activity_id ?? '' },
+      skip: !segment?.source_activity_id,
+      fetchPolicy: 'no-cache',
+    })
 
   const efforts = (effortsData?.garminSegmentEfforts?.items ??
     []) as SegmentEffort[]
@@ -181,6 +183,10 @@ export function GarminSegmentDetailPage() {
               endLat={segment.end_latitude}
               endLon={segment.end_longitude}
               routePoints={routePoints}
+            />
+            <SegmentElevationProfile
+              routePoints={routePoints}
+              loading={sourceTrackLoading}
             />
             <dl className="grid grid-cols-2 gap-x-4 gap-y-1 text-sm">
               <dt className="text-muted-foreground">Distance</dt>


### PR DESCRIPTION
## Summary

- add a responsive elevation profile beneath the segment route map
- normalize chart distance from the segment start and display start elevation, finish elevation, and total gain in feet
- cover loading, missing-data, accessibility, and light/dark theme behavior

## Why

The segment detail page currently shows the route geometry but not how elevation changes from the start to the finish. The new profile makes the climbing shape visible at a glance, similar to the elevation view on a Garmin device, while reusing the chart data already returned for the segment source activity.

## Impact

This is a UI-only change. It does not alter API contracts or persisted data. If usable altitude samples are unavailable, the page shows a clear fallback instead of an empty chart.

## Validation

- `npm run lint:all`
- `npm run type-check`
- `npm run build`
- `npm run test:coverage` - 449 tests passed
- focused elevation-profile coverage - 100% statements, branches, functions, and lines
- production-style Playwright segment route-map test in dark theme - passed

Refs #443
