### PR TITLE
test(e2e): add Playwright coverage for the hourly weather breakdown

### DIFF
--- a/e2e/garmin-weather-hourly.spec.ts
+++ b/e2e/garmin-weather-hourly.spec.ts
@@ -1,0 +1,45 @@
+import { test, expect } from '@playwright/test'
+import fs from 'fs'
+import path from 'path'
+
+const SCREENSHOT_DIR = path.join('e2e', 'screenshots', 'garmin-weather-hourly')
+// 2024-06-22 cycling activity, ~4.5h (14051s), confirmed to have 5 rows in
+// garmin_activity_weather_hourly as of the production backfill.
+const ACTIVITY_ID =
+  process.env.PLAYWRIGHT_GARMIN_WEATHER_HOURLY_ACTIVITY_ID ?? '16047161090'
+
+fs.mkdirSync(SCREENSHOT_DIR, { recursive: true })
+
+test.describe('Garmin Activity Weather - hourly breakdown', () => {
+  test('shows the hourly breakdown for a known multi-hour activity', async ({
+    page,
+  }) => {
+    await page.goto(`/garmin/${ACTIVITY_ID}`)
+
+    await expect(page.getByTestId('garmin-detail-tabs')).toBeVisible({
+      timeout: 20_000,
+    })
+    await page.getByTestId('garmin-tab-stats').click()
+
+    const weatherPanel = page.getByTestId('weather-panel')
+    await expect(weatherPanel).toBeVisible({ timeout: 20_000 })
+
+    const hourlyBreakdown = page.getByTestId('weather-hourly-breakdown')
+    await expect(hourlyBreakdown).toBeVisible({ timeout: 20_000 })
+    await expect(page.getByText('Over the activity')).toBeVisible()
+
+    await weatherPanel.scrollIntoViewIfNeeded()
+    await page.screenshot({
+      path: path.join(SCREENSHOT_DIR, 'weather-panel-full.png'),
+      clip: await weatherPanel.boundingBox().then((box) => box ?? undefined),
+    })
+    await page.screenshot({
+      path: path.join(SCREENSHOT_DIR, 'stats-tab-full-page.png'),
+      fullPage: true,
+    })
+
+    console.log(
+      `[garmin-weather-hourly] activity=${ACTIVITY_ID} weather-hourly-breakdown present=true`,
+    )
+  })
+})

--- a/e2e/garmin-weather-hourly.spec.ts
+++ b/e2e/garmin-weather-hourly.spec.ts
@@ -26,12 +26,17 @@ test.describe('Garmin Activity Weather - hourly breakdown', () => {
 
     const hourlyBreakdown = page.getByTestId('weather-hourly-breakdown')
     await expect(hourlyBreakdown).toBeVisible({ timeout: 20_000 })
-    await expect(page.getByText('Over the activity')).toBeVisible()
+    await expect(hourlyBreakdown.getByText('Over the activity')).toBeVisible()
+    await expect(hourlyBreakdown.getByText('85°F – 87°F')).toBeVisible()
+    for (const label of ['Start', '+1h', '+2h', '+3h', '+4h']) {
+      await expect(
+        hourlyBreakdown.getByText(label, { exact: true }),
+      ).toBeVisible()
+    }
 
     await weatherPanel.scrollIntoViewIfNeeded()
-    await page.screenshot({
+    await weatherPanel.screenshot({
       path: path.join(SCREENSHOT_DIR, 'weather-panel-full.png'),
-      clip: await weatherPanel.boundingBox().then((box) => box ?? undefined),
     })
     await page.screenshot({
       path: path.join(SCREENSHOT_DIR, 'stats-tab-full-page.png'),

--- a/e2e/garmin-weather-hourly.spec.ts
+++ b/e2e/garmin-weather-hourly.spec.ts
@@ -27,7 +27,9 @@ test.describe('Garmin Activity Weather - hourly breakdown', () => {
     const hourlyBreakdown = page.getByTestId('weather-hourly-breakdown')
     await expect(hourlyBreakdown).toBeVisible({ timeout: 20_000 })
     await expect(hourlyBreakdown.getByText('Over the activity')).toBeVisible()
-    await expect(hourlyBreakdown.getByText('85°F – 87°F')).toBeVisible()
+    await expect(
+      hourlyBreakdown.getByText(/^-?\d+°F – -?\d+°F$/),
+    ).toBeVisible()
     for (const label of ['Start', '+1h', '+2h', '+3h', '+4h']) {
       await expect(
         hourlyBreakdown.getByText(label, { exact: true }),


### PR DESCRIPTION
## Summary

Investigating a report that the Weather card wasn't showing the "Over the activity" hourly breakdown on a live activity page. Added a Playwright e2e test against a known multi-hour activity (`16047161090` — 4.5h ride, confirmed to have 5 rows in `garmin_activity_weather_hourly`) and ran it against production.

**Result: the feature works correctly.** Screenshot confirms the full card rendering — temperature range (`85°F – 87°F`), 5 hour chips (Start, +1h..+4h) each with icon, condition text, and temperature:

The originally-reported activity simply doesn't have 2+ hourly rows — `WeatherHourlyBreakdown` intentionally renders nothing below that threshold (a single-hour activity is already fully represented by the summary card above it). Not a bug, just the component's by-design empty case.

This test now guards the happy path going forward — activity id is overridable via `PLAYWRIGHT_GARMIN_WEATHER_HOURLY_ACTIVITY_ID` if that row ever needs to change.

## Test plan
- [x] `npx playwright test e2e/garmin-weather-hourly.spec.ts` — passes against production, screenshots captured (gitignored, matches existing e2e conventions)
- [x] `eslint` / `prettier` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)