### PR TITLE
feat(garmin): batch-prefetch route addresses for elevation playback

### DIFF
--- a/src/__generated__/graphql.ts
+++ b/src/__generated__/graphql.ts
@@ -1289,6 +1289,13 @@ export type Query = {
    * Requires the caller's Authorization header because a fallback can persist data.
    */
   reverseGeocodePoint: GeocodedPointAddress;
+  /**
+   * Resolve up to 300 coordinates from the dense point-cell cache in one
+   * database query, with no Pelias fallback. Requires the caller's
+   * Authorization header. Intended to prefetch addresses for a whole route
+   * once instead of one live lookup per point.
+   */
+  reverseGeocodePointsBatch: ReverseGeocodeBatchResponse;
   /** Retrieve a paginated list of unified GPS points from all sources. */
   unifiedGps: UnifiedGpsConnection;
   /** Find GPS points within a named reference location's geofence. */
@@ -1467,6 +1474,11 @@ export type QueryReverseGeocodePointArgs = {
 };
 
 
+export type QueryReverseGeocodePointsBatchArgs = {
+  points: Array<ReverseGeocodePointInput>;
+};
+
+
 export type QueryUnifiedGpsArgs = {
   date_from?: InputMaybe<Scalars['String']['input']>;
   date_to?: InputMaybe<Scalars['String']['input']>;
@@ -1515,6 +1527,56 @@ export type ReferenceLocation = {
   radius_meters: Scalars['Float']['output'];
   /** UTC timestamp when the record was last updated */
   updated_at?: Maybe<Scalars['String']['output']>;
+};
+
+/**
+ * One coordinate's cached address, or a cache miss, from a batch lookup. Unlike
+ * GeocodedPointAddress, this never triggers a Pelias fallback: an unresolved
+ * cell reports status "pending" rather than being resolved synchronously.
+ */
+export type ReverseGeocodeBatchItem = {
+  __typename?: 'ReverseGeocodeBatchItem';
+  /** Pelias confidence score from 0 to 1. */
+  confidence?: Maybe<Scalars['Float']['output']>;
+  /** Country name. */
+  country?: Maybe<Scalars['String']['output']>;
+  /** Full formatted address label. */
+  display_address?: Maybe<Scalars['String']['output']>;
+  /** UTC timestamp when geocoding was performed. */
+  geocoded_at?: Maybe<Scalars['String']['output']>;
+  /** House or building number. */
+  housenumber?: Maybe<Scalars['String']['output']>;
+  /** Resolved 4-decimal cell latitude. */
+  latitude: Scalars['Float']['output'];
+  /** City or town. */
+  locality?: Maybe<Scalars['String']['output']>;
+  /** Resolved 4-decimal cell longitude. */
+  longitude: Scalars['Float']['output'];
+  /** Neighbourhood name. */
+  neighbourhood?: Maybe<Scalars['String']['output']>;
+  /** Postal or ZIP code. */
+  postalcode?: Maybe<Scalars['String']['output']>;
+  /** State or province. */
+  region?: Maybe<Scalars['String']['output']>;
+  /** Geocoding status: success, no_coverage, error, or pending. */
+  status: Scalars['String']['output'];
+  /** Street name. */
+  street?: Maybe<Scalars['String']['output']>;
+};
+
+/** Multiple coordinates' cached addresses, returned in request order. */
+export type ReverseGeocodeBatchResponse = {
+  __typename?: 'ReverseGeocodeBatchResponse';
+  /** Resolved addresses in request order. */
+  items: Array<ReverseGeocodeBatchItem>;
+};
+
+/** One coordinate requested as part of a batch reverse-geocode lookup. */
+export type ReverseGeocodePointInput = {
+  /** Latitude in decimal degrees. */
+  latitude: Scalars['Float']['input'];
+  /** Longitude in decimal degrees. */
+  longitude: Scalars['Float']['input'];
 };
 
 /** Sort direction for query results. */
@@ -1589,6 +1651,8 @@ export type WithinReferenceResult = {
 /** One effort window requested as part of a batch series lookup. */
 
 /** Source used to resolve a point address. */
+
+/** One coordinate requested as part of a batch reverse-geocode lookup. */
 
 /** Sort direction for query results. */
 
@@ -1731,6 +1795,13 @@ export type ReverseGeocodePointQueryVariables = Exact<{
 
 
 export type ReverseGeocodePointQuery = { reverseGeocodePoint: { latitude: number, longitude: number, display_address: string | null, status: string, resolution_source: PointAddressSource } };
+
+export type ReverseGeocodePointsBatchQueryVariables = Exact<{
+  points: Array<ReverseGeocodePointInput> | ReverseGeocodePointInput;
+}>;
+
+
+export type ReverseGeocodePointsBatchQuery = { reverseGeocodePointsBatch: { items: Array<{ latitude: number, longitude: number, display_address: string | null, status: string }> } };
 
 export type TriggerGeocodingMutationVariables = Exact<{
   batch_size?: number | null | undefined;
@@ -2991,6 +3062,54 @@ export type ReverseGeocodePointQueryHookResult = ReturnType<typeof useReverseGeo
 export type ReverseGeocodePointLazyQueryHookResult = ReturnType<typeof useReverseGeocodePointLazyQuery>;
 export type ReverseGeocodePointSuspenseQueryHookResult = ReturnType<typeof useReverseGeocodePointSuspenseQuery>;
 export type ReverseGeocodePointQueryResult = ApolloReactCommon.QueryResult<ReverseGeocodePointQuery, ReverseGeocodePointQueryVariables>;
+export const ReverseGeocodePointsBatchDocument = gql`
+    query ReverseGeocodePointsBatch($points: [ReverseGeocodePointInput!]!) {
+  reverseGeocodePointsBatch(points: $points) {
+    items {
+      latitude
+      longitude
+      display_address
+      status
+    }
+  }
+}
+    `;
+
+/**
+ * __useReverseGeocodePointsBatchQuery__
+ *
+ * To run a query within a React component, call `useReverseGeocodePointsBatchQuery` and pass it any options that fit your needs.
+ * When your component renders, `useReverseGeocodePointsBatchQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useReverseGeocodePointsBatchQuery({
+ *   variables: {
+ *      points: // value for 'points'
+ *   },
+ * });
+ */
+export function useReverseGeocodePointsBatchQuery(baseOptions: ApolloReactHooks.QueryHookOptions<ReverseGeocodePointsBatchQuery, ReverseGeocodePointsBatchQueryVariables> & ({ variables: ReverseGeocodePointsBatchQueryVariables; skip?: boolean; } | { skip: boolean; }) ) {
+        const options = {...defaultOptions, ...baseOptions}
+        return ApolloReactHooks.useQuery<ReverseGeocodePointsBatchQuery, ReverseGeocodePointsBatchQueryVariables>(ReverseGeocodePointsBatchDocument, options);
+      }
+export function useReverseGeocodePointsBatchLazyQuery(baseOptions?: ApolloReactHooks.LazyQueryHookOptions<ReverseGeocodePointsBatchQuery, ReverseGeocodePointsBatchQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return ApolloReactHooks.useLazyQuery<ReverseGeocodePointsBatchQuery, ReverseGeocodePointsBatchQueryVariables>(ReverseGeocodePointsBatchDocument, options);
+        }
+// @ts-ignore
+export function useReverseGeocodePointsBatchSuspenseQuery(baseOptions?: ApolloReactHooks.SuspenseQueryHookOptions<ReverseGeocodePointsBatchQuery, ReverseGeocodePointsBatchQueryVariables>): ApolloReactHooks.UseSuspenseQueryResult<ReverseGeocodePointsBatchQuery, ReverseGeocodePointsBatchQueryVariables>;
+export function useReverseGeocodePointsBatchSuspenseQuery(baseOptions?: ApolloReactHooks.SkipToken | ApolloReactHooks.SuspenseQueryHookOptions<ReverseGeocodePointsBatchQuery, ReverseGeocodePointsBatchQueryVariables>): ApolloReactHooks.UseSuspenseQueryResult<ReverseGeocodePointsBatchQuery | undefined, ReverseGeocodePointsBatchQueryVariables>;
+export function useReverseGeocodePointsBatchSuspenseQuery(baseOptions?: ApolloReactHooks.SkipToken | ApolloReactHooks.SuspenseQueryHookOptions<ReverseGeocodePointsBatchQuery, ReverseGeocodePointsBatchQueryVariables>) {
+          const options = baseOptions === ApolloReactHooks.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
+          return ApolloReactHooks.useSuspenseQuery<ReverseGeocodePointsBatchQuery, ReverseGeocodePointsBatchQueryVariables>(ReverseGeocodePointsBatchDocument, options);
+        }
+export type ReverseGeocodePointsBatchQueryHookResult = ReturnType<typeof useReverseGeocodePointsBatchQuery>;
+export type ReverseGeocodePointsBatchLazyQueryHookResult = ReturnType<typeof useReverseGeocodePointsBatchLazyQuery>;
+export type ReverseGeocodePointsBatchSuspenseQueryHookResult = ReturnType<typeof useReverseGeocodePointsBatchSuspenseQuery>;
+export type ReverseGeocodePointsBatchQueryResult = ApolloReactCommon.QueryResult<ReverseGeocodePointsBatchQuery, ReverseGeocodePointsBatchQueryVariables>;
 export const TriggerGeocodingDocument = gql`
     mutation TriggerGeocoding($batch_size: Int, $retry_failed: Boolean) {
   triggerGeocoding(batch_size: $batch_size, retry_failed: $retry_failed) {

--- a/src/components/garmin/useReverseGeocodedAddress.ts
+++ b/src/components/garmin/useReverseGeocodedAddress.ts
@@ -1,4 +1,10 @@
-import { useEffect, useMemo, useRef, useState } from 'react'
+import {
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  useSyncExternalStore,
+} from 'react'
 import { useReverseGeocodePointLazyQuery } from '@/__generated__/graphql'
 
 export type ReverseGeocodedAddressState =
@@ -9,13 +15,70 @@ export type ReverseGeocodedAddressState =
   | { status: 'error' }
 
 // Round to ~11m precision so small jitter between adjacent samples reuses the
-// cache and we do not flood the geocoder while a cursor sweeps a chart.
-function roundCoord(value: number): number {
+// cache and we do not flood the geocoder while a cursor sweeps a chart. Also
+// the cell size used by otel-data-api's dense point-cell cache, so a rounded
+// key here matches one there exactly.
+export function roundCoord(value: number): number {
   return Math.round(value * 10_000) / 10_000
+}
+
+export function coordinateCacheKey(
+  latitude: number,
+  longitude: number,
+): string {
+  return `${roundCoord(latitude)},${roundCoord(longitude)}`
 }
 
 const DEBOUNCE_MS = 250
 const addressCache = new Map<string, string | null>()
+
+// Mutating addressCache alone does not re-render already-mounted consumers,
+// since it is a plain Map rather than React state. Seeding bumps this
+// version and notifies subscribers below so a point already on screen when a
+// batch prefetch lands picks up the newly-cached address immediately instead
+// of waiting on an unrelated re-render.
+let cacheVersion = 0
+const cacheSubscribers = new Set<() => void>()
+
+/**
+ * Seed the module-level address cache from a batch reverse-geocode prefetch
+ * (see useReverseGeocodedRouteAddresses). Only 'success' results are cached;
+ * 'pending'/'no_coverage'/'error' cells are left unset so the debounced
+ * single-point lookup in useReverseGeocodedAddress still runs for them when
+ * the cursor actually lands there, instead of permanently showing "No
+ * address found" for a point the batch endpoint simply hadn't cached yet.
+ */
+export function seedReverseGeocodedAddressCache(
+  results: readonly {
+    latitude: number
+    longitude: number
+    display_address?: string | null
+    status: string
+  }[],
+): void {
+  let seededAny = false
+  for (const result of results) {
+    if (result.status !== 'success') continue
+    const key = coordinateCacheKey(result.latitude, result.longitude)
+    if (!addressCache.has(key)) {
+      addressCache.set(key, result.display_address ?? null)
+      seededAny = true
+    }
+  }
+  if (seededAny) {
+    cacheVersion += 1
+    for (const notify of cacheSubscribers) notify()
+  }
+}
+
+function subscribeToCache(onChange: () => void): () => void {
+  cacheSubscribers.add(onChange)
+  return () => cacheSubscribers.delete(onChange)
+}
+
+function getCacheVersion(): number {
+  return cacheVersion
+}
 
 interface CoordinateTarget {
   key: string
@@ -65,6 +128,10 @@ export function useReverseGeocodedAddress(
     state: ReverseGeocodedAddressState
   } | null>(null)
   const abortRef = useRef<AbortController | null>(null)
+  // Re-render when a route-level batch prefetch seeds addressCache, so a
+  // point already on screen picks up its address without waiting on an
+  // unrelated re-render (the cache itself is a plain Map, not React state).
+  useSyncExternalStore(subscribeToCache, getCacheVersion, getCacheVersion)
 
   useEffect(() => {
     if (!target || addressCache.has(target.key)) return
@@ -74,6 +141,13 @@ export function useReverseGeocodedAddress(
     abortRef.current = controller
 
     const timer = window.setTimeout(async () => {
+      // Re-check the cache: a route-level batch prefetch (see
+      // useReverseGeocodedRouteAddresses) can seed this exact cell while this
+      // timer was pending, e.g. when both hooks mount together and the batch
+      // response resolves synchronously from Apollo's cache. Skip the
+      // now-redundant single-point request in that case; the render path
+      // below already reads straight from the cache once it is set.
+      if (addressCache.has(target.key)) return
       try {
         const response = await reverseGeocodePoint({
           variables: {

--- a/src/components/garmin/useReverseGeocodedRouteAddresses.test.tsx
+++ b/src/components/garmin/useReverseGeocodedRouteAddresses.test.tsx
@@ -1,0 +1,176 @@
+import { render, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const graphqlMocks = vi.hoisted(() => ({
+  useReverseGeocodePointsBatchQuery: vi.fn(),
+  reverseGeocodePoint: vi.fn(),
+}))
+
+vi.mock('@/__generated__/graphql', () => ({
+  useReverseGeocodePointsBatchQuery:
+    graphqlMocks.useReverseGeocodePointsBatchQuery,
+  useReverseGeocodePointLazyQuery: () => [graphqlMocks.reverseGeocodePoint],
+}))
+
+import { useReverseGeocodedRouteAddresses } from './useReverseGeocodedRouteAddresses'
+import { SegmentPointAddress } from './SegmentPointAddress'
+
+function TestHarness({
+  routePoints,
+  latitude,
+  longitude,
+}: Readonly<{
+  routePoints: { latitude: number | null; longitude: number | null }[]
+  latitude: number
+  longitude: number
+}>) {
+  useReverseGeocodedRouteAddresses(routePoints)
+  return (
+    <SegmentPointAddress
+      latitude={latitude}
+      longitude={longitude}
+      selected={false}
+    />
+  )
+}
+
+describe('useReverseGeocodedRouteAddresses', () => {
+  beforeEach(() => {
+    graphqlMocks.useReverseGeocodePointsBatchQuery.mockReset()
+    graphqlMocks.useReverseGeocodePointsBatchQuery.mockReturnValue({
+      data: undefined,
+    })
+    graphqlMocks.reverseGeocodePoint.mockReset()
+  })
+
+  it('dedupes route points to their rounded cell before requesting a batch', () => {
+    render(
+      <TestHarness
+        routePoints={[
+          { latitude: 41.10011, longitude: -74.20011 },
+          { latitude: 41.100114, longitude: -74.200114 }, // same ~11m cell
+          { latitude: null, longitude: -74.20011 }, // invalid, skipped
+          { latitude: 41.10021, longitude: -74.20021 },
+        ]}
+        latitude={41.10011}
+        longitude={-74.20011}
+      />,
+    )
+
+    expect(graphqlMocks.useReverseGeocodePointsBatchQuery).toHaveBeenCalledWith(
+      expect.objectContaining({
+        variables: {
+          points: [
+            { latitude: 41.10011, longitude: -74.20011 },
+            { latitude: 41.10021, longitude: -74.20021 },
+          ],
+        },
+        skip: false,
+      }),
+    )
+  })
+
+  it('skips the query when there are no valid route points', () => {
+    render(
+      <TestHarness
+        routePoints={[{ latitude: null, longitude: null }]}
+        latitude={41.20011}
+        longitude={-74.30011}
+      />,
+    )
+
+    expect(graphqlMocks.useReverseGeocodePointsBatchQuery).toHaveBeenCalledWith(
+      expect.objectContaining({ skip: true }),
+    )
+  })
+
+  it('caps the batch at 300 deduped points', () => {
+    const routePoints = Array.from({ length: 350 }, (_, i) => ({
+      // Each index moves by ~110m, comfortably past the ~11m dedup cell so
+      // every point is distinct.
+      latitude: 40 + i * 0.001,
+      longitude: -74,
+    }))
+
+    render(
+      <TestHarness routePoints={routePoints} latitude={40} longitude={-74} />,
+    )
+
+    const call = graphqlMocks.useReverseGeocodePointsBatchQuery.mock
+      .calls[0]?.[0] as {
+      variables: { points: unknown[] }
+    }
+    expect(call.variables.points).toHaveLength(300)
+  })
+
+  it('seeds the shared address cache from a successful batch result, letting SegmentPointAddress render it without its own request', async () => {
+    graphqlMocks.useReverseGeocodePointsBatchQuery.mockReturnValue({
+      data: {
+        reverseGeocodePointsBatch: {
+          items: [
+            {
+              latitude: 42.50011,
+              longitude: -75.60011,
+              display_address: 'Prefetched Ave, Prefetch, NY, USA',
+              status: 'success',
+            },
+          ],
+        },
+      },
+    })
+
+    render(
+      <TestHarness
+        routePoints={[{ latitude: 42.50011, longitude: -75.60011 }]}
+        latitude={42.50011}
+        longitude={-75.60011}
+      />,
+    )
+
+    expect(
+      await screen.findByText('Prefetched Ave, Prefetch, NY, USA'),
+    ).toBeInTheDocument()
+    expect(graphqlMocks.reverseGeocodePoint).not.toHaveBeenCalled()
+  })
+
+  it('does not cache a pending batch result, leaving the single-point fallback to resolve it', async () => {
+    graphqlMocks.useReverseGeocodePointsBatchQuery.mockReturnValue({
+      data: {
+        reverseGeocodePointsBatch: {
+          items: [
+            {
+              latitude: 43.50011,
+              longitude: -76.60011,
+              display_address: null,
+              status: 'pending',
+            },
+          ],
+        },
+      },
+    })
+    graphqlMocks.reverseGeocodePoint.mockResolvedValueOnce({
+      data: {
+        reverseGeocodePoint: {
+          latitude: 43.5001,
+          longitude: -76.6001,
+          display_address: 'Resolved later, NY, USA',
+          status: 'success',
+          resolution_source: 'database',
+        },
+      },
+    })
+
+    render(
+      <TestHarness
+        routePoints={[{ latitude: 43.50011, longitude: -76.60011 }]}
+        latitude={43.50011}
+        longitude={-76.60011}
+      />,
+    )
+
+    expect(
+      await screen.findByText('Resolved later, NY, USA'),
+    ).toBeInTheDocument()
+    expect(graphqlMocks.reverseGeocodePoint).toHaveBeenCalledOnce()
+  })
+})

--- a/src/components/garmin/useReverseGeocodedRouteAddresses.test.tsx
+++ b/src/components/garmin/useReverseGeocodedRouteAddresses.test.tsx
@@ -61,8 +61,8 @@ describe('useReverseGeocodedRouteAddresses', () => {
       expect.objectContaining({
         variables: {
           points: [
-            { latitude: 41.10011, longitude: -74.20011 },
-            { latitude: 41.10021, longitude: -74.20021 },
+            { latitude: 41.1001, longitude: -74.2001 },
+            { latitude: 41.1002, longitude: -74.2002 },
           ],
         },
         skip: false,

--- a/src/components/garmin/useReverseGeocodedRouteAddresses.ts
+++ b/src/components/garmin/useReverseGeocodedRouteAddresses.ts
@@ -1,0 +1,72 @@
+import { useEffect, useMemo } from 'react'
+import { useReverseGeocodePointsBatchQuery } from '@/__generated__/graphql'
+import {
+  coordinateCacheKey,
+  seedReverseGeocodedAddressCache,
+} from './useReverseGeocodedAddress'
+
+/** otel-data-api's POST /geocoding/reverse/batch bound (1-300 points). */
+const MAX_BATCH_POINTS = 300
+
+interface RoutePoint {
+  latitude: number | null | undefined
+  longitude: number | null | undefined
+}
+
+/**
+ * Deduplicate route points to their rounded ~11m cell (matching the cache key
+ * used by useReverseGeocodedAddress) and cap at the batch endpoint's limit.
+ * A segment's raw GPS points are far denser than its distinct addresses, so
+ * this keeps the request well under the bound for any reasonably-scoped
+ * segment without needing to chunk into multiple requests.
+ */
+function dedupedBatchPoints(
+  points: readonly RoutePoint[],
+): { latitude: number; longitude: number }[] {
+  const seen = new Set<string>()
+  const result: { latitude: number; longitude: number }[] = []
+  for (const point of points) {
+    if (
+      point.latitude == null ||
+      point.longitude == null ||
+      !Number.isFinite(point.latitude) ||
+      !Number.isFinite(point.longitude)
+    ) {
+      continue
+    }
+    const key = coordinateCacheKey(point.latitude, point.longitude)
+    if (seen.has(key)) continue
+    seen.add(key)
+    result.push({ latitude: point.latitude, longitude: point.longitude })
+    if (result.length >= MAX_BATCH_POINTS) break
+  }
+  return result
+}
+
+/**
+ * Prefetch addresses for an entire route's points in one batched request when
+ * the route loads, seeding useReverseGeocodedAddress's shared cache so
+ * playback/hover mostly resolve instantly instead of firing one debounced
+ * lookup per animation frame (which never settles during a continuous
+ * playback sweep). Points the batch endpoint hasn't cached yet are left for
+ * the existing single-point fallback to resolve lazily, same as before this
+ * prefetch existed.
+ */
+export function useReverseGeocodedRouteAddresses(
+  routePoints: readonly RoutePoint[],
+): void {
+  const points = useMemo(() => dedupedBatchPoints(routePoints), [routePoints])
+
+  const { data } = useReverseGeocodePointsBatchQuery({
+    variables: { points },
+    skip: points.length === 0,
+    fetchPolicy: 'cache-first',
+  })
+
+  useEffect(() => {
+    const items = data?.reverseGeocodePointsBatch.items
+    if (items && items.length > 0) {
+      seedReverseGeocodedAddressCache(items)
+    }
+  }, [data])
+}

--- a/src/components/garmin/useReverseGeocodedRouteAddresses.ts
+++ b/src/components/garmin/useReverseGeocodedRouteAddresses.ts
@@ -1,6 +1,7 @@
 import { useEffect, useMemo } from 'react'
 import { useReverseGeocodePointsBatchQuery } from '@/__generated__/graphql'
 import {
+  roundCoord,
   coordinateCacheKey,
   seedReverseGeocodedAddressCache,
 } from './useReverseGeocodedAddress'
@@ -37,7 +38,13 @@ function dedupedBatchPoints(
     const key = coordinateCacheKey(point.latitude, point.longitude)
     if (seen.has(key)) continue
     seen.add(key)
-    result.push({ latitude: point.latitude, longitude: point.longitude })
+    // Send the same rounded coordinates the key is derived from, rather than
+    // the raw point, so the request is explicit about resolving one address
+    // per ~11m cell instead of relying on the server rounding independently.
+    result.push({
+      latitude: roundCoord(point.latitude),
+      longitude: roundCoord(point.longitude),
+    })
     if (result.length >= MAX_BATCH_POINTS) break
   }
   return result

--- a/src/graphql/geocoding.ts
+++ b/src/graphql/geocoding.ts
@@ -26,6 +26,19 @@ export const REVERSE_GEOCODE_POINT_QUERY = gql`
   }
 `
 
+export const REVERSE_GEOCODE_POINTS_BATCH_QUERY = gql`
+  query ReverseGeocodePointsBatch($points: [ReverseGeocodePointInput!]!) {
+    reverseGeocodePointsBatch(points: $points) {
+      items {
+        latitude
+        longitude
+        display_address
+        status
+      }
+    }
+  }
+`
+
 export const TRIGGER_GEOCODING_MUTATION = gql`
   mutation TriggerGeocoding($batch_size: Int, $retry_failed: Boolean) {
     triggerGeocoding(batch_size: $batch_size, retry_failed: $retry_failed) {

--- a/src/pages/GarminSegmentDetailPage.test.tsx
+++ b/src/pages/GarminSegmentDetailPage.test.tsx
@@ -13,6 +13,10 @@ const segmentHooks = vi.hoisted(() => ({
     data: undefined,
     loading: false,
   })),
+  useReverseGeocodePointsBatchQuery: vi.fn(() => ({
+    data: undefined,
+    loading: false,
+  })),
 }))
 
 vi.mock('@/__generated__/graphql', () => segmentHooks)

--- a/src/pages/GarminSegmentDetailPage.tsx
+++ b/src/pages/GarminSegmentDetailPage.tsx
@@ -24,6 +24,7 @@ import {
   type SegmentElevationChartPoint,
 } from '@/components/garmin/SegmentElevationProfile.helpers'
 import { SegmentPointAddress } from '@/components/garmin/SegmentPointAddress'
+import { useReverseGeocodedRouteAddresses } from '@/components/garmin/useReverseGeocodedRouteAddresses'
 import { SegmentEffortsLeaderboard } from '@/components/garmin/SegmentEffortsLeaderboard'
 import { DeleteSegmentButton } from '@/components/garmin/DeleteSegmentButton'
 import {
@@ -107,6 +108,7 @@ export function GarminSegmentDetailPage() {
         : [],
     [segment, sourceTrackData?.garminChartData],
   )
+  useReverseGeocodedRouteAddresses(routePoints)
   const activeLatLng =
     activeElevationPoint?.latitude != null &&
     Number.isFinite(activeElevationPoint.latitude) &&


### PR DESCRIPTION
## Summary
- Fixes the segment detail page's "Selected point address" never resolving during elevation playback — the ~6s playback animation moves the cursor to a new coordinate faster than the existing 250ms debounce could ever settle, so the single-point lookup kept aborting itself before any request completed.
- Adds `useReverseGeocodedRouteAddresses`, which prefetches the whole route's addresses in **one** request via the new `reverseGeocodePointsBatch` query (stuartshay/otel-data-gateway#218 → stuartshay/otel-data-api#231) when the route loads.
- Route points are deduped to their rounded ~11m cell and capped at the batch endpoint's 300-point bound before being sent — a segment's raw GPS points are far denser than its distinct addresses, so this keeps requests well within bounds for any reasonably-scoped segment.
- Only `status: "success"` results are cached; cache misses are left for the existing single-point lookup to resolve lazily, same as before this prefetch existed (matches this session's earlier finding that dense per-point geocoding coverage isn't universal, so a pure-read batch endpoint will legitimately miss some points).

## Design notes
`useReverseGeocodedAddress`'s address cache is a plain module-level `Map`, so seeding it from the batch prefetch doesn't by itself re-render an already-mounted `SegmentPointAddress` consumer. Two small follow-on fixes were needed to make the prefetch actually visible:
- Added a minimal version counter + `useSyncExternalStore` subscription so a point already on screen when the batch prefetch resolves picks up its address immediately, instead of waiting on an unrelated re-render.
- The debounced single-point lookup now re-checks the cache inside its `setTimeout` callback (not just when the effect is scheduled), so a prefetch landing mid-debounce cancels the now-redundant request instead of firing it anyway.

Both were caught by a genuine race in the new tests (batch data resolving synchronously in the same commit as the point's own mount) — not a change made speculatively.

## Dependency
Requires stuartshay/otel-data-gateway#218 (which requires stuartshay/otel-data-api#231) to be merged/deployed first — the GraphQL field doesn't exist on `master`/prod yet. Regenerated `src/__generated__/graphql.ts` against the gateway feature branch's local schema file (`GRAPHQL_SCHEMA_PATH` override in `codegen.ts`) since the field isn't in the published `@stuartshay/otel-data-types` package yet; the diff is purely additive and will regenerate identically once that package catches up.

## Test plan
- [x] `npx vitest run` — 503/503 passing, including 5 new tests for `useReverseGeocodedRouteAddresses` (dedup, skip-when-empty, 300-point cap, cache-seeding making an on-screen point resolve without its own request, and the pending/miss case still falling back to the single-point lookup)
- [x] `npx tsc --noEmit` / `eslint` — clean
- [x] `prettier --check` — clean

## Deployment
- No environment or production infrastructure changes required
- Safe to merge ahead of the gateway/API dependency (additive only); should deploy after stuartshay/otel-data-gateway#218 is live, same sequencing as this session's earlier Speed/HR batch chain (#229 → #213 → #477)

🤖 Generated with [Claude Code](https://claude.com/claude-code)