### PR TITLE
feat(garmin): sync segment elevation hover with map

### DIFF
--- a/e2e/garmin-segment-route-map.spec.ts
+++ b/e2e/garmin-segment-route-map.spec.ts
@@ -52,5 +52,26 @@ test.describe('Garmin segment route map', () => {
       }),
     ).toBeVisible()
     await expect(elevationProfile.getByText('Start to finish')).toBeVisible()
+
+    const elevationChart = elevationProfile.locator(
+      '.recharts-responsive-container',
+    )
+    const chartBox = await elevationChart.boundingBox()
+    if (!chartBox) throw new Error('Segment elevation chart unavailable')
+    await page.mouse.move(
+      chartBox.x + chartBox.width / 2,
+      chartBox.y + chartBox.height / 2,
+    )
+
+    const hoverMarker = map.locator(
+      '.leaflet-overlay-pane svg path.segment-hover-marker',
+    )
+    await expect(hoverMarker).toHaveCount(1, { timeout: 5_000 })
+    await expect(
+      elevationProfile.locator('.recharts-tooltip-cursor'),
+    ).toHaveCount(1, { timeout: 5_000 })
+
+    await page.mouse.move(0, 0)
+    await expect(hoverMarker).toHaveCount(0, { timeout: 5_000 })
   })
 })

--- a/src/components/garmin/SegmentElevationProfile.helpers.ts
+++ b/src/components/garmin/SegmentElevationProfile.helpers.ts
@@ -1,9 +1,11 @@
 import type { ActivityChartTrackPoint } from '@/components/garmin/ActivityChartData'
 import { kmToMi, metersToFeet } from '@/lib/units'
 
-interface SegmentElevationChartPoint {
+export interface SegmentElevationChartPoint {
   distanceMiles: number
   elevationFeet: number
+  latitude: number | null
+  longitude: number | null
 }
 
 export interface SegmentElevationProfileData {
@@ -35,6 +37,8 @@ export function buildSegmentElevationProfile(
       Math.max(0, (point.distance_from_start_km as number) - startDistanceKm),
     ),
     elevationFeet: metersToFeet(point.altitude as number),
+    latitude: isFiniteNumber(point.latitude) ? point.latitude : null,
+    longitude: isFiniteNumber(point.longitude) ? point.longitude : null,
   }))
   const lastPoint = points[points.length - 1]
   const distanceMiles = lastPoint.distanceMiles

--- a/src/components/garmin/SegmentElevationProfile.test.tsx
+++ b/src/components/garmin/SegmentElevationProfile.test.tsx
@@ -187,7 +187,7 @@ describe('SegmentElevationProfile', () => {
   it('emits the active profile point and clears it when the pointer leaves', async () => {
     const user = userEvent.setup()
     const onActivePointChange = vi.fn()
-    render(
+    const { rerender } = render(
       <SegmentElevationProfile
         routePoints={routePoints}
         onActivePointChange={onActivePointChange}
@@ -214,6 +214,12 @@ describe('SegmentElevationProfile', () => {
     )
     expect(onActivePointChange).toHaveBeenCalledTimes(1)
 
+    rerender(
+      <SegmentElevationProfile
+        routePoints={routePoints.map((point) => ({ ...point }))}
+        onActivePointChange={onActivePointChange}
+      />,
+    )
     await user.click(
       screen.getByRole('button', { name: 'Hover profile point' }),
     )
@@ -233,6 +239,11 @@ describe('SegmentElevationProfile', () => {
     await waitFor(() =>
       expect(onActivePointChange).toHaveBeenLastCalledWith(null),
     )
+    const callCountAfterLeave = onActivePointChange.mock.calls.length
+
+    await user.click(screen.getByRole('button', { name: 'Leave profile' }))
+    await new Promise((resolve) => window.requestAnimationFrame(resolve))
+    expect(onActivePointChange).toHaveBeenCalledTimes(callCountAfterLeave)
   })
 
   it('cancels a queued hover update when the profile unmounts', () => {

--- a/src/components/garmin/SegmentElevationProfile.test.tsx
+++ b/src/components/garmin/SegmentElevationProfile.test.tsx
@@ -1,4 +1,5 @@
-import { render, screen } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { describe, expect, it, vi } from 'vitest'
 import { SegmentElevationProfile } from './SegmentElevationProfile'
 import { buildSegmentElevationProfile } from './SegmentElevationProfile.helpers'
@@ -10,12 +11,28 @@ vi.mock('recharts', () => ({
   AreaChart: ({
     children,
     data,
+    onMouseMove,
+    onMouseLeave,
   }: {
     children: React.ReactNode
     data: unknown[]
+    onMouseMove?: (state: {
+      activeTooltipIndex?: number | string | null
+    }) => void
+    onMouseLeave?: () => void
   }) => (
     <div data-testid="elevation-area-chart" data-point-count={data.length}>
       {children}
+      <button onClick={() => onMouseMove?.({ activeTooltipIndex: '1' })}>
+        Hover profile point
+      </button>
+      <button onClick={() => onMouseMove?.({ activeTooltipIndex: 0 })}>
+        Hover first profile point
+      </button>
+      <button onClick={() => onMouseMove?.({ activeTooltipIndex: '' })}>
+        Hover invalid profile point
+      </button>
+      <button onClick={onMouseLeave}>Leave profile</button>
     </div>
   ),
   Area: () => null,
@@ -44,16 +61,22 @@ const routePoints = [
     timestamp: '2026-07-18T12:00:00Z',
     distance_from_start_km: 10,
     altitude: 10,
+    latitude: 40.79,
+    longitude: -73.96,
   },
   {
     timestamp: '2026-07-18T12:00:30Z',
     distance_from_start_km: 10.1,
     altitude: 12,
+    latitude: 40.795,
+    longitude: -73.955,
   },
   {
     timestamp: '2026-07-18T12:01:00Z',
     distance_from_start_km: 10.2,
     altitude: 11,
+    latitude: Number.NaN,
+    longitude: null,
   },
 ]
 
@@ -67,6 +90,12 @@ describe('buildSegmentElevationProfile', () => {
     expect(profile?.startElevationFeet).toBeCloseTo(32.81, 2)
     expect(profile?.finishElevationFeet).toBeCloseTo(36.09, 2)
     expect(profile?.elevationGainFeet).toBeCloseTo(6.56, 2)
+    expect(profile?.points[1]).toEqual(
+      expect.objectContaining({ latitude: 40.795, longitude: -73.955 }),
+    )
+    expect(profile?.points[2]).toEqual(
+      expect.objectContaining({ latitude: null, longitude: null }),
+    )
   })
 
   it('returns null without at least two valid distance and altitude readings', () => {
@@ -153,5 +182,121 @@ describe('SegmentElevationProfile', () => {
     expect(
       screen.getByText('Elevation profile unavailable for this segment.'),
     ).toBeVisible()
+  })
+
+  it('emits the active profile point and clears it when the pointer leaves', async () => {
+    const user = userEvent.setup()
+    const onActivePointChange = vi.fn()
+    render(
+      <SegmentElevationProfile
+        routePoints={routePoints}
+        onActivePointChange={onActivePointChange}
+      />,
+    )
+
+    await user.click(
+      screen.getByRole('button', { name: 'Hover invalid profile point' }),
+    )
+    expect(onActivePointChange).not.toHaveBeenCalled()
+
+    await user.click(
+      screen.getByRole('button', { name: 'Hover profile point' }),
+    )
+    await waitFor(() =>
+      expect(onActivePointChange).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          distanceMiles: expect.any(Number),
+          elevationFeet: expect.any(Number),
+          latitude: 40.795,
+          longitude: -73.955,
+        }),
+      ),
+    )
+    expect(onActivePointChange).toHaveBeenCalledTimes(1)
+
+    await user.click(
+      screen.getByRole('button', { name: 'Hover profile point' }),
+    )
+    await new Promise((resolve) => window.requestAnimationFrame(resolve))
+    expect(onActivePointChange).toHaveBeenCalledTimes(1)
+
+    await user.click(
+      screen.getByRole('button', { name: 'Hover first profile point' }),
+    )
+    await waitFor(() =>
+      expect(onActivePointChange).toHaveBeenLastCalledWith(
+        expect.objectContaining({ latitude: 40.79, longitude: -73.96 }),
+      ),
+    )
+
+    await user.click(screen.getByRole('button', { name: 'Leave profile' }))
+    await waitFor(() =>
+      expect(onActivePointChange).toHaveBeenLastCalledWith(null),
+    )
+  })
+
+  it('cancels a queued hover update when the profile unmounts', () => {
+    const requestFrame = vi
+      .spyOn(window, 'requestAnimationFrame')
+      .mockReturnValue(42)
+    const cancelFrame = vi.spyOn(window, 'cancelAnimationFrame')
+    const onActivePointChange = vi.fn()
+    const { unmount } = render(
+      <SegmentElevationProfile
+        routePoints={routePoints}
+        onActivePointChange={onActivePointChange}
+      />,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Hover profile point' }))
+    expect(requestFrame).toHaveBeenCalledOnce()
+
+    unmount()
+    expect(cancelFrame).toHaveBeenCalledWith(42)
+    expect(onActivePointChange).not.toHaveBeenCalled()
+
+    requestFrame.mockRestore()
+    cancelFrame.mockRestore()
+  })
+
+  it('ignores hover updates when no listener is provided', () => {
+    const requestFrame = vi.spyOn(window, 'requestAnimationFrame')
+    render(<SegmentElevationProfile routePoints={routePoints} />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Hover profile point' }))
+
+    expect(requestFrame).not.toHaveBeenCalled()
+    requestFrame.mockRestore()
+  })
+
+  it('coalesces multiple hover events into the latest animation frame point', () => {
+    let queuedFrame: FrameRequestCallback | undefined
+    const requestFrame = vi
+      .spyOn(window, 'requestAnimationFrame')
+      .mockImplementation((callback) => {
+        queuedFrame = callback
+        return 42
+      })
+    const onActivePointChange = vi.fn()
+    render(
+      <SegmentElevationProfile
+        routePoints={routePoints}
+        onActivePointChange={onActivePointChange}
+      />,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Hover profile point' }))
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Hover first profile point' }),
+    )
+
+    expect(requestFrame).toHaveBeenCalledOnce()
+    queuedFrame?.(0)
+    expect(onActivePointChange).toHaveBeenCalledOnce()
+    expect(onActivePointChange).toHaveBeenCalledWith(
+      expect.objectContaining({ latitude: 40.79, longitude: -73.96 }),
+    )
+
+    requestFrame.mockRestore()
   })
 })

--- a/src/components/garmin/SegmentElevationProfile.tsx
+++ b/src/components/garmin/SegmentElevationProfile.tsx
@@ -1,3 +1,4 @@
+import { useCallback, useEffect, useRef } from 'react'
 import {
   Area,
   AreaChart,
@@ -8,7 +9,28 @@ import {
   YAxis,
 } from 'recharts'
 import type { ActivityChartTrackPoint } from '@/components/garmin/ActivityChartData'
-import { buildSegmentElevationProfile } from './SegmentElevationProfile.helpers'
+import {
+  buildSegmentElevationProfile,
+  type SegmentElevationChartPoint,
+} from './SegmentElevationProfile.helpers'
+
+type TooltipState =
+  Readonly<{ activeTooltipIndex?: number | string | null }> | undefined
+
+function pointFromTooltipState(
+  state: TooltipState,
+  points: readonly SegmentElevationChartPoint[],
+): SegmentElevationChartPoint | null {
+  const rawIndex = state?.activeTooltipIndex
+  const index =
+    typeof rawIndex === 'number'
+      ? rawIndex
+      : typeof rawIndex === 'string' && rawIndex.trim() !== ''
+        ? Number(rawIndex)
+        : Number.NaN
+
+  return Number.isInteger(index) && points[index] ? points[index] : null
+}
 
 function formatFeet(value: number): string {
   return `${Math.round(value).toLocaleString()} ft`
@@ -31,10 +53,45 @@ function ElevationStat({
 export function SegmentElevationProfile({
   routePoints,
   loading = false,
+  onActivePointChange,
 }: Readonly<{
   routePoints: readonly ActivityChartTrackPoint[]
   loading?: boolean
+  onActivePointChange?: (point: SegmentElevationChartPoint | null) => void
 }>) {
+  const pendingActivePointRef = useRef<SegmentElevationChartPoint | null>(null)
+  const lastActivePointRef = useRef<SegmentElevationChartPoint | null>(null)
+  const activePointFrameRef = useRef<number | null>(null)
+
+  const queueActivePointChange = useCallback(
+    (point: SegmentElevationChartPoint | null) => {
+      if (!onActivePointChange) return
+
+      pendingActivePointRef.current = point
+      if (activePointFrameRef.current != null) return
+
+      activePointFrameRef.current = window.requestAnimationFrame(() => {
+        activePointFrameRef.current = null
+        const nextPoint = pendingActivePointRef.current
+        if (nextPoint !== null && lastActivePointRef.current === nextPoint) {
+          return
+        }
+        lastActivePointRef.current = nextPoint
+        onActivePointChange(nextPoint)
+      })
+    },
+    [onActivePointChange],
+  )
+
+  useEffect(
+    () => () => {
+      if (activePointFrameRef.current != null) {
+        window.cancelAnimationFrame(activePointFrameRef.current)
+      }
+    },
+    [],
+  )
+
   if (loading) {
     return (
       <div
@@ -99,6 +156,13 @@ export function SegmentElevationProfile({
           <AreaChart
             data={profile.points}
             margin={{ top: 8, right: 8, bottom: 4, left: 0 }}
+            onMouseMove={(state: {
+              activeTooltipIndex?: number | string | null
+            }) => {
+              const point = pointFromTooltipState(state, profile.points)
+              if (point) queueActivePointChange(point)
+            }}
+            onMouseLeave={() => queueActivePointChange(null)}
           >
             <defs>
               <linearGradient

--- a/src/components/garmin/SegmentElevationProfile.tsx
+++ b/src/components/garmin/SegmentElevationProfile.tsx
@@ -32,6 +32,21 @@ function pointFromTooltipState(
   return Number.isInteger(index) && points[index] ? points[index] : null
 }
 
+function isSameProfilePoint(
+  previous: SegmentElevationChartPoint | null,
+  next: SegmentElevationChartPoint | null,
+): boolean {
+  if (previous === next) return true
+  if (!previous || !next) return false
+
+  return (
+    previous.distanceMiles === next.distanceMiles &&
+    previous.elevationFeet === next.elevationFeet &&
+    previous.latitude === next.latitude &&
+    previous.longitude === next.longitude
+  )
+}
+
 function formatFeet(value: number): string {
   return `${Math.round(value).toLocaleString()} ft`
 }
@@ -73,7 +88,7 @@ export function SegmentElevationProfile({
       activePointFrameRef.current = window.requestAnimationFrame(() => {
         activePointFrameRef.current = null
         const nextPoint = pendingActivePointRef.current
-        if (nextPoint !== null && lastActivePointRef.current === nextPoint) {
+        if (isSameProfilePoint(lastActivePointRef.current, nextPoint)) {
           return
         }
         lastActivePointRef.current = nextPoint

--- a/src/components/garmin/SegmentStartEndMap.test.tsx
+++ b/src/components/garmin/SegmentStartEndMap.test.tsx
@@ -14,6 +14,8 @@ const leafletMocks = vi.hoisted(() => {
   const marker = {
     bindPopup: vi.fn().mockReturnThis(),
     addTo: vi.fn().mockReturnThis(),
+    setLatLng: vi.fn().mockReturnThis(),
+    remove: vi.fn(),
   }
   const bounds = {
     isValid: vi.fn(() => true),
@@ -114,6 +116,80 @@ describe('SegmentStartEndMap', () => {
         ([, options]) => (options as { color: string }).color,
       ),
     ).toEqual(['#2563eb', '#2563eb'])
+  })
+
+  it('adds, moves, and removes one chart hover marker without refitting', async () => {
+    const routePoints = [
+      { latitude: 40.79, longitude: -73.96, altitude: 10 },
+      { latitude: 40.8, longitude: -73.95, altitude: 20 },
+    ]
+    const { rerender } = render(
+      <SegmentStartEndMap
+        startLat={40.79}
+        startLon={-73.96}
+        endLat={40.8}
+        endLon={-73.95}
+        routePoints={routePoints}
+      />,
+    )
+
+    await waitFor(() =>
+      expect(leafletMocks.circleMarker).toHaveBeenCalledTimes(2),
+    )
+
+    rerender(
+      <SegmentStartEndMap
+        startLat={40.79}
+        startLon={-73.96}
+        endLat={40.8}
+        endLon={-73.95}
+        routePoints={routePoints}
+        activeLatLng={{ lat: 40.795, lng: -73.955 }}
+      />,
+    )
+
+    await waitFor(() =>
+      expect(leafletMocks.circleMarker).toHaveBeenLastCalledWith(
+        [40.795, -73.955],
+        expect.objectContaining({ className: 'segment-hover-marker' }),
+      ),
+    )
+    expect(leafletMocks.mapInstance.fitBounds).toHaveBeenCalledTimes(1)
+
+    rerender(
+      <SegmentStartEndMap
+        startLat={40.79}
+        startLon={-73.96}
+        endLat={40.8}
+        endLon={-73.95}
+        routePoints={routePoints}
+        activeLatLng={{ lat: 40.797, lng: -73.953 }}
+      />,
+    )
+
+    await waitFor(() =>
+      expect(leafletMocks.marker.setLatLng).toHaveBeenLastCalledWith([
+        40.797, -73.953,
+      ]),
+    )
+    expect(leafletMocks.circleMarker).toHaveBeenCalledTimes(3)
+    expect(leafletMocks.mapInstance.fitBounds).toHaveBeenCalledTimes(1)
+
+    rerender(
+      <SegmentStartEndMap
+        startLat={40.79}
+        startLon={-73.96}
+        endLat={40.8}
+        endLon={-73.95}
+        routePoints={routePoints}
+        activeLatLng={null}
+      />,
+    )
+
+    await waitFor(() =>
+      expect(leafletMocks.marker.remove).toHaveBeenCalledOnce(),
+    )
+    expect(leafletMocks.mapInstance.fitBounds).toHaveBeenCalledTimes(1)
   })
 
   it('falls back to a straight dashed line and skips invalid bounds', async () => {

--- a/src/components/garmin/SegmentStartEndMap.tsx
+++ b/src/components/garmin/SegmentStartEndMap.tsx
@@ -12,6 +12,8 @@ interface SegmentStartEndMapProps {
     longitude: number
     altitude?: number | null
   }>
+  /** Point currently under the elevation-chart cursor. */
+  activeLatLng?: { lat: number; lng: number } | null
 }
 
 function elevationToColor(
@@ -50,9 +52,11 @@ export function SegmentStartEndMap({
   endLat,
   endLon,
   routePoints = [],
+  activeLatLng,
 }: Readonly<SegmentStartEndMapProps>) {
   const mapRef = useRef<HTMLDivElement>(null)
   const mapInstanceRef = useRef<L.Map | null>(null)
+  const hoverMarkerRef = useRef<L.CircleMarker | null>(null)
 
   useEffect(() => {
     if (!mapRef.current) return
@@ -152,8 +156,38 @@ export function SegmentStartEndMap({
     return () => {
       map.remove()
       mapInstanceRef.current = null
+      hoverMarkerRef.current = null
     }
   }, [startLat, startLon, endLat, endLon, routePoints])
+
+  // Move one marker along the route while the elevation graph is hovered.
+  // The map view stays fixed so scrubbing the graph does not disrupt context.
+  useEffect(() => {
+    const map = mapInstanceRef.current
+    if (!map) return
+
+    if (!activeLatLng) {
+      hoverMarkerRef.current?.remove()
+      hoverMarkerRef.current = null
+      return
+    }
+
+    if (hoverMarkerRef.current) {
+      hoverMarkerRef.current.setLatLng([activeLatLng.lat, activeLatLng.lng])
+    } else {
+      hoverMarkerRef.current = L.circleMarker(
+        [activeLatLng.lat, activeLatLng.lng],
+        {
+          radius: 6,
+          color: '#111827',
+          weight: 2,
+          fillColor: '#ffffff',
+          fillOpacity: 1,
+          className: 'segment-hover-marker',
+        },
+      ).addTo(map)
+    }
+  }, [activeLatLng])
 
   return (
     <div

--- a/src/pages/GarminSegmentDetailPage.test.tsx
+++ b/src/pages/GarminSegmentDetailPage.test.tsx
@@ -1,7 +1,7 @@
 import { screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { Route, Routes } from 'react-router-dom'
+import { Link, Route, Routes } from 'react-router-dom'
 import { renderWithRouter } from '@/test/renderWithRouter'
 import { GarminSegmentDetailPage } from './GarminSegmentDetailPage'
 
@@ -14,18 +14,48 @@ const segmentHooks = vi.hoisted(() => ({
 vi.mock('@/__generated__/graphql', () => segmentHooks)
 vi.mock('@/lib/newrelic-browser', () => ({ setNRCustomAttribute: vi.fn() }))
 vi.mock('@/components/garmin/SegmentStartEndMap', () => ({
-  SegmentStartEndMap: ({ routePoints = [] }: { routePoints?: unknown[] }) => (
-    <div data-testid="segment-map">map points: {routePoints.length}</div>
+  SegmentStartEndMap: ({
+    routePoints = [],
+    activeLatLng,
+  }: {
+    routePoints?: unknown[]
+    activeLatLng?: { lat: number; lng: number } | null
+  }) => (
+    <div data-testid="segment-map">
+      map points: {routePoints.length}; marker:{' '}
+      {activeLatLng ? `${activeLatLng.lat}, ${activeLatLng.lng}` : 'none'}
+    </div>
   ),
 }))
 vi.mock('@/components/garmin/SegmentElevationProfile', () => ({
   SegmentElevationProfile: ({
     routePoints = [],
+    onActivePointChange,
   }: {
     routePoints?: unknown[]
+    onActivePointChange?: (
+      point: { latitude: number | null; longitude: number | null } | null,
+    ) => void
   }) => (
     <div data-testid="segment-elevation-profile">
       elevation points: {routePoints.length}
+      <button
+        onClick={() =>
+          onActivePointChange?.({ latitude: 40.795, longitude: -73.965 })
+        }
+      >
+        Hover valid elevation point
+      </button>
+      <button
+        onClick={() =>
+          onActivePointChange?.({ latitude: null, longitude: -73.965 })
+        }
+      >
+        Hover invalid elevation point
+      </button>
+      <button onClick={() => onActivePointChange?.(null)}>
+        Leave elevation profile
+      </button>
     </div>
   ),
 }))
@@ -56,13 +86,16 @@ const segment = {
 
 function renderDetail(entry = '/garmin/segments/1') {
   return renderWithRouter(
-    <Routes>
-      <Route
-        path="garmin/segments/:segmentId"
-        element={<GarminSegmentDetailPage />}
-      />
-      <Route path="garmin/segments" element={<div>segment list</div>} />
-    </Routes>,
+    <>
+      <Link to="/garmin/segments/2">Switch test segment</Link>
+      <Routes>
+        <Route
+          path="garmin/segments/:segmentId"
+          element={<GarminSegmentDetailPage />}
+        />
+        <Route path="garmin/segments" element={<div>segment list</div>} />
+      </Routes>
+    </>,
     { entries: [entry] },
   )
 }
@@ -207,6 +240,39 @@ describe('GarminSegmentDetailPage', () => {
     renderDetail()
 
     expect(screen.getByText('Segment not found')).toBeVisible()
+  })
+
+  it('synchronizes valid elevation hover coordinates with the map', async () => {
+    const user = userEvent.setup()
+    renderDetail()
+
+    expect(screen.getByTestId('segment-map')).toHaveTextContent('marker: none')
+
+    await user.click(
+      screen.getByRole('button', { name: 'Hover valid elevation point' }),
+    )
+    expect(screen.getByTestId('segment-map')).toHaveTextContent(
+      'marker: 40.795, -73.965',
+    )
+
+    await user.click(
+      screen.getByRole('button', { name: 'Hover invalid elevation point' }),
+    )
+    expect(screen.getByTestId('segment-map')).toHaveTextContent('marker: none')
+
+    await user.click(
+      screen.getByRole('button', { name: 'Hover valid elevation point' }),
+    )
+    await user.click(
+      screen.getByRole('button', { name: 'Leave elevation profile' }),
+    )
+    expect(screen.getByTestId('segment-map')).toHaveTextContent('marker: none')
+
+    await user.click(
+      screen.getByRole('button', { name: 'Hover valid elevation point' }),
+    )
+    await user.click(screen.getByRole('link', { name: 'Switch test segment' }))
+    expect(screen.getByTestId('segment-map')).toHaveTextContent('marker: none')
   })
 
   it('rejects an invalid segment id without running the queries', () => {

--- a/src/pages/GarminSegmentDetailPage.tsx
+++ b/src/pages/GarminSegmentDetailPage.tsx
@@ -1,4 +1,10 @@
-import { useEffect, useMemo, useState, type ReactNode } from 'react'
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from 'react'
 import { Link, useNavigate, useParams } from 'react-router-dom'
 import { ArrowLeft } from 'lucide-react'
 import {
@@ -29,18 +35,29 @@ import { setNRCustomAttribute } from '@/lib/newrelic-browser'
 // so a popular segment can have well over 100 total efforts.
 const EFFORTS_LIMIT = 500
 
+interface ActiveElevationSelection {
+  segmentId: string | undefined
+  point: SegmentElevationChartPoint
+}
+
 export function GarminSegmentDetailPage() {
   const { segmentId } = useParams<{ segmentId: string }>()
   const navigate = useNavigate()
   const id = Number(segmentId)
   const validId = Number.isInteger(id) && id > 0
-  const [activeElevationPoint, setActiveElevationPoint] =
-    useState<SegmentElevationChartPoint | null>(null)
-  const [previousSegmentId, setPreviousSegmentId] = useState(segmentId)
-  if (segmentId !== previousSegmentId) {
-    setPreviousSegmentId(segmentId)
-    setActiveElevationPoint(null)
-  }
+  const [activeElevationSelection, setActiveElevationSelection] =
+    useState<ActiveElevationSelection | null>(null)
+  const activeElevationPoint =
+    activeElevationSelection != null &&
+    activeElevationSelection.segmentId === segmentId
+      ? activeElevationSelection.point
+      : null
+  const handleActiveElevationPointChange = useCallback(
+    (point: SegmentElevationChartPoint | null) => {
+      setActiveElevationSelection(point ? { segmentId, point } : null)
+    },
+    [segmentId],
+  )
 
   useEffect(() => {
     setNRCustomAttribute('garmin.flow', true)
@@ -206,7 +223,7 @@ export function GarminSegmentDetailPage() {
             <SegmentElevationProfile
               routePoints={routePoints}
               loading={sourceTrackLoading}
-              onActivePointChange={setActiveElevationPoint}
+              onActivePointChange={handleActiveElevationPointChange}
             />
             <dl className="grid grid-cols-2 gap-x-4 gap-y-1 text-sm">
               <dt className="text-muted-foreground">Distance</dt>

--- a/src/pages/GarminSegmentDetailPage.tsx
+++ b/src/pages/GarminSegmentDetailPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, type ReactNode } from 'react'
+import { useEffect, useMemo, useState, type ReactNode } from 'react'
 import { Link, useNavigate, useParams } from 'react-router-dom'
 import { ArrowLeft } from 'lucide-react'
 import {
@@ -13,6 +13,7 @@ import { Badge } from '@/components/ui/badge'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { SegmentStartEndMap } from '@/components/garmin/SegmentStartEndMap'
 import { SegmentElevationProfile } from '@/components/garmin/SegmentElevationProfile'
+import type { SegmentElevationChartPoint } from '@/components/garmin/SegmentElevationProfile.helpers'
 import { SegmentEffortsLeaderboard } from '@/components/garmin/SegmentEffortsLeaderboard'
 import { DeleteSegmentButton } from '@/components/garmin/DeleteSegmentButton'
 import {
@@ -33,6 +34,13 @@ export function GarminSegmentDetailPage() {
   const navigate = useNavigate()
   const id = Number(segmentId)
   const validId = Number.isInteger(id) && id > 0
+  const [activeElevationPoint, setActiveElevationPoint] =
+    useState<SegmentElevationChartPoint | null>(null)
+  const [previousSegmentId, setPreviousSegmentId] = useState(segmentId)
+  if (segmentId !== previousSegmentId) {
+    setPreviousSegmentId(segmentId)
+    setActiveElevationPoint(null)
+  }
 
   useEffect(() => {
     setNRCustomAttribute('garmin.flow', true)
@@ -78,6 +86,16 @@ export function GarminSegmentDetailPage() {
         : [],
     [segment, sourceTrackData?.garminChartData],
   )
+  const activeLatLng =
+    activeElevationPoint?.latitude != null &&
+    Number.isFinite(activeElevationPoint.latitude) &&
+    activeElevationPoint.longitude != null &&
+    Number.isFinite(activeElevationPoint.longitude)
+      ? {
+          lat: activeElevationPoint.latitude,
+          lng: activeElevationPoint.longitude,
+        }
+      : null
 
   const backLink = (
     <Link
@@ -183,10 +201,12 @@ export function GarminSegmentDetailPage() {
               endLat={segment.end_latitude}
               endLon={segment.end_longitude}
               routePoints={routePoints}
+              activeLatLng={activeLatLng}
             />
             <SegmentElevationProfile
               routePoints={routePoints}
               loading={sourceTrackLoading}
+              onActivePointChange={setActiveElevationPoint}
             />
             <dl className="grid grid-cols-2 gap-x-4 gap-y-1 text-sm">
               <dt className="text-muted-foreground">Distance</dt>


### PR DESCRIPTION
## Summary

- preserve route coordinates on Segment elevation-profile points and emit the active point while the chart is hovered
- synchronize that point with one moving Leaflet marker without recentering or refitting the Segment map
- clear the marker on pointer leave, segment navigation, or invalid coordinates
- extend component, page-integration, and Playwright coverage for the interaction

## Why

The Activity detail page already connects chart hover state to its route map. The Segment elevation graph did not expose where an elevation reading occurred along the mapped route, making climbs and descents harder to place geographically.

## Impact

Users can now scrub the Segment elevation graph and immediately see the corresponding point on the map. This is a UI-only change and does not modify API contracts or persisted data.

## Validation

- `npm run lint:all`
- `npm run type-check`
- `npm run build`
- `npm run test:coverage` - 453 tests passed before the final scheduler-edge additions
- `npm run test:run` - final 456 tests passed
- focused elevation-profile coverage - 100% statements, branches, functions, and lines
- local production-style Playwright Segment route-map scenario - passed
- visual hover-state inspection - chart crosshair and one mapped point aligned correctly

Refs #445
