### PR TITLE
feat(garmin): show Segment point address

### DIFF
--- a/e2e/garmin-segment-route-map.spec.ts
+++ b/e2e/garmin-segment-route-map.spec.ts
@@ -5,6 +5,7 @@ test.describe('Garmin segment route map', () => {
     page,
   }) => {
     await page.emulateMedia({ colorScheme: 'dark' })
+    await page.addInitScript(() => window.localStorage.setItem('theme', 'dark'))
     const chartDataResponse = page.waitForResponse(async (response) => {
       if (response.request().method() !== 'POST') return false
 
@@ -22,6 +23,17 @@ test.describe('Garmin segment route map', () => {
 
     const map = page.getByTestId('segment-map')
     await expect(map).toBeVisible()
+
+    const pointAddress = page.getByTestId('segment-point-address')
+    const addressValue = page.getByTestId('segment-point-address-value')
+    await expect(pointAddress.getByText('Start point address')).toBeVisible()
+    await expect(addressValue).not.toHaveText('Resolving…', {
+      timeout: 10_000,
+    })
+    await expect(addressValue).not.toHaveText('—')
+    await expect(addressValue).not.toHaveText('Unavailable')
+    const startAddress = await addressValue.textContent()
+    if (!startAddress) throw new Error('Segment start address unavailable')
 
     const routePaths = map.locator(
       '.leaflet-overlay-pane svg path[fill="none"]',
@@ -56,8 +68,13 @@ test.describe('Garmin segment route map', () => {
     const elevationChart = elevationProfile.locator(
       '.recharts-responsive-container',
     )
+    await elevationChart.scrollIntoViewIfNeeded()
     const chartBox = await elevationChart.boundingBox()
     if (!chartBox) throw new Error('Segment elevation chart unavailable')
+    const selectedAddressResponse = page.waitForResponse(
+      (response) =>
+        response.url().includes('/v1/reverse?') && response.status() === 200,
+    )
     await page.mouse.move(
       chartBox.x + chartBox.width / 2,
       chartBox.y + chartBox.height / 2,
@@ -70,8 +87,16 @@ test.describe('Garmin segment route map', () => {
     await expect(
       elevationProfile.locator('.recharts-tooltip-cursor'),
     ).toHaveCount(1, { timeout: 5_000 })
+    await expect(pointAddress.getByText('Selected point address')).toBeVisible()
+    await selectedAddressResponse
+    await expect(addressValue).not.toHaveText('Resolving…', {
+      timeout: 10_000,
+    })
+    await expect(addressValue).not.toHaveText('Unavailable')
 
     await page.mouse.move(0, 0)
     await expect(hoverMarker).toHaveCount(0, { timeout: 5_000 })
+    await expect(pointAddress.getByText('Start point address')).toBeVisible()
+    await expect(addressValue).toHaveText(startAddress)
   })
 })

--- a/src/components/garmin/ActivityHoverDetails.tsx
+++ b/src/components/garmin/ActivityHoverDetails.tsx
@@ -1,8 +1,10 @@
-import { useEffect, useMemo, useRef, useState } from 'react'
 import { Card, CardContent } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
-import { reverseGeocode } from '@/services/geocoder'
 import type { ChartDataPoint } from './ActivityChartData'
+import {
+  formatReverseGeocodedAddress,
+  useReverseGeocodedAddress,
+} from './useReverseGeocodedAddress'
 
 interface ActivityHoverDetailsProps {
   point: ChartDataPoint | null
@@ -12,97 +14,12 @@ interface ActivityHoverDetailsProps {
   onToggleSave?: () => void
 }
 
-type AddressState =
-  | { status: 'idle' }
-  | { status: 'loading' }
-  | { status: 'ok'; label: string }
-  | { status: 'empty' }
-  | { status: 'error' }
-
-// Round to ~11m precision so small jitter between adjacent samples reuses the
-// cache and we do not flood the geocoder while a cursor sweeps a chart.
-function roundCoord(n: number): number {
-  return Math.round(n * 10_000) / 10_000
-}
-
-const DEBOUNCE_MS = 250
-const addressCache = new Map<string, string | null>()
-
-interface CoordKey {
-  key: string
-  lat: number
-  lon: number
-}
-
-function coordKey(point: ChartDataPoint | null): CoordKey | null {
-  const latitude = point?.latitude
-  const longitude = point?.longitude
-  if (
-    latitude == null ||
-    longitude == null ||
-    !Number.isFinite(latitude) ||
-    !Number.isFinite(longitude)
-  ) {
-    return null
-  }
-  const lat = roundCoord(latitude)
-  const lon = roundCoord(longitude)
-  return { key: `${lat},${lon}`, lat, lon }
-}
-
 export function ActivityHoverDetails({
   point,
   isSaved = false,
   onToggleSave,
 }: Readonly<ActivityHoverDetailsProps>) {
-  const target = useMemo(() => coordKey(point), [point])
-  const [pendingState, setPendingState] = useState<{
-    key: string
-    state: AddressState
-  } | null>(null)
-  const abortRef = useRef<AbortController | null>(null)
-
-  useEffect(() => {
-    if (!target) return
-    if (addressCache.has(target.key)) return
-
-    abortRef.current?.abort()
-    const controller = new AbortController()
-    abortRef.current = controller
-
-    const timer = window.setTimeout(async () => {
-      try {
-        const res = await reverseGeocode(target.lat, target.lon, 1)
-        if (controller.signal.aborted) return
-        const label = res.features[0]?.properties?.label ?? null
-        addressCache.set(target.key, label)
-        setPendingState({
-          key: target.key,
-          state: label ? { status: 'ok', label } : { status: 'empty' },
-        })
-      } catch {
-        if (controller.signal.aborted) return
-        setPendingState({ key: target.key, state: { status: 'error' } })
-      }
-    }, DEBOUNCE_MS)
-
-    return () => {
-      window.clearTimeout(timer)
-      controller.abort()
-    }
-  }, [target])
-
-  const address: AddressState = (() => {
-    if (!target) return { status: 'idle' }
-    if (addressCache.has(target.key)) {
-      const cached = addressCache.get(target.key)
-      return cached ? { status: 'ok', label: cached } : { status: 'empty' }
-    }
-    if (pendingState?.key === target.key) {
-      return pendingState.state
-    }
-    return { status: 'loading' }
-  })()
+  const address = useReverseGeocodedAddress(point?.latitude, point?.longitude)
 
   if (!point) {
     return (
@@ -188,28 +105,12 @@ export function ActivityHoverDetails({
             className="font-medium"
             data-testid="activity-hover-address-value"
           >
-            {renderAddress(address)}
+            {formatReverseGeocodedAddress(address)}
           </span>
         </div>
       </CardContent>
     </Card>
   )
-}
-
-function renderAddress(state: AddressState): string {
-  switch (state.status) {
-    case 'loading':
-      return 'Resolving…'
-    case 'ok':
-      return state.label
-    case 'empty':
-      return 'No address found'
-    case 'error':
-      return 'Unavailable'
-    case 'idle':
-    default:
-      return '—'
-  }
 }
 
 // Format the hover distance in miles, appending the km value when available.

--- a/src/components/garmin/SegmentPointAddress.test.tsx
+++ b/src/components/garmin/SegmentPointAddress.test.tsx
@@ -1,0 +1,152 @@
+import { act, render, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const geocoderMocks = vi.hoisted(() => ({
+  reverseGeocode: vi.fn(),
+}))
+
+vi.mock('@/services/geocoder', () => geocoderMocks)
+
+import { SegmentPointAddress } from './SegmentPointAddress'
+
+function geocoderResponse(label?: string) {
+  return {
+    type: 'FeatureCollection',
+    features: label ? [{ properties: { label } }] : [],
+  }
+}
+
+describe('SegmentPointAddress', () => {
+  beforeEach(() => {
+    vi.useRealTimers()
+    geocoderMocks.reverseGeocode.mockReset()
+  })
+
+  it('resolves the start address, follows selection, and restores the cache', async () => {
+    geocoderMocks.reverseGeocode
+      .mockResolvedValueOnce(geocoderResponse('5th Ave, New York, NY, USA'))
+      .mockResolvedValueOnce(
+        geocoderResponse('Central Park, New York, NY, USA'),
+      )
+
+    const { rerender } = render(
+      <SegmentPointAddress
+        latitude={40.73061}
+        longitude={-73.935242}
+        selected={false}
+      />,
+    )
+
+    expect(screen.getByText('Start point address')).toBeInTheDocument()
+    expect(screen.getByText('Resolving…')).toBeInTheDocument()
+    expect(
+      await screen.findByText('5th Ave, New York, NY, USA'),
+    ).toBeInTheDocument()
+    expect(geocoderMocks.reverseGeocode).toHaveBeenNthCalledWith(
+      1,
+      40.7306,
+      -73.9352,
+      1,
+    )
+
+    rerender(
+      <SegmentPointAddress
+        latitude={40.771133}
+        longitude={-73.974187}
+        selected
+      />,
+    )
+
+    expect(screen.getByText('Selected point address')).toBeInTheDocument()
+    expect(
+      await screen.findByText('Central Park, New York, NY, USA'),
+    ).toBeInTheDocument()
+    expect(geocoderMocks.reverseGeocode).toHaveBeenNthCalledWith(
+      2,
+      40.7711,
+      -73.9742,
+      1,
+    )
+
+    rerender(
+      <SegmentPointAddress
+        latitude={40.73061}
+        longitude={-73.935242}
+        selected={false}
+      />,
+    )
+
+    expect(screen.getByText('Start point address')).toBeInTheDocument()
+    expect(screen.getByText('5th Ave, New York, NY, USA')).toBeInTheDocument()
+    expect(geocoderMocks.reverseGeocode).toHaveBeenCalledTimes(2)
+  })
+
+  it('handles invalid coordinates, empty results, and geocoder errors', async () => {
+    const { rerender } = render(
+      <SegmentPointAddress
+        latitude={Number.NaN}
+        longitude={-73.935242}
+        selected={false}
+      />,
+    )
+
+    expect(screen.getByTestId('segment-point-address-value')).toHaveTextContent(
+      '—',
+    )
+    expect(geocoderMocks.reverseGeocode).not.toHaveBeenCalled()
+
+    geocoderMocks.reverseGeocode.mockResolvedValueOnce(geocoderResponse())
+    rerender(
+      <SegmentPointAddress
+        latitude={40.70011}
+        longitude={-73.90011}
+        selected={false}
+      />,
+    )
+    expect(await screen.findByText('No address found')).toBeInTheDocument()
+
+    geocoderMocks.reverseGeocode.mockRejectedValueOnce(new Error('offline'))
+    rerender(
+      <SegmentPointAddress
+        latitude={40.70021}
+        longitude={-73.90021}
+        selected
+      />,
+    )
+    expect(await screen.findByText('Unavailable')).toBeInTheDocument()
+  })
+
+  it('debounces rapid coordinate changes and resolves only the latest point', async () => {
+    vi.useFakeTimers()
+    geocoderMocks.reverseGeocode.mockResolvedValue(
+      geocoderResponse('Latest selected point, New York, NY, USA'),
+    )
+
+    const { rerender } = render(
+      <SegmentPointAddress
+        latitude={40.72011}
+        longitude={-73.91011}
+        selected={false}
+      />,
+    )
+    rerender(
+      <SegmentPointAddress
+        latitude={40.72021}
+        longitude={-73.91021}
+        selected
+      />,
+    )
+
+    await act(async () => vi.advanceTimersByTimeAsync(250))
+
+    expect(geocoderMocks.reverseGeocode).toHaveBeenCalledOnce()
+    expect(geocoderMocks.reverseGeocode).toHaveBeenCalledWith(
+      40.7202,
+      -73.9102,
+      1,
+    )
+    expect(
+      screen.getByText('Latest selected point, New York, NY, USA'),
+    ).toBeInTheDocument()
+  })
+})

--- a/src/components/garmin/SegmentPointAddress.test.tsx
+++ b/src/components/garmin/SegmentPointAddress.test.tsx
@@ -1,5 +1,5 @@
 import { act, render, screen } from '@testing-library/react'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const geocoderMocks = vi.hoisted(() => ({
   reverseGeocode: vi.fn(),
@@ -20,6 +20,10 @@ describe('SegmentPointAddress', () => {
   beforeEach(() => {
     vi.useRealTimers()
     geocoderMocks.reverseGeocode.mockReset()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
   })
 
   it('resolves the start address, follows selection, and restores the cache', async () => {

--- a/src/components/garmin/SegmentPointAddress.tsx
+++ b/src/components/garmin/SegmentPointAddress.tsx
@@ -1,0 +1,38 @@
+import {
+  formatReverseGeocodedAddress,
+  useReverseGeocodedAddress,
+} from './useReverseGeocodedAddress'
+
+interface SegmentPointAddressProps {
+  latitude: number | null | undefined
+  longitude: number | null | undefined
+  selected: boolean
+}
+
+export function SegmentPointAddress({
+  latitude,
+  longitude,
+  selected,
+}: Readonly<SegmentPointAddressProps>) {
+  const address = useReverseGeocodedAddress(latitude, longitude)
+
+  return (
+    <div
+      className="rounded-md border bg-muted/20 px-3 py-2 text-sm"
+      data-testid="segment-point-address"
+    >
+      <div className="flex flex-wrap items-baseline justify-between gap-x-4 gap-y-1">
+        <span className="text-xs text-muted-foreground">
+          {selected ? 'Selected point address' : 'Start point address'}
+        </span>
+        <span
+          className="font-medium"
+          data-testid="segment-point-address-value"
+          aria-live="polite"
+        >
+          {formatReverseGeocodedAddress(address)}
+        </span>
+      </div>
+    </div>
+  )
+}

--- a/src/components/garmin/useReverseGeocodedAddress.ts
+++ b/src/components/garmin/useReverseGeocodedAddress.ts
@@ -1,0 +1,125 @@
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { reverseGeocode } from '@/services/geocoder'
+
+export type ReverseGeocodedAddressState =
+  | { status: 'idle' }
+  | { status: 'loading' }
+  | { status: 'ok'; label: string }
+  | { status: 'empty' }
+  | { status: 'error' }
+
+// Round to ~11m precision so small jitter between adjacent samples reuses the
+// cache and we do not flood the geocoder while a cursor sweeps a chart.
+function roundCoord(value: number): number {
+  return Math.round(value * 10_000) / 10_000
+}
+
+const DEBOUNCE_MS = 250
+const addressCache = new Map<string, string | null>()
+
+interface CoordinateTarget {
+  key: string
+  latitude: number
+  longitude: number
+}
+
+function coordinateTarget(
+  latitude: number | null | undefined,
+  longitude: number | null | undefined,
+): CoordinateTarget | null {
+  if (
+    latitude == null ||
+    longitude == null ||
+    !Number.isFinite(latitude) ||
+    !Number.isFinite(longitude) ||
+    latitude < -90 ||
+    latitude > 90 ||
+    longitude < -180 ||
+    longitude > 180
+  ) {
+    return null
+  }
+
+  const roundedLatitude = roundCoord(latitude)
+  const roundedLongitude = roundCoord(longitude)
+  return {
+    key: `${roundedLatitude},${roundedLongitude}`,
+    latitude: roundedLatitude,
+    longitude: roundedLongitude,
+  }
+}
+
+export function useReverseGeocodedAddress(
+  latitude: number | null | undefined,
+  longitude: number | null | undefined,
+): ReverseGeocodedAddressState {
+  const target = useMemo(
+    () => coordinateTarget(latitude, longitude),
+    [latitude, longitude],
+  )
+  const [pendingState, setPendingState] = useState<{
+    key: string
+    state: ReverseGeocodedAddressState
+  } | null>(null)
+  const abortRef = useRef<AbortController | null>(null)
+
+  useEffect(() => {
+    if (!target || addressCache.has(target.key)) return
+
+    abortRef.current?.abort()
+    const controller = new AbortController()
+    abortRef.current = controller
+
+    const timer = window.setTimeout(async () => {
+      try {
+        const response = await reverseGeocode(
+          target.latitude,
+          target.longitude,
+          1,
+        )
+        if (controller.signal.aborted) return
+
+        const label = response.features[0]?.properties?.label ?? null
+        addressCache.set(target.key, label)
+        setPendingState({
+          key: target.key,
+          state: label ? { status: 'ok', label } : { status: 'empty' },
+        })
+      } catch {
+        if (controller.signal.aborted) return
+        setPendingState({ key: target.key, state: { status: 'error' } })
+      }
+    }, DEBOUNCE_MS)
+
+    return () => {
+      window.clearTimeout(timer)
+      controller.abort()
+    }
+  }, [target])
+
+  if (!target) return { status: 'idle' }
+  if (addressCache.has(target.key)) {
+    const cached = addressCache.get(target.key)
+    return cached ? { status: 'ok', label: cached } : { status: 'empty' }
+  }
+  if (pendingState?.key === target.key) return pendingState.state
+  return { status: 'loading' }
+}
+
+export function formatReverseGeocodedAddress(
+  state: ReverseGeocodedAddressState,
+): string {
+  switch (state.status) {
+    case 'loading':
+      return 'Resolving…'
+    case 'ok':
+      return state.label
+    case 'empty':
+      return 'No address found'
+    case 'error':
+      return 'Unavailable'
+    case 'idle':
+    default:
+      return '—'
+  }
+}

--- a/src/pages/GarminSegmentDetailPage.test.tsx
+++ b/src/pages/GarminSegmentDetailPage.test.tsx
@@ -27,6 +27,21 @@ vi.mock('@/components/garmin/SegmentStartEndMap', () => ({
     </div>
   ),
 }))
+vi.mock('@/components/garmin/SegmentPointAddress', () => ({
+  SegmentPointAddress: ({
+    latitude,
+    longitude,
+    selected,
+  }: {
+    latitude: number
+    longitude: number
+    selected: boolean
+  }) => (
+    <div data-testid="segment-point-address">
+      {selected ? 'selected' : 'start'}: {latitude}, {longitude}
+    </div>
+  ),
+}))
 vi.mock('@/components/garmin/SegmentElevationProfile', () => ({
   SegmentElevationProfile: ({
     routePoints = [],
@@ -242,11 +257,14 @@ describe('GarminSegmentDetailPage', () => {
     expect(screen.getByText('Segment not found')).toBeVisible()
   })
 
-  it('synchronizes valid elevation hover coordinates with the map', async () => {
+  it('synchronizes elevation hover coordinates with the map and address', async () => {
     const user = userEvent.setup()
     renderDetail()
 
     expect(screen.getByTestId('segment-map')).toHaveTextContent('marker: none')
+    expect(screen.getByTestId('segment-point-address')).toHaveTextContent(
+      'start: 40.79, -73.96',
+    )
 
     await user.click(
       screen.getByRole('button', { name: 'Hover valid elevation point' }),
@@ -254,11 +272,17 @@ describe('GarminSegmentDetailPage', () => {
     expect(screen.getByTestId('segment-map')).toHaveTextContent(
       'marker: 40.795, -73.965',
     )
+    expect(screen.getByTestId('segment-point-address')).toHaveTextContent(
+      'selected: 40.795, -73.965',
+    )
 
     await user.click(
       screen.getByRole('button', { name: 'Hover invalid elevation point' }),
     )
     expect(screen.getByTestId('segment-map')).toHaveTextContent('marker: none')
+    expect(screen.getByTestId('segment-point-address')).toHaveTextContent(
+      'start: 40.79, -73.96',
+    )
 
     await user.click(
       screen.getByRole('button', { name: 'Hover valid elevation point' }),
@@ -267,6 +291,9 @@ describe('GarminSegmentDetailPage', () => {
       screen.getByRole('button', { name: 'Leave elevation profile' }),
     )
     expect(screen.getByTestId('segment-map')).toHaveTextContent('marker: none')
+    expect(screen.getByTestId('segment-point-address')).toHaveTextContent(
+      'start: 40.79, -73.96',
+    )
 
     await user.click(
       screen.getByRole('button', { name: 'Hover valid elevation point' }),

--- a/src/pages/GarminSegmentDetailPage.tsx
+++ b/src/pages/GarminSegmentDetailPage.tsx
@@ -20,6 +20,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { SegmentStartEndMap } from '@/components/garmin/SegmentStartEndMap'
 import { SegmentElevationProfile } from '@/components/garmin/SegmentElevationProfile'
 import type { SegmentElevationChartPoint } from '@/components/garmin/SegmentElevationProfile.helpers'
+import { SegmentPointAddress } from '@/components/garmin/SegmentPointAddress'
 import { SegmentEffortsLeaderboard } from '@/components/garmin/SegmentEffortsLeaderboard'
 import { DeleteSegmentButton } from '@/components/garmin/DeleteSegmentButton'
 import {
@@ -166,6 +167,11 @@ export function GarminSegmentDetailPage() {
     )
   }
 
+  const addressLatLng = activeLatLng ?? {
+    lat: segment.start_latitude,
+    lng: segment.start_longitude,
+  }
+
   let effortsStatusNode: ReactNode = null
   if (effortsLoading && !effortsData) {
     effortsStatusNode = <LoadingState message="Loading efforts..." />
@@ -219,6 +225,11 @@ export function GarminSegmentDetailPage() {
               endLon={segment.end_longitude}
               routePoints={routePoints}
               activeLatLng={activeLatLng}
+            />
+            <SegmentPointAddress
+              latitude={addressLatLng.lat}
+              longitude={addressLatLng.lng}
+              selected={activeLatLng != null}
             />
             <SegmentElevationProfile
               routePoints={routePoints}


### PR DESCRIPTION
## Summary
- display the Segment start-point address directly below the route map
- update the address to the elevation crosshair point and restore the cached start address when the crosshair clears
- share the Activity page's debounced, cached reverse-geocoding behavior and add coordinate validation
- cover the component, page synchronization, and deployed-style interaction with unit and Playwright tests

## Validation
- `npm run lint:all`
- `npm run type-check`
- `npm run build`
- `npm run test:run` (62 files, 472 tests)
- focused Vitest (3 files, 15 tests)
- local Playwright Segment route-map acceptance test (1 passed)
- `git diff --check`

Refs #455
