### PR TITLE
feat(garmin): add route playback to segment elevation profile

### DIFF
--- a/src/components/garmin/SegmentElevationProfile.test.tsx
+++ b/src/components/garmin/SegmentElevationProfile.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { describe, expect, it, vi } from 'vitest'
 import { SegmentElevationProfile } from './SegmentElevationProfile'
@@ -37,6 +37,9 @@ vi.mock('recharts', () => ({
   ),
   Area: () => null,
   CartesianGrid: () => null,
+  ReferenceDot: ({ x, y }: { x: number; y: number }) => (
+    <div data-testid="elevation-playing-dot" data-x={x} data-y={y} />
+  ),
   Tooltip: ({
     formatter,
     labelFormatter,
@@ -278,6 +281,97 @@ describe('SegmentElevationProfile', () => {
 
     expect(requestFrame).not.toHaveBeenCalled()
     requestFrame.mockRestore()
+  })
+
+  it('animates the active point from start to finish when Play is clicked', async () => {
+    const frameCallbacks: FrameRequestCallback[] = []
+    const requestFrame = vi
+      .spyOn(window, 'requestAnimationFrame')
+      .mockImplementation((callback) => {
+        frameCallbacks.push(callback)
+        return frameCallbacks.length
+      })
+    const now = vi.spyOn(performance, 'now').mockReturnValue(0)
+    const onActivePointChange = vi.fn()
+    const user = userEvent.setup()
+
+    render(
+      <SegmentElevationProfile
+        routePoints={routePoints}
+        onActivePointChange={onActivePointChange}
+      />,
+    )
+
+    await user.click(
+      screen.getByRole('button', { name: 'Play route playback' }),
+    )
+    expect(requestFrame).toHaveBeenCalledTimes(1)
+
+    // Run the first queued frame at t=0 (start of the animation).
+    act(() => frameCallbacks.shift()?.(0))
+    // queueActivePointChange defers the actual callback by one more frame.
+    act(() => frameCallbacks.shift()?.(0))
+    expect(
+      screen.getByRole('button', { name: 'Pause route playback' }),
+    ).toBeVisible()
+    expect(screen.getByTestId('elevation-playing-dot')).toBeInTheDocument()
+    expect(onActivePointChange).toHaveBeenLastCalledWith(
+      expect.objectContaining({ latitude: 40.79, longitude: -73.96 }),
+    )
+
+    // Advance to the end of the animation window; playback should stop and
+    // report the final profile point.
+    now.mockReturnValue(6000)
+    act(() => frameCallbacks.shift()?.(6000))
+    act(() => frameCallbacks.shift()?.(6000))
+
+    expect(onActivePointChange).toHaveBeenLastCalledWith(
+      expect.objectContaining({ latitude: null, longitude: null }),
+    )
+    expect(
+      screen.getByRole('button', { name: 'Play route playback' }),
+    ).toBeVisible()
+    expect(
+      screen.queryByTestId('elevation-playing-dot'),
+    ).not.toBeInTheDocument()
+
+    requestFrame.mockRestore()
+    now.mockRestore()
+  })
+
+  it('stops playback when the user hovers the chart manually', async () => {
+    const frameCallbacks: FrameRequestCallback[] = []
+    const requestFrame = vi
+      .spyOn(window, 'requestAnimationFrame')
+      .mockImplementation((callback) => {
+        frameCallbacks.push(callback)
+        return frameCallbacks.length
+      })
+    const cancelFrame = vi.spyOn(window, 'cancelAnimationFrame')
+    const now = vi.spyOn(performance, 'now').mockReturnValue(0)
+    const user = userEvent.setup()
+
+    render(<SegmentElevationProfile routePoints={routePoints} />)
+
+    await user.click(
+      screen.getByRole('button', { name: 'Play route playback' }),
+    )
+    act(() => frameCallbacks.shift()?.(0))
+    expect(
+      screen.getByRole('button', { name: 'Pause route playback' }),
+    ).toBeVisible()
+
+    await user.click(
+      screen.getByRole('button', { name: 'Hover profile point' }),
+    )
+    expect(cancelFrame).toHaveBeenCalled()
+    expect(
+      screen.getByRole('button', { name: 'Play route playback' }),
+    ).toBeVisible()
+
+    requestFrame.mockRestore()
+    cancelFrame.mockRestore()
+    now.mockRestore()
   })
 
   it('coalesces multiple hover events into the latest animation frame point', () => {

--- a/src/components/garmin/SegmentElevationProfile.test.tsx
+++ b/src/components/garmin/SegmentElevationProfile.test.tsx
@@ -321,7 +321,6 @@ describe('SegmentElevationProfile', () => {
 
     // Advance to the end of the animation window; playback should stop and
     // report the final profile point.
-    now.mockReturnValue(6000)
     act(() => frameCallbacks.shift()?.(6000))
     act(() => frameCallbacks.shift()?.(6000))
 
@@ -364,6 +363,45 @@ describe('SegmentElevationProfile', () => {
     await user.click(
       screen.getByRole('button', { name: 'Hover profile point' }),
     )
+    expect(cancelFrame).toHaveBeenCalled()
+    expect(
+      screen.getByRole('button', { name: 'Play route playback' }),
+    ).toBeVisible()
+
+    requestFrame.mockRestore()
+    cancelFrame.mockRestore()
+    now.mockRestore()
+  })
+
+  it('resets the Play button when the route changes mid-playback', async () => {
+    const frameCallbacks: FrameRequestCallback[] = []
+    const requestFrame = vi
+      .spyOn(window, 'requestAnimationFrame')
+      .mockImplementation((callback) => {
+        frameCallbacks.push(callback)
+        return frameCallbacks.length
+      })
+    const cancelFrame = vi.spyOn(window, 'cancelAnimationFrame')
+    const now = vi.spyOn(performance, 'now').mockReturnValue(0)
+    const user = userEvent.setup()
+
+    const { rerender } = render(
+      <SegmentElevationProfile routePoints={routePoints} />,
+    )
+
+    await user.click(
+      screen.getByRole('button', { name: 'Play route playback' }),
+    )
+    act(() => frameCallbacks.shift()?.(0))
+    expect(
+      screen.getByRole('button', { name: 'Pause route playback' }),
+    ).toBeVisible()
+
+    const otherRoutePoints = routePoints.map((point) => ({ ...point }))
+    act(() => {
+      rerender(<SegmentElevationProfile routePoints={otherRoutePoints} />)
+    })
+
     expect(cancelFrame).toHaveBeenCalled()
     expect(
       screen.getByRole('button', { name: 'Play route playback' }),

--- a/src/components/garmin/SegmentElevationProfile.tsx
+++ b/src/components/garmin/SegmentElevationProfile.tsx
@@ -167,12 +167,14 @@ export function SegmentElevationProfile({
   }, [playingIndex, startPlayback, stopPlayback])
 
   // Stop any in-flight playback when the underlying route changes (e.g. a
-  // different segment is viewed) or the component unmounts.
+  // different segment is viewed), so the button doesn't get stuck showing
+  // Pause with no animation running.
   useEffect(() => {
     return () => {
       if (playbackFrameRef.current != null) {
         window.cancelAnimationFrame(playbackFrameRef.current)
         playbackFrameRef.current = null
+        setPlayingIndex(null)
       }
     }
   }, [routePoints])

--- a/src/components/garmin/SegmentElevationProfile.tsx
+++ b/src/components/garmin/SegmentElevationProfile.tsx
@@ -1,18 +1,24 @@
-import { useCallback, useEffect, useRef } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { Pause, Play } from 'lucide-react'
 import {
   Area,
   AreaChart,
   CartesianGrid,
+  ReferenceDot,
   ResponsiveContainer,
   Tooltip,
   XAxis,
   YAxis,
 } from 'recharts'
 import type { ActivityChartTrackPoint } from '@/components/garmin/ActivityChartData'
+import { Button } from '@/components/ui/button'
 import {
   buildSegmentElevationProfile,
   type SegmentElevationChartPoint,
 } from './SegmentElevationProfile.helpers'
+
+/** Total wall-clock time to animate from start to finish, in milliseconds. */
+const PLAYBACK_DURATION_MS = 6000
 
 type TooltipState =
   Readonly<{ activeTooltipIndex?: number | string | null }> | undefined
@@ -107,6 +113,70 @@ export function SegmentElevationProfile({
     [],
   )
 
+  const profile = useMemo(
+    () => buildSegmentElevationProfile(routePoints),
+    [routePoints],
+  )
+
+  const [playingIndex, setPlayingIndex] = useState<number | null>(null)
+  const playbackFrameRef = useRef<number | null>(null)
+
+  const stopPlayback = useCallback(() => {
+    if (playbackFrameRef.current != null) {
+      window.cancelAnimationFrame(playbackFrameRef.current)
+      playbackFrameRef.current = null
+    }
+    setPlayingIndex(null)
+    queueActivePointChange(null)
+  }, [queueActivePointChange])
+
+  const startPlayback = useCallback(() => {
+    if (!profile || profile.points.length < 2) return
+
+    const totalPoints = profile.points.length
+    const startTime = performance.now()
+
+    const step = (now: number) => {
+      const elapsed = now - startTime
+      const progress = Math.min(1, elapsed / PLAYBACK_DURATION_MS)
+      const index = Math.min(
+        totalPoints - 1,
+        Math.floor(progress * (totalPoints - 1)),
+      )
+
+      setPlayingIndex(index)
+      queueActivePointChange(profile.points[index])
+
+      if (progress >= 1) {
+        playbackFrameRef.current = null
+        setPlayingIndex(null)
+        return
+      }
+      playbackFrameRef.current = window.requestAnimationFrame(step)
+    }
+
+    playbackFrameRef.current = window.requestAnimationFrame(step)
+  }, [profile, queueActivePointChange])
+
+  const togglePlayback = useCallback(() => {
+    if (playbackFrameRef.current != null || playingIndex != null) {
+      stopPlayback()
+    } else {
+      startPlayback()
+    }
+  }, [playingIndex, startPlayback, stopPlayback])
+
+  // Stop any in-flight playback when the underlying route changes (e.g. a
+  // different segment is viewed) or the component unmounts.
+  useEffect(() => {
+    return () => {
+      if (playbackFrameRef.current != null) {
+        window.cancelAnimationFrame(playbackFrameRef.current)
+        playbackFrameRef.current = null
+      }
+    }
+  }, [routePoints])
+
   if (loading) {
     return (
       <div
@@ -117,8 +187,6 @@ export function SegmentElevationProfile({
       </div>
     )
   }
-
-  const profile = buildSegmentElevationProfile(routePoints)
 
   if (!profile) {
     return (
@@ -131,6 +199,8 @@ export function SegmentElevationProfile({
     )
   }
 
+  const isPlaying = playingIndex != null
+  const playingPoint = isPlaying ? profile.points[playingIndex] : null
   const accessibleSummary = `Elevation profile from ${formatFeet(profile.startElevationFeet)} at the segment start to ${formatFeet(profile.finishElevationFeet)} at the finish, with ${formatFeet(profile.elevationGainFeet)} of elevation gain over ${profile.distanceMiles.toFixed(2)} miles.`
 
   return (
@@ -140,11 +210,33 @@ export function SegmentElevationProfile({
       aria-labelledby="segment-elevation-heading"
     >
       <div className="flex flex-wrap items-start justify-between gap-3">
-        <div>
-          <h3 id="segment-elevation-heading" className="text-sm font-semibold">
-            Elevation
-          </h3>
-          <p className="text-xs text-muted-foreground">Start to finish</p>
+        <div className="flex items-start gap-3">
+          <div>
+            <h3
+              id="segment-elevation-heading"
+              className="text-sm font-semibold"
+            >
+              Elevation
+            </h3>
+            <p className="text-xs text-muted-foreground">Start to finish</p>
+          </div>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            data-testid="segment-elevation-play-button"
+            aria-label={
+              isPlaying ? 'Pause route playback' : 'Play route playback'
+            }
+            onClick={togglePlayback}
+            disabled={profile.points.length < 2}
+          >
+            {isPlaying ? (
+              <Pause className="h-4 w-4" aria-hidden="true" />
+            ) : (
+              <Play className="h-4 w-4" aria-hidden="true" />
+            )}
+          </Button>
         </div>
         <dl className="grid grid-cols-3 gap-x-5">
           <ElevationStat
@@ -174,10 +266,14 @@ export function SegmentElevationProfile({
             onMouseMove={(state: {
               activeTooltipIndex?: number | string | null
             }) => {
+              if (isPlaying) stopPlayback()
               const point = pointFromTooltipState(state, profile.points)
               if (point) queueActivePointChange(point)
             }}
-            onMouseLeave={() => queueActivePointChange(null)}
+            onMouseLeave={() => {
+              if (isPlaying) return
+              queueActivePointChange(null)
+            }}
           >
             <defs>
               <linearGradient
@@ -220,6 +316,17 @@ export function SegmentElevationProfile({
               dot={false}
               activeDot={{ r: 4 }}
             />
+            {playingPoint && (
+              <ReferenceDot
+                x={playingPoint.distanceMiles}
+                y={playingPoint.elevationFeet}
+                r={5}
+                stroke="#111827"
+                strokeWidth={2}
+                fill="#ffffff"
+                ifOverflow="extendDomain"
+              />
+            )}
           </AreaChart>
         </ResponsiveContainer>
       </div>


### PR DESCRIPTION
## Summary
- Adds a Play/Pause button to the segment elevation chart (`SegmentElevationProfile`) that animates the active point from start to finish over ~6 seconds
- Reuses the existing `onActivePointChange` callback, so the `SegmentStartEndMap` marker automatically moves in sync with playback — no changes needed to the map component
- Manually hovering the chart interrupts playback and hands control back to the cursor; playback also auto-stops when it reaches the finish

## Test plan
- [x] `SegmentElevationProfile.test.tsx` — 2 new tests covering full playback animation and hover-interrupt behavior (12/12 passing)
- [x] `GarminSegmentDetailPage.test.tsx` — unaffected, still passing (9/9)
- [x] `tsc --noEmit` and `eslint` clean
- [x] Manually verified in the browser against the live dev backend (Playwright + Cognito test user): Play → Pause icon toggles, dot animates along the elevation curve, map marker moves in sync, auto-stops at finish, manual hover interrupts playback

🤖 Generated with [Claude Code](https://claude.com/claude-code)