### PR TITLE
feat(garmin): show live speed/HR in segment effort leaderboard

### DIFF
--- a/src/__generated__/graphql.ts
+++ b/src/__generated__/graphql.ts
@@ -744,6 +744,26 @@ export type GarminSegmentEffortSeries = {
   effort_start: Scalars['String']['output'];
 };
 
+/**
+ * Multiple efforts' speed/HR series, binned by normalized distance along a
+ * segment and returned in the same order as requested.
+ */
+export type GarminSegmentEffortSeriesBatch = {
+  __typename?: 'GarminSegmentEffortSeriesBatch';
+  /** Effort series in request order */
+  items: Array<GarminSegmentEffortSeries>;
+};
+
+/** One effort window requested as part of a batch series lookup. */
+export type GarminSegmentEffortSeriesBatchItemInput = {
+  /** Garmin activity identifier of the effort */
+  activity_id: Scalars['String']['input'];
+  /** Effort end timestamp, exactly as returned by garminSegmentEfforts */
+  effort_end: Scalars['String']['input'];
+  /** Effort start timestamp, exactly as returned by garminSegmentEfforts */
+  effort_start: Scalars['String']['input'];
+};
+
 /** One distance bin of an effort's speed/heart-rate series along a segment. */
 export type GarminSegmentEffortSeriesBin = {
   __typename?: 'GarminSegmentEffortSeriesBin';
@@ -1230,6 +1250,12 @@ export type Query = {
    * segment, for comparing efforts at the same point on the course.
    */
   garminSegmentEffortSeries: GarminSegmentEffortSeries;
+  /**
+   * Multiple efforts' speed/HR series binned by normalized distance along a
+   * saved segment, computed with one database query and returned in request
+   * order. Accepts 1-50 effort windows.
+   */
+  garminSegmentEffortSeriesBatch: GarminSegmentEffortSeriesBatch;
   /** Rank all historical activity efforts over a saved segment (fastest first). */
   garminSegmentEfforts: GarminSegmentEffortsConnection;
   /** List saved Garmin segments, optionally filtered by sport. */
@@ -1364,6 +1390,13 @@ export type QueryGarminSegmentEffortSeriesArgs = {
   bins?: InputMaybe<Scalars['Int']['input']>;
   effort_end: Scalars['String']['input'];
   effort_start: Scalars['String']['input'];
+  id: Scalars['Int']['input'];
+};
+
+
+export type QueryGarminSegmentEffortSeriesBatchArgs = {
+  bins?: InputMaybe<Scalars['Int']['input']>;
+  efforts: Array<GarminSegmentEffortSeriesBatchItemInput>;
   id: Scalars['Int']['input'];
 };
 
@@ -1552,6 +1585,8 @@ export type WithinReferenceResult = {
 };
 
 /** Input for creating a saved Garmin segment (e.g. from an activity lap or climb). */
+
+/** One effort window requested as part of a batch series lookup. */
 
 /** Source used to resolve a point address. */
 
@@ -1800,6 +1835,15 @@ export type GarminSegmentEffortSeriesQueryVariables = Exact<{
 
 
 export type GarminSegmentEffortSeriesQuery = { garminSegmentEffortSeries: { activity_id: string, effort_start: string, effort_end: string, bin_count: number, bins: Array<{ index: number, fraction: number, speed_kmh: number | null, heart_rate: number | null }> } };
+
+export type GarminSegmentEffortSeriesBatchQueryVariables = Exact<{
+  id: number;
+  efforts: Array<GarminSegmentEffortSeriesBatchItemInput> | GarminSegmentEffortSeriesBatchItemInput;
+  bins?: number | null | undefined;
+}>;
+
+
+export type GarminSegmentEffortSeriesBatchQuery = { garminSegmentEffortSeriesBatch: { items: Array<{ activity_id: string, effort_start: string, effort_end: string, bin_count: number, bins: Array<{ index: number, fraction: number, speed_kmh: number | null, heart_rate: number | null }> }> } };
 
 export type CreateGarminSegmentMutationVariables = Exact<{
   input: CreateGarminSegmentInput;
@@ -3694,6 +3738,62 @@ export type GarminSegmentEffortSeriesQueryHookResult = ReturnType<typeof useGarm
 export type GarminSegmentEffortSeriesLazyQueryHookResult = ReturnType<typeof useGarminSegmentEffortSeriesLazyQuery>;
 export type GarminSegmentEffortSeriesSuspenseQueryHookResult = ReturnType<typeof useGarminSegmentEffortSeriesSuspenseQuery>;
 export type GarminSegmentEffortSeriesQueryResult = ApolloReactCommon.QueryResult<GarminSegmentEffortSeriesQuery, GarminSegmentEffortSeriesQueryVariables>;
+export const GarminSegmentEffortSeriesBatchDocument = gql`
+    query GarminSegmentEffortSeriesBatch($id: Int!, $efforts: [GarminSegmentEffortSeriesBatchItemInput!]!, $bins: Int) {
+  garminSegmentEffortSeriesBatch(id: $id, efforts: $efforts, bins: $bins) {
+    items {
+      activity_id
+      effort_start
+      effort_end
+      bin_count
+      bins {
+        index
+        fraction
+        speed_kmh
+        heart_rate
+      }
+    }
+  }
+}
+    `;
+
+/**
+ * __useGarminSegmentEffortSeriesBatchQuery__
+ *
+ * To run a query within a React component, call `useGarminSegmentEffortSeriesBatchQuery` and pass it any options that fit your needs.
+ * When your component renders, `useGarminSegmentEffortSeriesBatchQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useGarminSegmentEffortSeriesBatchQuery({
+ *   variables: {
+ *      id: // value for 'id'
+ *      efforts: // value for 'efforts'
+ *      bins: // value for 'bins'
+ *   },
+ * });
+ */
+export function useGarminSegmentEffortSeriesBatchQuery(baseOptions: ApolloReactHooks.QueryHookOptions<GarminSegmentEffortSeriesBatchQuery, GarminSegmentEffortSeriesBatchQueryVariables> & ({ variables: GarminSegmentEffortSeriesBatchQueryVariables; skip?: boolean; } | { skip: boolean; }) ) {
+        const options = {...defaultOptions, ...baseOptions}
+        return ApolloReactHooks.useQuery<GarminSegmentEffortSeriesBatchQuery, GarminSegmentEffortSeriesBatchQueryVariables>(GarminSegmentEffortSeriesBatchDocument, options);
+      }
+export function useGarminSegmentEffortSeriesBatchLazyQuery(baseOptions?: ApolloReactHooks.LazyQueryHookOptions<GarminSegmentEffortSeriesBatchQuery, GarminSegmentEffortSeriesBatchQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return ApolloReactHooks.useLazyQuery<GarminSegmentEffortSeriesBatchQuery, GarminSegmentEffortSeriesBatchQueryVariables>(GarminSegmentEffortSeriesBatchDocument, options);
+        }
+// @ts-ignore
+export function useGarminSegmentEffortSeriesBatchSuspenseQuery(baseOptions?: ApolloReactHooks.SuspenseQueryHookOptions<GarminSegmentEffortSeriesBatchQuery, GarminSegmentEffortSeriesBatchQueryVariables>): ApolloReactHooks.UseSuspenseQueryResult<GarminSegmentEffortSeriesBatchQuery, GarminSegmentEffortSeriesBatchQueryVariables>;
+export function useGarminSegmentEffortSeriesBatchSuspenseQuery(baseOptions?: ApolloReactHooks.SkipToken | ApolloReactHooks.SuspenseQueryHookOptions<GarminSegmentEffortSeriesBatchQuery, GarminSegmentEffortSeriesBatchQueryVariables>): ApolloReactHooks.UseSuspenseQueryResult<GarminSegmentEffortSeriesBatchQuery | undefined, GarminSegmentEffortSeriesBatchQueryVariables>;
+export function useGarminSegmentEffortSeriesBatchSuspenseQuery(baseOptions?: ApolloReactHooks.SkipToken | ApolloReactHooks.SuspenseQueryHookOptions<GarminSegmentEffortSeriesBatchQuery, GarminSegmentEffortSeriesBatchQueryVariables>) {
+          const options = baseOptions === ApolloReactHooks.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
+          return ApolloReactHooks.useSuspenseQuery<GarminSegmentEffortSeriesBatchQuery, GarminSegmentEffortSeriesBatchQueryVariables>(GarminSegmentEffortSeriesBatchDocument, options);
+        }
+export type GarminSegmentEffortSeriesBatchQueryHookResult = ReturnType<typeof useGarminSegmentEffortSeriesBatchQuery>;
+export type GarminSegmentEffortSeriesBatchLazyQueryHookResult = ReturnType<typeof useGarminSegmentEffortSeriesBatchLazyQuery>;
+export type GarminSegmentEffortSeriesBatchSuspenseQueryHookResult = ReturnType<typeof useGarminSegmentEffortSeriesBatchSuspenseQuery>;
+export type GarminSegmentEffortSeriesBatchQueryResult = ApolloReactCommon.QueryResult<GarminSegmentEffortSeriesBatchQuery, GarminSegmentEffortSeriesBatchQueryVariables>;
 export const CreateGarminSegmentDocument = gql`
     mutation CreateGarminSegment($input: CreateGarminSegmentInput!) {
   createGarminSegment(input: $input) {

--- a/src/__generated__/graphql.ts
+++ b/src/__generated__/graphql.ts
@@ -725,6 +725,38 @@ export type GarminSegmentEffort = {
   sport?: Maybe<Scalars['String']['output']>;
 };
 
+/**
+ * A single effort's speed/HR series binned by normalized distance along the
+ * segment. bins always contains exactly bin_count entries ordered by index;
+ * bins with no samples carry null metrics.
+ */
+export type GarminSegmentEffortSeries = {
+  __typename?: 'GarminSegmentEffortSeries';
+  /** Garmin activity identifier */
+  activity_id: Scalars['String']['output'];
+  /** Number of distance bins in the series */
+  bin_count: Scalars['Int']['output'];
+  /** Distance-ordered bins spanning the traversal */
+  bins: Array<GarminSegmentEffortSeriesBin>;
+  /** UTC timestamp reaching the segment end corridor */
+  effort_end: Scalars['String']['output'];
+  /** UTC timestamp entering the segment start corridor */
+  effort_start: Scalars['String']['output'];
+};
+
+/** One distance bin of an effort's speed/heart-rate series along a segment. */
+export type GarminSegmentEffortSeriesBin = {
+  __typename?: 'GarminSegmentEffortSeriesBin';
+  /** Bin midpoint as a 0..1 fraction of the effort's traversal distance */
+  fraction: Scalars['Float']['output'];
+  /** Average heart rate within the bin in bpm (null for empty bins) */
+  heart_rate?: Maybe<Scalars['Int']['output']>;
+  /** 0-based bin index from segment start */
+  index: Scalars['Int']['output'];
+  /** Average speed within the bin in km/h (null for empty bins) */
+  speed_kmh?: Maybe<Scalars['Float']['output']>;
+};
+
 /** Ranked efforts for a segment across all matching activities (fastest first). */
 export type GarminSegmentEffortsConnection = {
   __typename?: 'GarminSegmentEffortsConnection';
@@ -1193,6 +1225,11 @@ export type Query = {
   garminLapsComparison: GarminLapsComparisonConnection;
   /** Fetch a single saved Garmin segment by id. Returns null if it does not exist. */
   garminSegment?: Maybe<GarminSegment>;
+  /**
+   * One effort's speed/HR series binned by normalized distance along a saved
+   * segment, for comparing efforts at the same point on the course.
+   */
+  garminSegmentEffortSeries: GarminSegmentEffortSeries;
   /** Rank all historical activity efforts over a saved segment (fastest first). */
   garminSegmentEfforts: GarminSegmentEffortsConnection;
   /** List saved Garmin segments, optionally filtered by sport. */
@@ -1318,6 +1355,15 @@ export type QueryGarminLapsComparisonArgs = {
 
 
 export type QueryGarminSegmentArgs = {
+  id: Scalars['Int']['input'];
+};
+
+
+export type QueryGarminSegmentEffortSeriesArgs = {
+  activity_id: Scalars['String']['input'];
+  bins?: InputMaybe<Scalars['Int']['input']>;
+  effort_end: Scalars['String']['input'];
+  effort_start: Scalars['String']['input'];
   id: Scalars['Int']['input'];
 };
 
@@ -1743,6 +1789,17 @@ export type GarminSegmentEffortsQueryVariables = Exact<{
 
 
 export type GarminSegmentEffortsQuery = { garminSegmentEfforts: { total: number, segment: { start_lat: number, start_lon: number, end_lat: number, end_lon: number, tolerance_meters: number }, items: Array<{ rank: number, activity_id: string, sport: string | null, activity_start_time: string | null, effort_start: string, effort_end: string, elapsed_seconds: number, distance_km: number | null, avg_speed_kmh: number | null, avg_heart_rate: number | null, max_heart_rate: number | null }> } };
+
+export type GarminSegmentEffortSeriesQueryVariables = Exact<{
+  id: number;
+  activity_id: string;
+  effort_start: string;
+  effort_end: string;
+  bins?: number | null | undefined;
+}>;
+
+
+export type GarminSegmentEffortSeriesQuery = { garminSegmentEffortSeries: { activity_id: string, effort_start: string, effort_end: string, bin_count: number, bins: Array<{ index: number, fraction: number, speed_kmh: number | null, heart_rate: number | null }> } };
 
 export type CreateGarminSegmentMutationVariables = Exact<{
   input: CreateGarminSegmentInput;
@@ -3575,6 +3632,68 @@ export type GarminSegmentEffortsQueryHookResult = ReturnType<typeof useGarminSeg
 export type GarminSegmentEffortsLazyQueryHookResult = ReturnType<typeof useGarminSegmentEffortsLazyQuery>;
 export type GarminSegmentEffortsSuspenseQueryHookResult = ReturnType<typeof useGarminSegmentEffortsSuspenseQuery>;
 export type GarminSegmentEffortsQueryResult = ApolloReactCommon.QueryResult<GarminSegmentEffortsQuery, GarminSegmentEffortsQueryVariables>;
+export const GarminSegmentEffortSeriesDocument = gql`
+    query GarminSegmentEffortSeries($id: Int!, $activity_id: String!, $effort_start: String!, $effort_end: String!, $bins: Int) {
+  garminSegmentEffortSeries(
+    id: $id
+    activity_id: $activity_id
+    effort_start: $effort_start
+    effort_end: $effort_end
+    bins: $bins
+  ) {
+    activity_id
+    effort_start
+    effort_end
+    bin_count
+    bins {
+      index
+      fraction
+      speed_kmh
+      heart_rate
+    }
+  }
+}
+    `;
+
+/**
+ * __useGarminSegmentEffortSeriesQuery__
+ *
+ * To run a query within a React component, call `useGarminSegmentEffortSeriesQuery` and pass it any options that fit your needs.
+ * When your component renders, `useGarminSegmentEffortSeriesQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useGarminSegmentEffortSeriesQuery({
+ *   variables: {
+ *      id: // value for 'id'
+ *      activity_id: // value for 'activity_id'
+ *      effort_start: // value for 'effort_start'
+ *      effort_end: // value for 'effort_end'
+ *      bins: // value for 'bins'
+ *   },
+ * });
+ */
+export function useGarminSegmentEffortSeriesQuery(baseOptions: ApolloReactHooks.QueryHookOptions<GarminSegmentEffortSeriesQuery, GarminSegmentEffortSeriesQueryVariables> & ({ variables: GarminSegmentEffortSeriesQueryVariables; skip?: boolean; } | { skip: boolean; }) ) {
+        const options = {...defaultOptions, ...baseOptions}
+        return ApolloReactHooks.useQuery<GarminSegmentEffortSeriesQuery, GarminSegmentEffortSeriesQueryVariables>(GarminSegmentEffortSeriesDocument, options);
+      }
+export function useGarminSegmentEffortSeriesLazyQuery(baseOptions?: ApolloReactHooks.LazyQueryHookOptions<GarminSegmentEffortSeriesQuery, GarminSegmentEffortSeriesQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return ApolloReactHooks.useLazyQuery<GarminSegmentEffortSeriesQuery, GarminSegmentEffortSeriesQueryVariables>(GarminSegmentEffortSeriesDocument, options);
+        }
+// @ts-ignore
+export function useGarminSegmentEffortSeriesSuspenseQuery(baseOptions?: ApolloReactHooks.SuspenseQueryHookOptions<GarminSegmentEffortSeriesQuery, GarminSegmentEffortSeriesQueryVariables>): ApolloReactHooks.UseSuspenseQueryResult<GarminSegmentEffortSeriesQuery, GarminSegmentEffortSeriesQueryVariables>;
+export function useGarminSegmentEffortSeriesSuspenseQuery(baseOptions?: ApolloReactHooks.SkipToken | ApolloReactHooks.SuspenseQueryHookOptions<GarminSegmentEffortSeriesQuery, GarminSegmentEffortSeriesQueryVariables>): ApolloReactHooks.UseSuspenseQueryResult<GarminSegmentEffortSeriesQuery | undefined, GarminSegmentEffortSeriesQueryVariables>;
+export function useGarminSegmentEffortSeriesSuspenseQuery(baseOptions?: ApolloReactHooks.SkipToken | ApolloReactHooks.SuspenseQueryHookOptions<GarminSegmentEffortSeriesQuery, GarminSegmentEffortSeriesQueryVariables>) {
+          const options = baseOptions === ApolloReactHooks.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
+          return ApolloReactHooks.useSuspenseQuery<GarminSegmentEffortSeriesQuery, GarminSegmentEffortSeriesQueryVariables>(GarminSegmentEffortSeriesDocument, options);
+        }
+export type GarminSegmentEffortSeriesQueryHookResult = ReturnType<typeof useGarminSegmentEffortSeriesQuery>;
+export type GarminSegmentEffortSeriesLazyQueryHookResult = ReturnType<typeof useGarminSegmentEffortSeriesLazyQuery>;
+export type GarminSegmentEffortSeriesSuspenseQueryHookResult = ReturnType<typeof useGarminSegmentEffortSeriesSuspenseQuery>;
+export type GarminSegmentEffortSeriesQueryResult = ApolloReactCommon.QueryResult<GarminSegmentEffortSeriesQuery, GarminSegmentEffortSeriesQueryVariables>;
 export const CreateGarminSegmentDocument = gql`
     mutation CreateGarminSegment($input: CreateGarminSegmentInput!) {
   createGarminSegment(input: $input) {

--- a/src/components/garmin/SegmentEffortLiveCells.tsx
+++ b/src/components/garmin/SegmentEffortLiveCells.tsx
@@ -1,0 +1,72 @@
+import { TableCell } from '@/components/ui/table'
+import { useGarminSegmentEffortSeriesQuery } from '@/__generated__/graphql'
+import {
+  formatHeartRate,
+  formatSpeedMph,
+  type SegmentEffort,
+} from './segmentEfforts'
+import { sampleAtFraction } from './segmentEffortSeries'
+
+interface SegmentEffortLiveCellsProps {
+  segmentId: number
+  effort: SegmentEffort
+  /**
+   * Current playback/hover position as a 0..1 fraction of the segment, or
+   * null when idle. The series is only fetched once a position is active.
+   */
+  activeFraction: number | null
+  /** Only top-ranked rows fetch series data; disabled rows render em dashes. */
+  enabled: boolean
+}
+
+/**
+ * The two live-value cells ("Speed @ pt" / "HR @ pt") for one leaderboard row.
+ * Owns the per-effort series query so each row loads lazily and caches
+ * independently; an effort's window is immutable, so the series never needs
+ * refetching.
+ */
+export function SegmentEffortLiveCells({
+  segmentId,
+  effort,
+  activeFraction,
+  enabled,
+}: Readonly<SegmentEffortLiveCellsProps>) {
+  const { data, loading } = useGarminSegmentEffortSeriesQuery({
+    variables: {
+      id: segmentId,
+      activity_id: effort.activity_id,
+      effort_start: effort.effort_start,
+      effort_end: effort.effort_end,
+    },
+    skip: !enabled || activeFraction == null,
+    fetchPolicy: 'cache-first',
+  })
+
+  const sample =
+    activeFraction != null && data
+      ? sampleAtFraction(data.garminSegmentEffortSeries.bins, activeFraction)
+      : null
+
+  if (activeFraction != null && enabled && loading) {
+    return (
+      <>
+        <TableCell className="tabular-nums text-muted-foreground">…</TableCell>
+        <TableCell className="tabular-nums text-muted-foreground">…</TableCell>
+      </>
+    )
+  }
+
+  return (
+    <>
+      <TableCell
+        className="tabular-nums"
+        data-testid="segment-effort-live-speed"
+      >
+        {sample ? formatSpeedMph(sample.speed_kmh) : '—'}
+      </TableCell>
+      <TableCell className="tabular-nums" data-testid="segment-effort-live-hr">
+        {sample ? formatHeartRate(sample.heart_rate) : '—'}
+      </TableCell>
+    </>
+  )
+}

--- a/src/components/garmin/SegmentEffortLiveCells.tsx
+++ b/src/components/garmin/SegmentEffortLiveCells.tsx
@@ -1,50 +1,42 @@
 import { TableCell } from '@/components/ui/table'
-import { useGarminSegmentEffortSeriesQuery } from '@/__generated__/graphql'
+import { formatHeartRate, formatSpeedMph } from './segmentEfforts'
 import {
-  formatHeartRate,
-  formatSpeedMph,
-  type SegmentEffort,
-} from './segmentEfforts'
-import { sampleAtFraction } from './segmentEffortSeries'
+  sampleAtFraction,
+  type SegmentEffortSeriesBin,
+} from './segmentEffortSeries'
 
 interface SegmentEffortLiveCellsProps {
-  segmentId: number
-  effort: SegmentEffort
+  /**
+   * This effort's series bins from the batched leaderboard-level fetch, or
+   * undefined while the batch is loading/hasn't been requested for this row.
+   */
+  bins: readonly SegmentEffortSeriesBin[] | undefined
   /**
    * Current playback/hover position as a 0..1 fraction of the segment, or
-   * null when idle. The series is only fetched once a position is active.
+   * null when idle.
    */
   activeFraction: number | null
-  /** Only top-ranked rows fetch series data; disabled rows render em dashes. */
+  /** Whether this row is within the batch's fetch window (top N rows). */
   enabled: boolean
+  /** Whether the batch request covering this row is in flight. */
+  loading: boolean
 }
 
 /**
- * The two live-value cells ("Speed @ pt" / "HR @ pt") for one leaderboard row.
- * Owns the per-effort series query so each row loads lazily and caches
- * independently; an effort's window is immutable, so the series never needs
- * refetching.
+ * The two live-value cells ("Speed @ pt" / "HR @ pt") for one leaderboard
+ * row. Purely presentational: the leaderboard fetches one batched series
+ * request for all visible rows and passes each row its own slice, so
+ * re-sorting or scrubbing playback never fans out into per-row requests.
  */
 export function SegmentEffortLiveCells({
-  segmentId,
-  effort,
+  bins,
   activeFraction,
   enabled,
+  loading,
 }: Readonly<SegmentEffortLiveCellsProps>) {
-  const { data, loading } = useGarminSegmentEffortSeriesQuery({
-    variables: {
-      id: segmentId,
-      activity_id: effort.activity_id,
-      effort_start: effort.effort_start,
-      effort_end: effort.effort_end,
-    },
-    skip: !enabled || activeFraction == null,
-    fetchPolicy: 'cache-first',
-  })
-
   const sample =
-    activeFraction != null && data
-      ? sampleAtFraction(data.garminSegmentEffortSeries.bins, activeFraction)
+    activeFraction != null && bins
+      ? sampleAtFraction(bins, activeFraction)
       : null
 
   if (activeFraction != null && enabled && loading) {

--- a/src/components/garmin/SegmentEffortsLeaderboard.test.tsx
+++ b/src/components/garmin/SegmentEffortsLeaderboard.test.tsx
@@ -1,9 +1,15 @@
 import { render, screen, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { MemoryRouter } from 'react-router-dom'
-import { describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { SegmentEffortsLeaderboard } from './SegmentEffortsLeaderboard'
 import type { SegmentEffort } from './segmentEfforts'
+
+const seriesHooks = vi.hoisted(() => ({
+  useGarminSegmentEffortSeriesQuery: vi.fn(),
+}))
+
+vi.mock('@/__generated__/graphql', () => seriesHooks)
 
 function effort(overrides: Partial<SegmentEffort>): SegmentEffort {
   return {
@@ -22,13 +28,46 @@ function effort(overrides: Partial<SegmentEffort>): SegmentEffort {
   }
 }
 
-function renderLeaderboard(efforts: SegmentEffort[]) {
+function seriesResult(
+  bins: Array<Partial<{ speed_kmh: number | null; heart_rate: number | null }>>,
+) {
+  return {
+    loading: false,
+    data: {
+      garminSegmentEffortSeries: {
+        activity_id: 'activity',
+        effort_start: '2026-07-01T10:00:00Z',
+        effort_end: '2026-07-01T10:01:30Z',
+        bin_count: bins.length,
+        bins: bins.map((b, index) => ({
+          index,
+          fraction: (index + 0.5) / bins.length,
+          speed_kmh: b.speed_kmh ?? null,
+          heart_rate: b.heart_rate ?? null,
+        })),
+      },
+    },
+  }
+}
+
+function renderLeaderboard(
+  efforts: SegmentEffort[],
+  props: { segmentId?: number; activeFraction?: number | null } = {},
+) {
   render(
     <MemoryRouter>
-      <SegmentEffortsLeaderboard efforts={efforts} />
+      <SegmentEffortsLeaderboard efforts={efforts} {...props} />
     </MemoryRouter>,
   )
 }
+
+beforeEach(() => {
+  seriesHooks.useGarminSegmentEffortSeriesQuery.mockReset()
+  seriesHooks.useGarminSegmentEffortSeriesQuery.mockReturnValue({
+    data: undefined,
+    loading: false,
+  })
+})
 
 describe('SegmentEffortsLeaderboard', () => {
   it('defaults to most recent sort', () => {
@@ -130,5 +169,77 @@ describe('SegmentEffortsLeaderboard', () => {
       within(rows[0]).queryByTestId('segment-effort-pr'),
     ).not.toBeInTheDocument()
     expect(within(rows[1]).getByTestId('segment-effort-pr')).toBeVisible()
+  })
+
+  it('shows em dashes in the live columns when idle', () => {
+    renderLeaderboard([effort({})], { segmentId: 5, activeFraction: null })
+
+    const row = screen.getByTestId('segment-effort-row')
+    expect(
+      within(row).getByTestId('segment-effort-live-speed'),
+    ).toHaveTextContent('—')
+    expect(within(row).getByTestId('segment-effort-live-hr')).toHaveTextContent(
+      '—',
+    )
+    // Idle rows must not fetch: the query is mounted but skipped.
+    for (const call of seriesHooks.useGarminSegmentEffortSeriesQuery.mock
+      .calls) {
+      expect(call[0].skip).toBe(true)
+    }
+  })
+
+  it('shows speed and HR at the active fraction during playback', () => {
+    seriesHooks.useGarminSegmentEffortSeriesQuery.mockReturnValue(
+      seriesResult([
+        { speed_kmh: 16.09, heart_rate: 120 },
+        { speed_kmh: 32.19, heart_rate: 140 },
+      ]),
+    )
+
+    renderLeaderboard([effort({})], { segmentId: 5, activeFraction: 0.75 })
+
+    const row = screen.getByTestId('segment-effort-row')
+    // Fraction 0.75 of 2 bins → bin 1 (32.19 km/h ≈ 20.0 mph, 140 bpm).
+    expect(
+      within(row).getByTestId('segment-effort-live-speed'),
+    ).toHaveTextContent('20.0 mph')
+    expect(within(row).getByTestId('segment-effort-live-hr')).toHaveTextContent(
+      '140',
+    )
+
+    const call =
+      seriesHooks.useGarminSegmentEffortSeriesQuery.mock.calls.at(-1)?.[0]
+    expect(call.skip).toBe(false)
+    expect(call.variables).toEqual({
+      id: 5,
+      activity_id: 'activity',
+      effort_start: '2026-07-01T10:00:00Z',
+      effort_end: '2026-07-01T10:01:30Z',
+    })
+  })
+
+  it('only lets the top 20 rows of the current sort fetch series data', () => {
+    const efforts = Array.from({ length: 25 }, (_, i) =>
+      effort({
+        activity_id: `activity-${i}`,
+        activity_start_time: `2026-06-${String(i + 1).padStart(2, '0')}T10:00:00Z`,
+        effort_start: `2026-06-${String(i + 1).padStart(2, '0')}T10:00:00Z`,
+      }),
+    )
+
+    renderLeaderboard(efforts, { segmentId: 5, activeFraction: 0.5 })
+
+    const calls = seriesHooks.useGarminSegmentEffortSeriesQuery.mock.calls
+    expect(calls).toHaveLength(25)
+    const active = calls.filter((call) => call[0].skip === false)
+    expect(active).toHaveLength(20)
+  })
+
+  it('renders static em dashes without a segment id', () => {
+    renderLeaderboard([effort({})], { activeFraction: 0.5 })
+
+    expect(seriesHooks.useGarminSegmentEffortSeriesQuery).not.toHaveBeenCalled()
+    const row = screen.getByTestId('segment-effort-row')
+    expect(within(row).getAllByText('—').length).toBeGreaterThanOrEqual(2)
   })
 })

--- a/src/components/garmin/SegmentEffortsLeaderboard.test.tsx
+++ b/src/components/garmin/SegmentEffortsLeaderboard.test.tsx
@@ -6,7 +6,7 @@ import { SegmentEffortsLeaderboard } from './SegmentEffortsLeaderboard'
 import type { SegmentEffort } from './segmentEfforts'
 
 const seriesHooks = vi.hoisted(() => ({
-  useGarminSegmentEffortSeriesQuery: vi.fn(),
+  useGarminSegmentEffortSeriesBatchQuery: vi.fn(),
 }))
 
 vi.mock('@/__generated__/graphql', () => seriesHooks)
@@ -28,22 +28,26 @@ function effort(overrides: Partial<SegmentEffort>): SegmentEffort {
   }
 }
 
-function seriesResult(
-  bins: Array<Partial<{ speed_kmh: number | null; heart_rate: number | null }>>,
+function batchResult(
+  itemsBins: Array<
+    Array<Partial<{ speed_kmh: number | null; heart_rate: number | null }>>
+  >,
 ) {
   return {
     loading: false,
     data: {
-      garminSegmentEffortSeries: {
-        activity_id: 'activity',
-        effort_start: '2026-07-01T10:00:00Z',
-        effort_end: '2026-07-01T10:01:30Z',
-        bin_count: bins.length,
-        bins: bins.map((b, index) => ({
-          index,
-          fraction: (index + 0.5) / bins.length,
-          speed_kmh: b.speed_kmh ?? null,
-          heart_rate: b.heart_rate ?? null,
+      garminSegmentEffortSeriesBatch: {
+        items: itemsBins.map((bins) => ({
+          activity_id: 'activity',
+          effort_start: '2026-07-01T10:00:00Z',
+          effort_end: '2026-07-01T10:01:30Z',
+          bin_count: bins.length,
+          bins: bins.map((b, index) => ({
+            index,
+            fraction: (index + 0.5) / bins.length,
+            speed_kmh: b.speed_kmh ?? null,
+            heart_rate: b.heart_rate ?? null,
+          })),
         })),
       },
     },
@@ -62,8 +66,8 @@ function renderLeaderboard(
 }
 
 beforeEach(() => {
-  seriesHooks.useGarminSegmentEffortSeriesQuery.mockReset()
-  seriesHooks.useGarminSegmentEffortSeriesQuery.mockReturnValue({
+  seriesHooks.useGarminSegmentEffortSeriesBatchQuery.mockReset()
+  seriesHooks.useGarminSegmentEffortSeriesBatchQuery.mockReturnValue({
     data: undefined,
     loading: false,
   })
@@ -181,18 +185,19 @@ describe('SegmentEffortsLeaderboard', () => {
     expect(within(row).getByTestId('segment-effort-live-hr')).toHaveTextContent(
       '—',
     )
-    // Idle rows must not fetch: the query is mounted but skipped.
-    for (const call of seriesHooks.useGarminSegmentEffortSeriesQuery.mock
-      .calls) {
-      expect(call[0].skip).toBe(true)
-    }
+    // Idle: the batch query is mounted but skipped, no fetch fires.
+    const call =
+      seriesHooks.useGarminSegmentEffortSeriesBatchQuery.mock.calls.at(-1)?.[0]
+    expect(call.skip).toBe(true)
   })
 
   it('shows speed and HR at the active fraction during playback', () => {
-    seriesHooks.useGarminSegmentEffortSeriesQuery.mockReturnValue(
-      seriesResult([
-        { speed_kmh: 16.09, heart_rate: 120 },
-        { speed_kmh: 32.19, heart_rate: 140 },
+    seriesHooks.useGarminSegmentEffortSeriesBatchQuery.mockReturnValue(
+      batchResult([
+        [
+          { speed_kmh: 16.09, heart_rate: 120 },
+          { speed_kmh: 32.19, heart_rate: 140 },
+        ],
       ]),
     )
 
@@ -208,17 +213,21 @@ describe('SegmentEffortsLeaderboard', () => {
     )
 
     const call =
-      seriesHooks.useGarminSegmentEffortSeriesQuery.mock.calls.at(-1)?.[0]
+      seriesHooks.useGarminSegmentEffortSeriesBatchQuery.mock.calls.at(-1)?.[0]
     expect(call.skip).toBe(false)
     expect(call.variables).toEqual({
       id: 5,
-      activity_id: 'activity',
-      effort_start: '2026-07-01T10:00:00Z',
-      effort_end: '2026-07-01T10:01:30Z',
+      efforts: [
+        {
+          activity_id: 'activity',
+          effort_start: '2026-07-01T10:00:00Z',
+          effort_end: '2026-07-01T10:01:30Z',
+        },
+      ],
     })
   })
 
-  it('only lets the top 20 rows of the current sort fetch series data', () => {
+  it('only includes the top 20 rows of the current sort in the batch request', () => {
     const efforts = Array.from({ length: 25 }, (_, i) =>
       effort({
         activity_id: `activity-${i}`,
@@ -229,16 +238,22 @@ describe('SegmentEffortsLeaderboard', () => {
 
     renderLeaderboard(efforts, { segmentId: 5, activeFraction: 0.5 })
 
-    const calls = seriesHooks.useGarminSegmentEffortSeriesQuery.mock.calls
-    expect(calls).toHaveLength(25)
-    const active = calls.filter((call) => call[0].skip === false)
-    expect(active).toHaveLength(20)
+    // One batched call total (not one per row), covering only the top 20.
+    expect(
+      seriesHooks.useGarminSegmentEffortSeriesBatchQuery,
+    ).toHaveBeenCalledTimes(1)
+    const call =
+      seriesHooks.useGarminSegmentEffortSeriesBatchQuery.mock.calls[0][0]
+    expect(call.skip).toBe(false)
+    expect(call.variables.efforts).toHaveLength(20)
   })
 
   it('renders static em dashes without a segment id', () => {
     renderLeaderboard([effort({})], { activeFraction: 0.5 })
 
-    expect(seriesHooks.useGarminSegmentEffortSeriesQuery).not.toHaveBeenCalled()
+    const call =
+      seriesHooks.useGarminSegmentEffortSeriesBatchQuery.mock.calls.at(-1)?.[0]
+    expect(call.skip).toBe(true)
     const row = screen.getByTestId('segment-effort-row')
     expect(within(row).getAllByText('—').length).toBeGreaterThanOrEqual(2)
   })

--- a/src/components/garmin/SegmentEffortsLeaderboard.tsx
+++ b/src/components/garmin/SegmentEffortsLeaderboard.tsx
@@ -1,6 +1,7 @@
 import { useMemo, useState } from 'react'
 import { Link } from 'react-router-dom'
 import { Trophy } from 'lucide-react'
+import { useGarminSegmentEffortSeriesBatchQuery } from '@/__generated__/graphql'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import {
@@ -13,6 +14,7 @@ import {
 } from '@/components/ui/table'
 import { cn } from '@/lib/utils'
 import { SegmentEffortLiveCells } from './SegmentEffortLiveCells'
+import type { SegmentEffortSeriesBin } from './segmentEffortSeries'
 import {
   EFFORT_SORTS,
   bestEffortKey,
@@ -36,7 +38,7 @@ const LIVE_ROW_LIMIT = 20
 
 interface SegmentEffortsLeaderboardProps {
   efforts: SegmentEffort[]
-  /** Saved segment id, required for the per-row live series query. */
+  /** Saved segment id, required for the batched live series query. */
   segmentId?: number
   /**
    * Current playback/hover position as a 0..1 fraction of the segment, or
@@ -54,6 +56,35 @@ export function SegmentEffortsLeaderboard({
 
   const bestKey = useMemo(() => bestEffortKey(efforts), [efforts])
   const sorted = useMemo(() => sortEfforts(efforts, sort), [efforts, sort])
+  const liveRows = useMemo(() => sorted.slice(0, LIVE_ROW_LIMIT), [sorted])
+
+  // One batched request covers every live row, however the leaderboard is
+  // currently sorted, instead of a request per row. Re-sorting changes which
+  // efforts are in the batch and triggers a refetch; scrubbing playback/hover just
+  // re-samples the already-fetched bins client-side.
+  const { data: batchData, loading: batchLoading } =
+    useGarminSegmentEffortSeriesBatchQuery({
+      variables: {
+        id: segmentId ?? 0,
+        efforts: liveRows.map((effort) => ({
+          activity_id: effort.activity_id,
+          effort_start: effort.effort_start,
+          effort_end: effort.effort_end,
+        })),
+      },
+      skip:
+        segmentId == null || activeFraction == null || liveRows.length === 0,
+      fetchPolicy: 'cache-first',
+    })
+  const binsByKey = useMemo(() => {
+    const map = new Map<string, readonly SegmentEffortSeriesBin[]>()
+    const items = batchData?.garminSegmentEffortSeriesBatch.items ?? []
+    liveRows.forEach((effort, index) => {
+      const item = items[index]
+      if (item) map.set(effortKey(effort), item.bins)
+    })
+    return map
+  }, [batchData, liveRows])
 
   return (
     <div className="space-y-3">
@@ -133,19 +164,12 @@ export function SegmentEffortsLeaderboard({
                   <TableCell className="tabular-nums">
                     {formatHeartRate(effort.max_heart_rate)}
                   </TableCell>
-                  {segmentId != null ? (
-                    <SegmentEffortLiveCells
-                      segmentId={segmentId}
-                      effort={effort}
-                      activeFraction={activeFraction}
-                      enabled={index < LIVE_ROW_LIMIT}
-                    />
-                  ) : (
-                    <>
-                      <TableCell className="tabular-nums">—</TableCell>
-                      <TableCell className="tabular-nums">—</TableCell>
-                    </>
-                  )}
+                  <SegmentEffortLiveCells
+                    bins={binsByKey.get(effortKey(effort))}
+                    activeFraction={activeFraction}
+                    enabled={index < LIVE_ROW_LIMIT}
+                    loading={batchLoading}
+                  />
                   <TableCell className="text-right">
                     <Link
                       to={`/garmin/${effort.activity_id}`}

--- a/src/components/garmin/SegmentEffortsLeaderboard.tsx
+++ b/src/components/garmin/SegmentEffortsLeaderboard.tsx
@@ -12,6 +12,7 @@ import {
   TableRow,
 } from '@/components/ui/table'
 import { cn } from '@/lib/utils'
+import { SegmentEffortLiveCells } from './SegmentEffortLiveCells'
 import {
   EFFORT_SORTS,
   bestEffortKey,
@@ -26,12 +27,28 @@ import {
   type SegmentEffort,
 } from './segmentEfforts'
 
+/**
+ * Only this many top rows (under the current sort) fetch live series data.
+ * Roughly one screen's worth of rows; keeps the request fan-out bounded on segments with
+ * hundreds of efforts while covering the rows users actually watch.
+ */
+const LIVE_ROW_LIMIT = 20
+
 interface SegmentEffortsLeaderboardProps {
   efforts: SegmentEffort[]
+  /** Saved segment id, required for the per-row live series query. */
+  segmentId?: number
+  /**
+   * Current playback/hover position as a 0..1 fraction of the segment, or
+   * null when idle. When set, top rows show speed/HR at that position.
+   */
+  activeFraction?: number | null
 }
 
 export function SegmentEffortsLeaderboard({
   efforts,
+  segmentId,
+  activeFraction = null,
 }: Readonly<SegmentEffortsLeaderboardProps>) {
   const [sort, setSort] = useState<EffortSort>('date')
 
@@ -67,6 +84,8 @@ export function SegmentEffortsLeaderboard({
               <TableHead>Distance</TableHead>
               <TableHead>Avg HR</TableHead>
               <TableHead>Max HR</TableHead>
+              <TableHead>Speed @ pt</TableHead>
+              <TableHead>HR @ pt</TableHead>
               <TableHead className="text-right">Activity</TableHead>
             </TableRow>
           </TableHeader>
@@ -114,6 +133,19 @@ export function SegmentEffortsLeaderboard({
                   <TableCell className="tabular-nums">
                     {formatHeartRate(effort.max_heart_rate)}
                   </TableCell>
+                  {segmentId != null ? (
+                    <SegmentEffortLiveCells
+                      segmentId={segmentId}
+                      effort={effort}
+                      activeFraction={activeFraction}
+                      enabled={index < LIVE_ROW_LIMIT}
+                    />
+                  ) : (
+                    <>
+                      <TableCell className="tabular-nums">—</TableCell>
+                      <TableCell className="tabular-nums">—</TableCell>
+                    </>
+                  )}
                   <TableCell className="text-right">
                     <Link
                       to={`/garmin/${effort.activity_id}`}

--- a/src/components/garmin/SegmentElevationProfile.test.tsx
+++ b/src/components/garmin/SegmentElevationProfile.test.tsx
@@ -175,6 +175,25 @@ describe('SegmentElevationProfile', () => {
     ).toBeVisible()
   })
 
+  it('reuses a profile precomputed by the parent', () => {
+    const precomputedProfile = buildSegmentElevationProfile(routePoints)
+
+    render(
+      <SegmentElevationProfile
+        routePoints={[]}
+        precomputedProfile={precomputedProfile}
+      />,
+    )
+
+    expect(screen.getByTestId('elevation-area-chart')).toHaveAttribute(
+      'data-point-count',
+      '3',
+    )
+    expect(
+      screen.queryByTestId('segment-elevation-profile-empty'),
+    ).not.toBeInTheDocument()
+  })
+
   it('renders a clear fallback when elevation data is unavailable', () => {
     render(
       <SegmentElevationProfile

--- a/src/components/garmin/SegmentElevationProfile.tsx
+++ b/src/components/garmin/SegmentElevationProfile.tsx
@@ -15,6 +15,7 @@ import { Button } from '@/components/ui/button'
 import {
   buildSegmentElevationProfile,
   type SegmentElevationChartPoint,
+  type SegmentElevationProfileData,
 } from './SegmentElevationProfile.helpers'
 
 /** Total wall-clock time to animate from start to finish, in milliseconds. */
@@ -73,10 +74,13 @@ function ElevationStat({
 
 export function SegmentElevationProfile({
   routePoints,
+  precomputedProfile,
   loading = false,
   onActivePointChange,
 }: Readonly<{
   routePoints: readonly ActivityChartTrackPoint[]
+  /** Reuse a profile already built by the parent when it also needs the data. */
+  precomputedProfile?: SegmentElevationProfileData | null
   loading?: boolean
   onActivePointChange?: (point: SegmentElevationChartPoint | null) => void
 }>) {
@@ -114,8 +118,11 @@ export function SegmentElevationProfile({
   )
 
   const profile = useMemo(
-    () => buildSegmentElevationProfile(routePoints),
-    [routePoints],
+    () =>
+      precomputedProfile === undefined
+        ? buildSegmentElevationProfile(routePoints)
+        : precomputedProfile,
+    [precomputedProfile, routePoints],
   )
 
   const [playingIndex, setPlayingIndex] = useState<number | null>(null)

--- a/src/components/garmin/segmentEffortSeries.test.ts
+++ b/src/components/garmin/segmentEffortSeries.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest'
+import {
+  binIndexForFraction,
+  sampleAtFraction,
+  type SegmentEffortSeriesBin,
+} from './segmentEffortSeries'
+
+function bin(
+  index: number,
+  overrides: Partial<SegmentEffortSeriesBin> = {},
+): SegmentEffortSeriesBin {
+  return {
+    index,
+    fraction: (index + 0.5) / 10,
+    speed_kmh: 18 + index,
+    heart_rate: 120 + index,
+    ...overrides,
+  }
+}
+
+describe('binIndexForFraction', () => {
+  it('maps fractions to clamped bin indexes', () => {
+    expect(binIndexForFraction(0, 10)).toBe(0)
+    expect(binIndexForFraction(0.05, 10)).toBe(0)
+    expect(binIndexForFraction(0.55, 10)).toBe(5)
+    expect(binIndexForFraction(0.999, 10)).toBe(9)
+    expect(binIndexForFraction(1, 10)).toBe(9)
+  })
+
+  it('clamps out-of-range and invalid inputs', () => {
+    expect(binIndexForFraction(-0.5, 10)).toBe(0)
+    expect(binIndexForFraction(1.5, 10)).toBe(9)
+    expect(binIndexForFraction(Number.NaN, 10)).toBe(0)
+    expect(binIndexForFraction(0.5, 0)).toBe(0)
+  })
+})
+
+describe('sampleAtFraction', () => {
+  it('returns the reading from the exact bin', () => {
+    const bins = Array.from({ length: 10 }, (_, i) => bin(i))
+
+    expect(sampleAtFraction(bins, 0.55)).toEqual({
+      speed_kmh: 23,
+      heart_rate: 125,
+    })
+  })
+
+  it('falls back to the nearest non-empty bin within two bins', () => {
+    const bins = Array.from({ length: 10 }, (_, i) =>
+      i === 5 || i === 6
+        ? bin(i, { speed_kmh: null, heart_rate: null })
+        : bin(i),
+    )
+
+    // Bin 5 is empty; bin 4 is the nearest neighbor with data.
+    expect(sampleAtFraction(bins, 0.55)).toEqual({
+      speed_kmh: 22,
+      heart_rate: 124,
+    })
+  })
+
+  it('returns null when no bin within the radius has data', () => {
+    const bins = Array.from({ length: 10 }, (_, i) =>
+      i >= 3 && i <= 7 ? bin(i, { speed_kmh: null, heart_rate: null }) : bin(i),
+    )
+
+    expect(sampleAtFraction(bins, 0.55)).toBeNull()
+  })
+
+  it('treats a bin with only one metric as data', () => {
+    const bins = [bin(0, { speed_kmh: null, heart_rate: 133 })]
+
+    expect(sampleAtFraction(bins, 0)).toEqual({
+      speed_kmh: null,
+      heart_rate: 133,
+    })
+  })
+
+  it('returns null for an empty series', () => {
+    expect(sampleAtFraction([], 0.5)).toBeNull()
+  })
+})

--- a/src/components/garmin/segmentEffortSeries.ts
+++ b/src/components/garmin/segmentEffortSeries.ts
@@ -1,0 +1,60 @@
+/** One distance bin of an effort's speed/HR series (garminSegmentEffortSeries.bins). */
+export interface SegmentEffortSeriesBin {
+  index: number
+  fraction: number
+  speed_kmh?: number | null
+  heart_rate?: number | null
+}
+
+export interface SegmentEffortSample {
+  speed_kmh: number | null
+  heart_rate: number | null
+}
+
+/**
+ * How many neighboring bins to scan on each side when the exact bin has no
+ * samples (GPS dropouts leave short runs of empty bins mid-series).
+ */
+const NEAREST_BIN_RADIUS = 2
+
+/** Map a 0..1 fraction to a bin index, clamped to the series bounds. */
+export function binIndexForFraction(
+  fraction: number,
+  binCount: number,
+): number {
+  if (binCount <= 0 || !Number.isFinite(fraction)) return 0
+  const index = Math.floor(fraction * binCount)
+  return Math.min(Math.max(index, 0), binCount - 1)
+}
+
+function binHasData(bin: SegmentEffortSeriesBin | undefined): boolean {
+  return bin != null && (bin.speed_kmh != null || bin.heart_rate != null)
+}
+
+/**
+ * The speed/HR reading at the given fraction of the traversal, falling back to
+ * the nearest non-empty bin within {@link NEAREST_BIN_RADIUS} to bridge GPS
+ * gaps. Returns null when no nearby bin has data (degenerate efforts).
+ */
+export function sampleAtFraction(
+  bins: readonly SegmentEffortSeriesBin[],
+  fraction: number,
+): SegmentEffortSample | null {
+  if (bins.length === 0) return null
+
+  const center = binIndexForFraction(fraction, bins.length)
+  for (let offset = 0; offset <= NEAREST_BIN_RADIUS; offset++) {
+    for (const index of offset === 0
+      ? [center]
+      : [center - offset, center + offset]) {
+      const bin = bins[index]
+      if (binHasData(bin)) {
+        return {
+          speed_kmh: bin.speed_kmh ?? null,
+          heart_rate: bin.heart_rate ?? null,
+        }
+      }
+    }
+  }
+  return null
+}

--- a/src/graphql/segments.ts
+++ b/src/graphql/segments.ts
@@ -83,6 +83,35 @@ export const GARMIN_SEGMENT_EFFORTS_QUERY = gql`
   }
 `
 
+export const GARMIN_SEGMENT_EFFORT_SERIES_QUERY = gql`
+  query GarminSegmentEffortSeries(
+    $id: Int!
+    $activity_id: String!
+    $effort_start: String!
+    $effort_end: String!
+    $bins: Int
+  ) {
+    garminSegmentEffortSeries(
+      id: $id
+      activity_id: $activity_id
+      effort_start: $effort_start
+      effort_end: $effort_end
+      bins: $bins
+    ) {
+      activity_id
+      effort_start
+      effort_end
+      bin_count
+      bins {
+        index
+        fraction
+        speed_kmh
+        heart_rate
+      }
+    }
+  }
+`
+
 export const CREATE_GARMIN_SEGMENT_MUTATION = gql`
   mutation CreateGarminSegment($input: CreateGarminSegmentInput!) {
     createGarminSegment(input: $input) {

--- a/src/graphql/segments.ts
+++ b/src/graphql/segments.ts
@@ -112,6 +112,29 @@ export const GARMIN_SEGMENT_EFFORT_SERIES_QUERY = gql`
   }
 `
 
+export const GARMIN_SEGMENT_EFFORT_SERIES_BATCH_QUERY = gql`
+  query GarminSegmentEffortSeriesBatch(
+    $id: Int!
+    $efforts: [GarminSegmentEffortSeriesBatchItemInput!]!
+    $bins: Int
+  ) {
+    garminSegmentEffortSeriesBatch(id: $id, efforts: $efforts, bins: $bins) {
+      items {
+        activity_id
+        effort_start
+        effort_end
+        bin_count
+        bins {
+          index
+          fraction
+          speed_kmh
+          heart_rate
+        }
+      }
+    }
+  }
+`
+
 export const CREATE_GARMIN_SEGMENT_MUTATION = gql`
   mutation CreateGarminSegment($input: CreateGarminSegmentInput!) {
     createGarminSegment(input: $input) {

--- a/src/pages/GarminSegmentDetailPage.test.tsx
+++ b/src/pages/GarminSegmentDetailPage.test.tsx
@@ -9,6 +9,10 @@ const segmentHooks = vi.hoisted(() => ({
   useGarminSegmentQuery: vi.fn(),
   useGarminSegmentEffortsQuery: vi.fn(),
   useGarminChartDataQuery: vi.fn(),
+  useGarminSegmentEffortSeriesQuery: vi.fn(() => ({
+    data: undefined,
+    loading: false,
+  })),
 }))
 
 vi.mock('@/__generated__/graphql', () => segmentHooks)

--- a/src/pages/GarminSegmentDetailPage.test.tsx
+++ b/src/pages/GarminSegmentDetailPage.test.tsx
@@ -9,7 +9,7 @@ const segmentHooks = vi.hoisted(() => ({
   useGarminSegmentQuery: vi.fn(),
   useGarminSegmentEffortsQuery: vi.fn(),
   useGarminChartDataQuery: vi.fn(),
-  useGarminSegmentEffortSeriesQuery: vi.fn(() => ({
+  useGarminSegmentEffortSeriesBatchQuery: vi.fn(() => ({
     data: undefined,
     loading: false,
   })),

--- a/src/pages/GarminSegmentDetailPage.tsx
+++ b/src/pages/GarminSegmentDetailPage.tsx
@@ -117,9 +117,8 @@ export function GarminSegmentDetailPage() {
           lng: activeElevationPoint.longitude,
         }
       : null
-  // Same pure computation SegmentElevationProfile performs internally; the
-  // page needs the total distance to normalize the active point into a 0..1
-  // fraction for the leaderboard's live speed/HR cells.
+  // Build once and share with SegmentElevationProfile; the page also needs the
+  // total distance to normalize the active point for the live speed/HR cells.
   const elevationProfile = useMemo(
     () => buildSegmentElevationProfile(routePoints),
     [routePoints],
@@ -255,6 +254,7 @@ export function GarminSegmentDetailPage() {
             />
             <SegmentElevationProfile
               routePoints={routePoints}
+              precomputedProfile={elevationProfile}
               loading={sourceTrackLoading}
               onActivePointChange={handleActiveElevationPointChange}
             />

--- a/src/pages/GarminSegmentDetailPage.tsx
+++ b/src/pages/GarminSegmentDetailPage.tsx
@@ -19,7 +19,10 @@ import { Badge } from '@/components/ui/badge'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { SegmentStartEndMap } from '@/components/garmin/SegmentStartEndMap'
 import { SegmentElevationProfile } from '@/components/garmin/SegmentElevationProfile'
-import type { SegmentElevationChartPoint } from '@/components/garmin/SegmentElevationProfile.helpers'
+import {
+  buildSegmentElevationProfile,
+  type SegmentElevationChartPoint,
+} from '@/components/garmin/SegmentElevationProfile.helpers'
 import { SegmentPointAddress } from '@/components/garmin/SegmentPointAddress'
 import { SegmentEffortsLeaderboard } from '@/components/garmin/SegmentEffortsLeaderboard'
 import { DeleteSegmentButton } from '@/components/garmin/DeleteSegmentButton'
@@ -113,6 +116,25 @@ export function GarminSegmentDetailPage() {
           lat: activeElevationPoint.latitude,
           lng: activeElevationPoint.longitude,
         }
+      : null
+  // Same pure computation SegmentElevationProfile performs internally; the
+  // page needs the total distance to normalize the active point into a 0..1
+  // fraction for the leaderboard's live speed/HR cells.
+  const elevationProfile = useMemo(
+    () => buildSegmentElevationProfile(routePoints),
+    [routePoints],
+  )
+  const activeFraction =
+    activeElevationPoint != null &&
+    elevationProfile != null &&
+    elevationProfile.distanceMiles > 0
+      ? Math.min(
+          Math.max(
+            activeElevationPoint.distanceMiles / elevationProfile.distanceMiles,
+            0,
+          ),
+          1,
+        )
       : null
 
   const backLink = (
@@ -272,7 +294,11 @@ export function GarminSegmentDetailPage() {
           </CardHeader>
           <CardContent>
             {effortsStatusNode ?? (
-              <SegmentEffortsLeaderboard efforts={efforts} />
+              <SegmentEffortsLeaderboard
+                efforts={efforts}
+                segmentId={id}
+                activeFraction={activeFraction}
+              />
             )}
           </CardContent>
         </Card>


### PR DESCRIPTION
## Summary
- Adds two columns to the segment Effort leaderboard, "Speed @ pt" and "HR @ pt", showing each effort's speed/heart rate at the current position on the course
- While the elevation playback cursor animates (or the chart is hovered — they share the same `onActivePointChange` callback, so hover works for free), the leaderboard fetches speed/HR for the top 20 rows under the current sort and samples it at the cursor's distance fraction
- Uses `garminSegmentEffortSeriesBatch` (stuartshay/otel-data-gateway#213 → stuartshay/otel-data-api#229): **one** request covers all 20 rows, computed with a single database query server-side, instead of 20 separate per-row requests. `SegmentEffortLiveCells` is a pure presentational component; the leaderboard owns the batched fetch and hands each row its own bin slice.
- New `segmentEffortSeries` helpers (fraction→bin lookup with a ±2-bin nearest-non-empty fallback for GPS gaps)
- Idle: zero requests, em dashes. Once active: one batched fetch (`fetchPolicy: 'cache-first'`, effort windows are immutable) that stays warm across the rest of the session — re-sorting triggers exactly one new batched fetch for the newly-ranked top 20; scrubbing playback/hover never issues additional requests.

## Dependency
Requires stuartshay/otel-data-gateway#213 (which requires stuartshay/otel-data-api#228 — merged/deployed — and #229, still open) to be merged/deployed first. This PR's new query will error against the current production gateway until that lands — safe to merge into this repo but hold the *deploy* until the gateway PR is live.

## Test plan
- [x] `vitest run` — 346/346 passing, including 6 tests for the fraction/bin helpers and leaderboard tests covering idle em dashes, values at a given fraction, one batched request for the top 20 rows, and the no-segment-id fallback
- [x] `tsc --noEmit` / `eslint` clean
- [x] Verified end-to-end against a local API → gateway → UI stack (real Cognito test user, real dev DB) on the otel-data-api PR #229 branch: pressed Play on a real segment, watched the top rows' Speed/HR columns update in sync with the elevation cursor. Confirmed via network capture: exactly **1** batch request when playback starts (not 20), **0** new requests across the full 6s of scrubbing or on replay, and exactly **1** new batch request after changing the sort order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)