### PR TITLE
feat(garmin): use persisted point geocoding

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -31,6 +31,52 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event.pull_request.user.login == 'stuartshay'
     steps:
+      - name: Request Copilot review
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const prNumber = context.payload.pull_request.number;
+            const copilotLogin = 'copilot-pull-request-reviewer[bot]';
+
+            const { data: reviews } = await github.rest.pulls.listReviews({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: prNumber,
+            });
+
+            const existingReview = reviews.some(
+              review => review.user?.login === copilotLogin && review.state !== 'DISMISSED'
+            );
+
+            if (existingReview) {
+              core.info('Copilot review already exists');
+              return;
+            }
+
+            const { data: requestedReviewers } = await github.rest.pulls.listRequestedReviewers({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: prNumber,
+            });
+
+            const existingRequest = requestedReviewers.users.some(
+              reviewer => reviewer.login === copilotLogin
+            );
+
+            if (existingRequest) {
+              core.info('Copilot review already requested');
+              return;
+            }
+
+            await github.rest.pulls.requestReviewers({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: prNumber,
+              reviewers: [copilotLogin],
+            });
+
+            core.info('Requested Copilot review');
+
       - name: Wait for Copilot review
         uses: actions/github-script@v9
         with:

--- a/e2e/garmin-segment-route-map.spec.ts
+++ b/e2e/garmin-segment-route-map.spec.ts
@@ -99,8 +99,8 @@ test.describe('Garmin segment route map', () => {
         }
       }
     }
-    expect(selectedResponseBody.data?.reverseGeocodePoint?.status).toBe(
-      'success',
+    expect(['success', 'no_coverage']).toContain(
+      selectedResponseBody.data?.reverseGeocodePoint?.status,
     )
     expect(['database', 'pelias']).toContain(
       selectedResponseBody.data?.reverseGeocodePoint?.resolution_source,

--- a/e2e/garmin-segment-route-map.spec.ts
+++ b/e2e/garmin-segment-route-map.spec.ts
@@ -73,7 +73,9 @@ test.describe('Garmin segment route map', () => {
     if (!chartBox) throw new Error('Segment elevation chart unavailable')
     const selectedAddressResponse = page.waitForResponse(
       (response) =>
-        response.url().includes('/v1/reverse?') && response.status() === 200,
+        response.request().method() === 'POST' &&
+        (response.request().postData() ?? '').includes('ReverseGeocodePoint') &&
+        response.status() === 200,
     )
     await page.mouse.move(
       chartBox.x + chartBox.width / 2,
@@ -88,7 +90,21 @@ test.describe('Garmin segment route map', () => {
       elevationProfile.locator('.recharts-tooltip-cursor'),
     ).toHaveCount(1, { timeout: 5_000 })
     await expect(pointAddress.getByText('Selected point address')).toBeVisible()
-    await selectedAddressResponse
+    const selectedResponse = await selectedAddressResponse
+    const selectedResponseBody = (await selectedResponse.json()) as {
+      data?: {
+        reverseGeocodePoint?: {
+          status?: string
+          resolution_source?: string
+        }
+      }
+    }
+    expect(selectedResponseBody.data?.reverseGeocodePoint?.status).toBe(
+      'success',
+    )
+    expect(['database', 'pelias']).toContain(
+      selectedResponseBody.data?.reverseGeocodePoint?.resolution_source,
+    )
     await expect(addressValue).not.toHaveText('Resolving…', {
       timeout: 10_000,
     })

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@fontsource-variable/geist": "^5.2.8",
         "@newrelic/browser-agent": "^1.314.0",
         "@radix-ui/react-slot": "^1.3.0",
-        "@stuartshay/otel-graphql-types": "1.0.489",
+        "@stuartshay/otel-graphql-types": "1.0.590",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "date-fns": "^4.1.0",
@@ -6431,9 +6431,9 @@
       "license": "MIT"
     },
     "node_modules/@stuartshay/otel-graphql-types": {
-      "version": "1.0.489",
-      "resolved": "https://registry.npmjs.org/@stuartshay/otel-graphql-types/-/otel-graphql-types-1.0.489.tgz",
-      "integrity": "sha512-4lLDdhj95/vMZ/h6XIG19JCx/1Ww9pEFX7fh0MU6WUY9UiNLwXAb8uGDHbTDoAhwrbBROa1P1O0ZuIHfZMbxKg==",
+      "version": "1.0.590",
+      "resolved": "https://registry.npmjs.org/@stuartshay/otel-graphql-types/-/otel-graphql-types-1.0.590.tgz",
+      "integrity": "sha512-LoUteJb0dk/wWkidvuUOVkhC6IDXz2jLGRxNSwqBBes1atURRBAdunkn5/rsqbvvgQ4FZ9+OTr16CZRdSwmKww==",
       "license": "MIT"
     },
     "node_modules/@tailwindcss/node": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@fontsource-variable/geist": "^5.2.8",
     "@newrelic/browser-agent": "^1.314.0",
     "@radix-ui/react-slot": "^1.3.0",
-    "@stuartshay/otel-graphql-types": "1.0.489",
+    "@stuartshay/otel-graphql-types": "1.0.590",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "date-fns": "^4.1.0",

--- a/src/__generated__/graphql.ts
+++ b/src/__generated__/graphql.ts
@@ -826,6 +826,39 @@ export type GeocodedAddressSummary = {
   waypoint_kind?: Maybe<Scalars['String']['output']>;
 };
 
+/** Reverse-geocoded address for a 4-decimal coordinate cell. */
+export type GeocodedPointAddress = {
+  __typename?: 'GeocodedPointAddress';
+  /** Pelias confidence score from 0 to 1. */
+  confidence?: Maybe<Scalars['Float']['output']>;
+  /** Country name. */
+  country?: Maybe<Scalars['String']['output']>;
+  /** Full formatted address label. */
+  display_address?: Maybe<Scalars['String']['output']>;
+  /** UTC timestamp when geocoding was performed. */
+  geocoded_at?: Maybe<Scalars['String']['output']>;
+  /** House or building number. */
+  housenumber?: Maybe<Scalars['String']['output']>;
+  /** Resolved 4-decimal cell latitude. */
+  latitude: Scalars['Float']['output'];
+  /** City or town. */
+  locality?: Maybe<Scalars['String']['output']>;
+  /** Resolved 4-decimal cell longitude. */
+  longitude: Scalars['Float']['output'];
+  /** Neighbourhood name. */
+  neighbourhood?: Maybe<Scalars['String']['output']>;
+  /** Postal or ZIP code. */
+  postalcode?: Maybe<Scalars['String']['output']>;
+  /** State or province. */
+  region?: Maybe<Scalars['String']['output']>;
+  /** Whether the address came from the cache or Pelias fallback. */
+  resolution_source: PointAddressSource;
+  /** Geocoding status: success, no_coverage, error, or pending. */
+  status: Scalars['String']['output'];
+  /** Street name. */
+  street?: Maybe<Scalars['String']['output']>;
+};
+
 /** Coverage statistics for a single geocoding source (owntracks or garmin). */
 export type GeocodingSourceStatus = {
   __typename?: 'GeocodingSourceStatus';
@@ -1068,6 +1101,13 @@ export type PaginationInfo = {
   total: Scalars['Int']['output'];
 };
 
+/** Source used to resolve a point address. */
+export type PointAddressSource =
+  /** Address was returned from the persisted dense-cell cache. */
+  | 'database'
+  /** Address was resolved through the Pelias fallback and persisted. */
+  | 'pelias';
+
 export type Query = {
   __typename?: 'Query';
   /** Calculate the geodesic distance between two geographic points. */
@@ -1140,6 +1180,11 @@ export type Query = {
   referenceLocation?: Maybe<ReferenceLocation>;
   /** List all named reference locations. */
   referenceLocations: Array<ReferenceLocation>;
+  /**
+   * Resolve an address from the dense point-cell cache, with Pelias fallback.
+   * Requires the caller's Authorization header because a fallback can persist data.
+   */
+  reverseGeocodePoint: GeocodedPointAddress;
   /** Retrieve a paginated list of unified GPS points from all sources. */
   unifiedGps: UnifiedGpsConnection;
   /** Find GPS points within a named reference location's geofence. */
@@ -1291,6 +1336,12 @@ export type QueryReferenceLocationArgs = {
 };
 
 
+export type QueryReverseGeocodePointArgs = {
+  latitude: Scalars['Float']['input'];
+  longitude: Scalars['Float']['input'];
+};
+
+
 export type QueryUnifiedGpsArgs = {
   date_from?: InputMaybe<Scalars['String']['input']>;
   date_to?: InputMaybe<Scalars['String']['input']>;
@@ -1409,6 +1460,8 @@ export type WithinReferenceResult = {
 };
 
 /** Input for creating a saved Garmin segment (e.g. from an activity lap or climb). */
+
+/** Source used to resolve a point address. */
 
 /** Sort direction for query results. */
 
@@ -1536,6 +1589,14 @@ export type GeocodingStatusQueryVariables = Exact<{ [key: string]: never; }>;
 
 
 export type GeocodingStatusQuery = { geocodingStatus: { total_locations: number, geocoded: number, success: number, pending: number, no_coverage: number, errors: number, coverage_percent: number } };
+
+export type ReverseGeocodePointQueryVariables = Exact<{
+  latitude: number;
+  longitude: number;
+}>;
+
+
+export type ReverseGeocodePointQuery = { reverseGeocodePoint: { latitude: number, longitude: number, display_address: string | null, status: string, resolution_source: PointAddressSource } };
 
 export type TriggerGeocodingMutationVariables = Exact<{
   batch_size?: number | null | undefined;
@@ -2676,6 +2737,54 @@ export type GeocodingStatusQueryHookResult = ReturnType<typeof useGeocodingStatu
 export type GeocodingStatusLazyQueryHookResult = ReturnType<typeof useGeocodingStatusLazyQuery>;
 export type GeocodingStatusSuspenseQueryHookResult = ReturnType<typeof useGeocodingStatusSuspenseQuery>;
 export type GeocodingStatusQueryResult = ApolloReactCommon.QueryResult<GeocodingStatusQuery, GeocodingStatusQueryVariables>;
+export const ReverseGeocodePointDocument = gql`
+    query ReverseGeocodePoint($latitude: Float!, $longitude: Float!) {
+  reverseGeocodePoint(latitude: $latitude, longitude: $longitude) {
+    latitude
+    longitude
+    display_address
+    status
+    resolution_source
+  }
+}
+    `;
+
+/**
+ * __useReverseGeocodePointQuery__
+ *
+ * To run a query within a React component, call `useReverseGeocodePointQuery` and pass it any options that fit your needs.
+ * When your component renders, `useReverseGeocodePointQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useReverseGeocodePointQuery({
+ *   variables: {
+ *      latitude: // value for 'latitude'
+ *      longitude: // value for 'longitude'
+ *   },
+ * });
+ */
+export function useReverseGeocodePointQuery(baseOptions: ApolloReactHooks.QueryHookOptions<ReverseGeocodePointQuery, ReverseGeocodePointQueryVariables> & ({ variables: ReverseGeocodePointQueryVariables; skip?: boolean; } | { skip: boolean; }) ) {
+        const options = {...defaultOptions, ...baseOptions}
+        return ApolloReactHooks.useQuery<ReverseGeocodePointQuery, ReverseGeocodePointQueryVariables>(ReverseGeocodePointDocument, options);
+      }
+export function useReverseGeocodePointLazyQuery(baseOptions?: ApolloReactHooks.LazyQueryHookOptions<ReverseGeocodePointQuery, ReverseGeocodePointQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return ApolloReactHooks.useLazyQuery<ReverseGeocodePointQuery, ReverseGeocodePointQueryVariables>(ReverseGeocodePointDocument, options);
+        }
+// @ts-ignore
+export function useReverseGeocodePointSuspenseQuery(baseOptions?: ApolloReactHooks.SuspenseQueryHookOptions<ReverseGeocodePointQuery, ReverseGeocodePointQueryVariables>): ApolloReactHooks.UseSuspenseQueryResult<ReverseGeocodePointQuery, ReverseGeocodePointQueryVariables>;
+export function useReverseGeocodePointSuspenseQuery(baseOptions?: ApolloReactHooks.SkipToken | ApolloReactHooks.SuspenseQueryHookOptions<ReverseGeocodePointQuery, ReverseGeocodePointQueryVariables>): ApolloReactHooks.UseSuspenseQueryResult<ReverseGeocodePointQuery | undefined, ReverseGeocodePointQueryVariables>;
+export function useReverseGeocodePointSuspenseQuery(baseOptions?: ApolloReactHooks.SkipToken | ApolloReactHooks.SuspenseQueryHookOptions<ReverseGeocodePointQuery, ReverseGeocodePointQueryVariables>) {
+          const options = baseOptions === ApolloReactHooks.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
+          return ApolloReactHooks.useSuspenseQuery<ReverseGeocodePointQuery, ReverseGeocodePointQueryVariables>(ReverseGeocodePointDocument, options);
+        }
+export type ReverseGeocodePointQueryHookResult = ReturnType<typeof useReverseGeocodePointQuery>;
+export type ReverseGeocodePointLazyQueryHookResult = ReturnType<typeof useReverseGeocodePointLazyQuery>;
+export type ReverseGeocodePointSuspenseQueryHookResult = ReturnType<typeof useReverseGeocodePointSuspenseQuery>;
+export type ReverseGeocodePointQueryResult = ApolloReactCommon.QueryResult<ReverseGeocodePointQuery, ReverseGeocodePointQueryVariables>;
 export const TriggerGeocodingDocument = gql`
     mutation TriggerGeocoding($batch_size: Int, $retry_failed: Boolean) {
   triggerGeocoding(batch_size: $batch_size, retry_failed: $retry_failed) {

--- a/src/components/garmin/ActivityHoverDetails.test.tsx
+++ b/src/components/garmin/ActivityHoverDetails.test.tsx
@@ -2,11 +2,13 @@ import { render, screen, waitFor } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { ChartDataPoint } from './ActivityChartData'
 
-const geocoderMocks = vi.hoisted(() => ({
-  reverseGeocode: vi.fn(),
+const graphqlMocks = vi.hoisted(() => ({
+  reverseGeocodePoint: vi.fn(),
 }))
 
-vi.mock('@/services/geocoder', () => geocoderMocks)
+vi.mock('@/__generated__/graphql', () => ({
+  useReverseGeocodePointLazyQuery: () => [graphqlMocks.reverseGeocodePoint],
+}))
 
 import { ActivityHoverDetails } from './ActivityHoverDetails'
 
@@ -30,7 +32,7 @@ function chartPoint(overrides: Partial<ChartDataPoint> = {}): ChartDataPoint {
 
 describe('ActivityHoverDetails', () => {
   beforeEach(() => {
-    geocoderMocks.reverseGeocode.mockReset()
+    graphqlMocks.reverseGeocodePoint.mockReset()
   })
 
   it('shows instructional copy when no point is selected', () => {
@@ -39,19 +41,20 @@ describe('ActivityHoverDetails', () => {
     expect(
       screen.getByText(/Hover the Elevation or Speed chart/i),
     ).toBeInTheDocument()
-    expect(geocoderMocks.reverseGeocode).not.toHaveBeenCalled()
+    expect(graphqlMocks.reverseGeocodePoint).not.toHaveBeenCalled()
   })
 
   it('renders metrics and resolves the point address', async () => {
-    geocoderMocks.reverseGeocode.mockResolvedValue({
-      type: 'FeatureCollection',
-      features: [
-        {
-          properties: {
-            label: 'Brooklyn Bridge, New York, NY, USA',
-          },
+    graphqlMocks.reverseGeocodePoint.mockResolvedValue({
+      data: {
+        reverseGeocodePoint: {
+          latitude: 40.7123,
+          longitude: -74.0057,
+          display_address: 'Brooklyn Bridge, New York, NY, USA',
+          status: 'success',
+          resolution_source: 'database',
         },
-      ],
+      },
     })
 
     render(<ActivityHoverDetails point={chartPoint()} />)
@@ -65,11 +68,9 @@ describe('ActivityHoverDetails', () => {
     expect(screen.getByText('Resolving…')).toBeInTheDocument()
 
     await waitFor(() =>
-      expect(geocoderMocks.reverseGeocode).toHaveBeenCalledWith(
-        40.7123,
-        -74.0057,
-        1,
-      ),
+      expect(graphqlMocks.reverseGeocodePoint).toHaveBeenCalledWith({
+        variables: { latitude: 40.7123, longitude: -74.0057 },
+      }),
     )
     expect(
       await screen.findByText('Brooklyn Bridge, New York, NY, USA'),
@@ -77,9 +78,16 @@ describe('ActivityHoverDetails', () => {
   })
 
   it('shows empty, unavailable, and missing metric fallbacks', async () => {
-    geocoderMocks.reverseGeocode.mockResolvedValueOnce({
-      type: 'FeatureCollection',
-      features: [],
+    graphqlMocks.reverseGeocodePoint.mockResolvedValueOnce({
+      data: {
+        reverseGeocodePoint: {
+          latitude: 40.7129,
+          longitude: -74.0061,
+          display_address: null,
+          status: 'no_coverage',
+          resolution_source: 'pelias',
+        },
+      },
     })
 
     const { rerender } = render(
@@ -101,7 +109,7 @@ describe('ActivityHoverDetails', () => {
     expect(screen.getAllByText('—')).toHaveLength(6)
     expect(await screen.findByText('No address found')).toBeInTheDocument()
 
-    geocoderMocks.reverseGeocode.mockRejectedValueOnce(new Error('offline'))
+    graphqlMocks.reverseGeocodePoint.mockRejectedValueOnce(new Error('offline'))
     rerender(
       <ActivityHoverDetails
         point={chartPoint({ latitude: 40.71341, longitude: -74.00661 })}

--- a/src/components/garmin/SegmentPointAddress.test.tsx
+++ b/src/components/garmin/SegmentPointAddress.test.tsx
@@ -1,25 +1,34 @@
 import { act, render, screen } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-const geocoderMocks = vi.hoisted(() => ({
-  reverseGeocode: vi.fn(),
+const graphqlMocks = vi.hoisted(() => ({
+  reverseGeocodePoint: vi.fn(),
 }))
 
-vi.mock('@/services/geocoder', () => geocoderMocks)
+vi.mock('@/__generated__/graphql', () => ({
+  useReverseGeocodePointLazyQuery: () => [graphqlMocks.reverseGeocodePoint],
+}))
 
 import { SegmentPointAddress } from './SegmentPointAddress'
 
 function geocoderResponse(label?: string) {
   return {
-    type: 'FeatureCollection',
-    features: label ? [{ properties: { label } }] : [],
+    data: {
+      reverseGeocodePoint: {
+        latitude: 40.7306,
+        longitude: -73.9352,
+        display_address: label ?? null,
+        status: label ? 'success' : 'no_coverage',
+        resolution_source: label ? 'database' : 'pelias',
+      },
+    },
   }
 }
 
 describe('SegmentPointAddress', () => {
   beforeEach(() => {
     vi.useRealTimers()
-    geocoderMocks.reverseGeocode.mockReset()
+    graphqlMocks.reverseGeocodePoint.mockReset()
   })
 
   afterEach(() => {
@@ -27,7 +36,7 @@ describe('SegmentPointAddress', () => {
   })
 
   it('resolves the start address, follows selection, and restores the cache', async () => {
-    geocoderMocks.reverseGeocode
+    graphqlMocks.reverseGeocodePoint
       .mockResolvedValueOnce(geocoderResponse('5th Ave, New York, NY, USA'))
       .mockResolvedValueOnce(
         geocoderResponse('Central Park, New York, NY, USA'),
@@ -46,12 +55,9 @@ describe('SegmentPointAddress', () => {
     expect(
       await screen.findByText('5th Ave, New York, NY, USA'),
     ).toBeInTheDocument()
-    expect(geocoderMocks.reverseGeocode).toHaveBeenNthCalledWith(
-      1,
-      40.7306,
-      -73.9352,
-      1,
-    )
+    expect(graphqlMocks.reverseGeocodePoint).toHaveBeenNthCalledWith(1, {
+      variables: { latitude: 40.7306, longitude: -73.9352 },
+    })
 
     rerender(
       <SegmentPointAddress
@@ -65,12 +71,9 @@ describe('SegmentPointAddress', () => {
     expect(
       await screen.findByText('Central Park, New York, NY, USA'),
     ).toBeInTheDocument()
-    expect(geocoderMocks.reverseGeocode).toHaveBeenNthCalledWith(
-      2,
-      40.7711,
-      -73.9742,
-      1,
-    )
+    expect(graphqlMocks.reverseGeocodePoint).toHaveBeenNthCalledWith(2, {
+      variables: { latitude: 40.7711, longitude: -73.9742 },
+    })
 
     rerender(
       <SegmentPointAddress
@@ -82,7 +85,7 @@ describe('SegmentPointAddress', () => {
 
     expect(screen.getByText('Start point address')).toBeInTheDocument()
     expect(screen.getByText('5th Ave, New York, NY, USA')).toBeInTheDocument()
-    expect(geocoderMocks.reverseGeocode).toHaveBeenCalledTimes(2)
+    expect(graphqlMocks.reverseGeocodePoint).toHaveBeenCalledTimes(2)
   })
 
   it('handles invalid coordinates, empty results, and geocoder errors', async () => {
@@ -97,9 +100,9 @@ describe('SegmentPointAddress', () => {
     expect(screen.getByTestId('segment-point-address-value')).toHaveTextContent(
       '—',
     )
-    expect(geocoderMocks.reverseGeocode).not.toHaveBeenCalled()
+    expect(graphqlMocks.reverseGeocodePoint).not.toHaveBeenCalled()
 
-    geocoderMocks.reverseGeocode.mockResolvedValueOnce(geocoderResponse())
+    graphqlMocks.reverseGeocodePoint.mockResolvedValueOnce(geocoderResponse())
     rerender(
       <SegmentPointAddress
         latitude={40.70011}
@@ -109,7 +112,10 @@ describe('SegmentPointAddress', () => {
     )
     expect(await screen.findByText('No address found')).toBeInTheDocument()
 
-    geocoderMocks.reverseGeocode.mockRejectedValueOnce(new Error('offline'))
+    graphqlMocks.reverseGeocodePoint.mockResolvedValueOnce({
+      data: undefined,
+      error: new Error('offline'),
+    })
     rerender(
       <SegmentPointAddress
         latitude={40.70021}
@@ -122,7 +128,7 @@ describe('SegmentPointAddress', () => {
 
   it('debounces rapid coordinate changes and resolves only the latest point', async () => {
     vi.useFakeTimers()
-    geocoderMocks.reverseGeocode.mockResolvedValue(
+    graphqlMocks.reverseGeocodePoint.mockResolvedValue(
       geocoderResponse('Latest selected point, New York, NY, USA'),
     )
 
@@ -143,12 +149,10 @@ describe('SegmentPointAddress', () => {
 
     await act(async () => vi.advanceTimersByTimeAsync(250))
 
-    expect(geocoderMocks.reverseGeocode).toHaveBeenCalledOnce()
-    expect(geocoderMocks.reverseGeocode).toHaveBeenCalledWith(
-      40.7202,
-      -73.9102,
-      1,
-    )
+    expect(graphqlMocks.reverseGeocodePoint).toHaveBeenCalledOnce()
+    expect(graphqlMocks.reverseGeocodePoint).toHaveBeenCalledWith({
+      variables: { latitude: 40.7202, longitude: -73.9102 },
+    })
     expect(
       screen.getByText('Latest selected point, New York, NY, USA'),
     ).toBeInTheDocument()

--- a/src/components/garmin/SegmentPointAddress.test.tsx
+++ b/src/components/garmin/SegmentPointAddress.test.tsx
@@ -11,14 +11,17 @@ vi.mock('@/__generated__/graphql', () => ({
 
 import { SegmentPointAddress } from './SegmentPointAddress'
 
-function geocoderResponse(label?: string) {
+function geocoderResponse(
+  label?: string,
+  status = label ? 'success' : 'no_coverage',
+) {
   return {
     data: {
       reverseGeocodePoint: {
         latitude: 40.7306,
         longitude: -73.9352,
         display_address: label ?? null,
-        status: label ? 'success' : 'no_coverage',
+        status,
         resolution_source: label ? 'database' : 'pelias',
       },
     },
@@ -125,6 +128,50 @@ describe('SegmentPointAddress', () => {
     )
     expect(await screen.findByText('Unavailable')).toBeInTheDocument()
   })
+
+  it.each([
+    { status: 'error', latitude: 40.6801 },
+    { status: 'pending', latitude: 40.6802 },
+  ])(
+    'shows $status as unavailable without caching it',
+    async ({ status, latitude }) => {
+      graphqlMocks.reverseGeocodePoint
+        .mockResolvedValueOnce(geocoderResponse(undefined, status))
+        .mockResolvedValueOnce(
+          geocoderResponse('Recovered point, New York, NY, USA'),
+        )
+
+      const { rerender } = render(
+        <SegmentPointAddress
+          latitude={latitude}
+          longitude={-73.9501}
+          selected
+        />,
+      )
+
+      expect(await screen.findByText('Unavailable')).toBeInTheDocument()
+
+      rerender(
+        <SegmentPointAddress
+          latitude={Number.NaN}
+          longitude={-73.9501}
+          selected={false}
+        />,
+      )
+      rerender(
+        <SegmentPointAddress
+          latitude={latitude}
+          longitude={-73.9501}
+          selected
+        />,
+      )
+
+      expect(
+        await screen.findByText('Recovered point, New York, NY, USA'),
+      ).toBeInTheDocument()
+      expect(graphqlMocks.reverseGeocodePoint).toHaveBeenCalledTimes(2)
+    },
+  )
 
   it('debounces rapid coordinate changes and resolves only the latest point', async () => {
     vi.useFakeTimers()

--- a/src/components/garmin/useReverseGeocodedAddress.ts
+++ b/src/components/garmin/useReverseGeocodedAddress.ts
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
-import { reverseGeocode } from '@/services/geocoder'
+import { useReverseGeocodePointLazyQuery } from '@/__generated__/graphql'
 
 export type ReverseGeocodedAddressState =
   | { status: 'idle' }
@@ -53,6 +53,9 @@ export function useReverseGeocodedAddress(
   latitude: number | null | undefined,
   longitude: number | null | undefined,
 ): ReverseGeocodedAddressState {
+  const [reverseGeocodePoint] = useReverseGeocodePointLazyQuery({
+    fetchPolicy: 'no-cache',
+  })
   const target = useMemo(
     () => coordinateTarget(latitude, longitude),
     [latitude, longitude],
@@ -72,14 +75,18 @@ export function useReverseGeocodedAddress(
 
     const timer = window.setTimeout(async () => {
       try {
-        const response = await reverseGeocode(
-          target.latitude,
-          target.longitude,
-          1,
-        )
+        const response = await reverseGeocodePoint({
+          variables: {
+            latitude: target.latitude,
+            longitude: target.longitude,
+          },
+        })
         if (controller.signal.aborted) return
+        if (response.error) throw response.error
 
-        const label = response.features[0]?.properties?.label ?? null
+        const point = response.data?.reverseGeocodePoint
+        const label =
+          point?.status === 'success' ? (point.display_address ?? null) : null
         addressCache.set(target.key, label)
         setPendingState({
           key: target.key,
@@ -95,7 +102,7 @@ export function useReverseGeocodedAddress(
       window.clearTimeout(timer)
       controller.abort()
     }
-  }, [target])
+  }, [reverseGeocodePoint, target])
 
   if (!target) return { status: 'idle' }
   if (addressCache.has(target.key)) {

--- a/src/components/garmin/useReverseGeocodedAddress.ts
+++ b/src/components/garmin/useReverseGeocodedAddress.ts
@@ -85,8 +85,16 @@ export function useReverseGeocodedAddress(
         if (response.error) throw response.error
 
         const point = response.data?.reverseGeocodePoint
+        if (
+          !point ||
+          (point.status !== 'success' && point.status !== 'no_coverage')
+        ) {
+          setPendingState({ key: target.key, state: { status: 'error' } })
+          return
+        }
+
         const label =
-          point?.status === 'success' ? (point.display_address ?? null) : null
+          point.status === 'success' ? (point.display_address ?? null) : null
         addressCache.set(target.key, label)
         setPendingState({
           key: target.key,

--- a/src/graphql/geocoding.ts
+++ b/src/graphql/geocoding.ts
@@ -14,6 +14,18 @@ export const GEOCODING_STATUS_QUERY = gql`
   }
 `
 
+export const REVERSE_GEOCODE_POINT_QUERY = gql`
+  query ReverseGeocodePoint($latitude: Float!, $longitude: Float!) {
+    reverseGeocodePoint(latitude: $latitude, longitude: $longitude) {
+      latitude
+      longitude
+      display_address
+      status
+      resolution_source
+    }
+  }
+`
+
 export const TRIGGER_GEOCODING_MUTATION = gql`
   mutation TriggerGeocoding($batch_size: Int, $retry_failed: Boolean) {
     triggerGeocoding(batch_size: $batch_size, retry_failed: $retry_failed) {

--- a/src/pages/GarminDetailPage.test.tsx
+++ b/src/pages/GarminDetailPage.test.tsx
@@ -13,6 +13,8 @@ const garminDetailHooks = vi.hoisted(() => ({
   useGarminActivityWeatherQuery: vi.fn(),
   useGarminActivityWeatherHourlyQuery: vi.fn(),
   useGarminExportPointsLazyQuery: vi.fn(),
+  useReverseGeocodePointLazyQuery: vi.fn(),
+  reverseGeocodePoint: vi.fn(),
 }))
 const toastMocks = vi.hoisted(() => ({
   error: vi.fn(),
@@ -21,9 +23,6 @@ const toastMocks = vi.hoisted(() => ({
 
 vi.mock('@/__generated__/graphql', () => garminDetailHooks)
 vi.mock('sonner', () => ({ toast: toastMocks }))
-vi.mock('@/services/geocoder', () => ({
-  reverseGeocode: vi.fn().mockResolvedValue({ features: [] }),
-}))
 
 vi.mock('@/components/garmin/ActivityHeader', () => ({
   ActivityHeader: ({ backTo, sport }: { backTo: string; sport: string }) => (
@@ -190,6 +189,8 @@ describe('GarminDetailPage', () => {
     garminDetailHooks.useGarminActivityWeatherQuery.mockReset()
     garminDetailHooks.useGarminActivityWeatherHourlyQuery.mockReset()
     garminDetailHooks.useGarminExportPointsLazyQuery.mockReset()
+    garminDetailHooks.useReverseGeocodePointLazyQuery.mockReset()
+    garminDetailHooks.reverseGeocodePoint.mockReset()
     toastMocks.error.mockReset()
     toastMocks.warning.mockReset()
 
@@ -197,6 +198,18 @@ describe('GarminDetailPage', () => {
     garminDetailHooks.useGarminExportPointsLazyQuery.mockReturnValue([
       vi.fn(),
       { loading: false },
+    ])
+    garminDetailHooks.reverseGeocodePoint.mockResolvedValue({
+      data: {
+        reverseGeocodePoint: {
+          display_address: null,
+          status: 'no_coverage',
+          resolution_source: 'pelias',
+        },
+      },
+    })
+    garminDetailHooks.useReverseGeocodePointLazyQuery.mockReturnValue([
+      garminDetailHooks.reverseGeocodePoint,
     ])
     garminDetailHooks.useGarminActivityClimbsQuery.mockReturnValue({
       loading: false,


### PR DESCRIPTION
## Summary

- replace direct browser Pelias lookups for Segment and Activity hover addresses with the authenticated `reverseGeocodePoint` GraphQL query
- preserve the existing 250 ms debounce, 4-decimal coordinate cache, stale-response guard, and user-facing loading/error states
- consume `@stuartshay/otel-graphql-types@1.0.590` and regenerate Apollo operation types
- update unit, page-integration, and Playwright coverage to validate the GraphQL response and resolution source

## Data flow

The UI now calls the gateway. The API checks `public.geocoded_point_cells` first and performs the persisted Pelias fallback only when the cell is missing. This removes direct Pelias traffic from the elevation crosshair path while retaining fallback behavior server-side.

## Validation

- `npm run codegen` (reproducible)
- `npm run lint:all`
- `npm run type-check`
- `npm run build`
- `npm run test:run` (62 files, 472 tests)
- focused integration rerun after the GraphQL error-path assertion (3 files, 27 tests)
- `git diff --check`

Production Playwright acceptance remains a post-deployment gate because the new operation requires a live Cognito bearer token.

## Contract propagation

- API: stuartshay/otel-data-api#223
- Gateway: stuartshay/otel-data-gateway#203
- Gateway deployment: stuartshay/k8s-gitops#1005
- GraphQL types handoff: #457 (`1.0.590`)

Refs #455