### PR TITLE
fix(garmin): pause elevation playback in place instead of resetting

### DIFF
--- a/src/components/garmin/SegmentElevationProfile.test.tsx
+++ b/src/components/garmin/SegmentElevationProfile.test.tsx
@@ -324,16 +324,17 @@ describe('SegmentElevationProfile', () => {
     await user.click(
       screen.getByRole('button', { name: 'Play route playback' }),
     )
-    expect(requestFrame).toHaveBeenCalledTimes(1)
-
-    // Run the first queued frame at t=0 (start of the animation).
-    act(() => frameCallbacks.shift()?.(0))
-    // queueActivePointChange defers the actual callback by one more frame.
-    act(() => frameCallbacks.shift()?.(0))
+    // startPlayback emits the starting point synchronously (so a Pause
+    // clicked before the first tick still has a position), which itself
+    // queues one coalescing frame, plus the actual playback step frame.
+    expect(requestFrame).toHaveBeenCalledTimes(2)
     expect(
       screen.getByRole('button', { name: 'Pause route playback' }),
     ).toBeVisible()
     expect(screen.getByTestId('elevation-playing-dot')).toBeInTheDocument()
+
+    // Run the queued coalescing frame for the synchronous starting point.
+    act(() => frameCallbacks.shift()?.(0))
     expect(onActivePointChange).toHaveBeenLastCalledWith(
       expect.objectContaining({ latitude: 40.79, longitude: -73.96 }),
     )
@@ -380,6 +381,15 @@ describe('SegmentElevationProfile', () => {
     await user.click(
       screen.getByRole('button', { name: 'Play route playback' }),
     )
+    // startPlayback emits the starting point (index 0) synchronously, which
+    // queues one coalescing frame in addition to the real playback step.
+    // Drain it first so onActivePointChange reflects the start point before
+    // advancing into the animation itself.
+    act(() => frameCallbacks.shift()?.(0))
+    expect(onActivePointChange).toHaveBeenLastCalledWith(
+      expect.objectContaining({ latitude: 40.79, longitude: -73.96 }),
+    )
+
     // Advance partway through the animation (half the 6s duration), landing
     // on the middle profile point (index 1 of 3).
     act(() => frameCallbacks.shift()?.(3000))
@@ -419,6 +429,13 @@ describe('SegmentElevationProfile', () => {
     await user.click(
       screen.getByRole('button', { name: 'Play route playback' }),
     )
+    // Resuming also emits the paused point synchronously, queuing its own
+    // coalescing frame ahead of the real resumed step; drain it first.
+    act(() => frameCallbacks.shift()?.(100))
+    expect(onActivePointChange).toHaveBeenLastCalledWith(
+      expect.objectContaining({ latitude: 40.795, longitude: -73.955 }),
+    )
+
     act(() => frameCallbacks.shift()?.(3100))
     act(() => frameCallbacks.shift()?.(3100))
     expect(onActivePointChange).toHaveBeenLastCalledWith(

--- a/src/components/garmin/SegmentElevationProfile.test.tsx
+++ b/src/components/garmin/SegmentElevationProfile.test.tsx
@@ -357,6 +357,82 @@ describe('SegmentElevationProfile', () => {
     now.mockRestore()
   })
 
+  it('pauses in place and resumes from the paused position instead of restarting', async () => {
+    const frameCallbacks: FrameRequestCallback[] = []
+    const requestFrame = vi
+      .spyOn(window, 'requestAnimationFrame')
+      .mockImplementation((callback) => {
+        frameCallbacks.push(callback)
+        return frameCallbacks.length
+      })
+    const cancelFrame = vi.spyOn(window, 'cancelAnimationFrame')
+    const now = vi.spyOn(performance, 'now').mockReturnValue(0)
+    const onActivePointChange = vi.fn()
+    const user = userEvent.setup()
+
+    render(
+      <SegmentElevationProfile
+        routePoints={routePoints}
+        onActivePointChange={onActivePointChange}
+      />,
+    )
+
+    await user.click(
+      screen.getByRole('button', { name: 'Play route playback' }),
+    )
+    // Advance partway through the animation (half the 6s duration), landing
+    // on the middle profile point (index 1 of 3).
+    act(() => frameCallbacks.shift()?.(3000))
+    act(() => frameCallbacks.shift()?.(3000))
+    expect(
+      screen.getByRole('button', { name: 'Pause route playback' }),
+    ).toBeVisible()
+    expect(onActivePointChange).toHaveBeenLastCalledWith(
+      expect.objectContaining({ latitude: 40.795, longitude: -73.955 }),
+    )
+
+    // Pause: the animation frame is cancelled, but the marker/active point
+    // stay at the paused position rather than resetting to null.
+    await user.click(
+      screen.getByRole('button', { name: 'Pause route playback' }),
+    )
+    expect(cancelFrame).toHaveBeenCalled()
+    expect(
+      screen.getByRole('button', { name: 'Play route playback' }),
+    ).toBeVisible()
+    expect(screen.getByTestId('elevation-playing-dot')).toBeInTheDocument()
+    expect(onActivePointChange).toHaveBeenLastCalledWith(
+      expect.objectContaining({ latitude: 40.795, longitude: -73.955 }),
+    )
+    // The mocked requestAnimationFrame queue does not actually remove a
+    // frame cancelled via cancelAnimationFrame (unlike a real browser), so
+    // drop the stale pre-pause frame that's still sitting in the queue
+    // before resuming, or it would run ahead of the fresh resumed step.
+    frameCallbacks.length = 0
+
+    // Resume: pressing Play again continues from the paused index instead of
+    // restarting at t=0. Paused halfway through (index 1 of 2), so only the
+    // remaining half of the 6000ms duration (3000ms of wall-clock time from
+    // the resume click) is needed to reach the final point -- a fresh
+    // restart would need the full 6000ms instead.
+    now.mockReturnValue(100)
+    await user.click(
+      screen.getByRole('button', { name: 'Play route playback' }),
+    )
+    act(() => frameCallbacks.shift()?.(3100))
+    act(() => frameCallbacks.shift()?.(3100))
+    expect(onActivePointChange).toHaveBeenLastCalledWith(
+      expect.objectContaining({ latitude: null, longitude: null }),
+    )
+    expect(
+      screen.getByRole('button', { name: 'Play route playback' }),
+    ).toBeVisible()
+
+    requestFrame.mockRestore()
+    cancelFrame.mockRestore()
+    now.mockRestore()
+  })
+
   it('stops playback when the user hovers the chart manually', async () => {
     const frameCallbacks: FrameRequestCallback[] = []
     const requestFrame = vi

--- a/src/components/garmin/SegmentElevationProfile.tsx
+++ b/src/components/garmin/SegmentElevationProfile.tsx
@@ -178,6 +178,11 @@ export function SegmentElevationProfile({
       (startIndex / (totalPoints - 1)) * PLAYBACK_DURATION_MS
     setIsAnimating(true)
     setPausedIndex(null)
+    // Set synchronously (not left to the first step() tick) so a Pause
+    // clicked before the first animation frame runs still has a position to
+    // pause at, instead of pausedIndex falling back to null/a reset.
+    setPlayingIndex(startIndex)
+    queueActivePointChange(profile.points[startIndex])
 
     const step = (now: number) => {
       const elapsed = now - startTime

--- a/src/components/garmin/SegmentElevationProfile.tsx
+++ b/src/components/garmin/SegmentElevationProfile.tsx
@@ -126,22 +126,58 @@ export function SegmentElevationProfile({
   )
 
   const [playingIndex, setPlayingIndex] = useState<number | null>(null)
+  // Whether the animation loop is actively advancing. Distinct from
+  // playingIndex != null, which stays set while paused so the marker and
+  // Speed/HR cells keep showing the paused position instead of resetting.
+  const [isAnimating, setIsAnimating] = useState(false)
+  // The index playback was paused at, so Play resumes from there instead of
+  // always restarting at the beginning. Cleared whenever playback runs to
+  // completion or the route changes, so a finished or freshly-loaded route
+  // starts over from index 0.
+  const [pausedIndex, setPausedIndex] = useState<number | null>(null)
   const playbackFrameRef = useRef<number | null>(null)
 
+  // True stop/reset: cancels the animation frame and clears the active point
+  // entirely. Used when the route changes or the chart is hovered (which
+  // takes over the active-point display), not by the Pause button itself --
+  // that calls pausePlayback below so position is kept.
   const stopPlayback = useCallback(() => {
     if (playbackFrameRef.current != null) {
       window.cancelAnimationFrame(playbackFrameRef.current)
       playbackFrameRef.current = null
     }
+    setIsAnimating(false)
     setPlayingIndex(null)
+    setPausedIndex(null)
     queueActivePointChange(null)
   }, [queueActivePointChange])
+
+  // Pauses in place: cancels the animation frame but keeps the current
+  // position (both the displayed active point and pausedIndex), so a
+  // subsequent Play resumes from here instead of restarting.
+  const pausePlayback = useCallback(() => {
+    if (playbackFrameRef.current != null) {
+      window.cancelAnimationFrame(playbackFrameRef.current)
+      playbackFrameRef.current = null
+    }
+    setIsAnimating(false)
+    setPausedIndex(playingIndex)
+  }, [playingIndex])
 
   const startPlayback = useCallback(() => {
     if (!profile || profile.points.length < 2) return
 
     const totalPoints = profile.points.length
-    const startTime = performance.now()
+    const startIndex = pausedIndex ?? 0
+    // Back-date the start time so elapsed/PLAYBACK_DURATION_MS already
+    // reflects startIndex's progress -- resuming partway through plays only
+    // the remaining distance, over its proportional share of the full
+    // duration, rather than restarting the full 6s from the resume point.
+    const startTime =
+      performance.now() -
+      (startIndex / (totalPoints - 1)) * PLAYBACK_DURATION_MS
+    setIsAnimating(true)
+    setPausedIndex(null)
 
     const step = (now: number) => {
       const elapsed = now - startTime
@@ -156,6 +192,7 @@ export function SegmentElevationProfile({
 
       if (progress >= 1) {
         playbackFrameRef.current = null
+        setIsAnimating(false)
         setPlayingIndex(null)
         return
       }
@@ -163,26 +200,28 @@ export function SegmentElevationProfile({
     }
 
     playbackFrameRef.current = window.requestAnimationFrame(step)
-  }, [profile, queueActivePointChange])
+  }, [profile, pausedIndex, queueActivePointChange])
 
   const togglePlayback = useCallback(() => {
-    if (playbackFrameRef.current != null || playingIndex != null) {
-      stopPlayback()
+    if (isAnimating) {
+      pausePlayback()
     } else {
       startPlayback()
     }
-  }, [playingIndex, startPlayback, stopPlayback])
+  }, [isAnimating, pausePlayback, startPlayback])
 
   // Stop any in-flight playback when the underlying route changes (e.g. a
   // different segment is viewed), so the button doesn't get stuck showing
-  // Pause with no animation running.
+  // Pause with no animation running, and a new route always starts fresh.
   useEffect(() => {
     return () => {
       if (playbackFrameRef.current != null) {
         window.cancelAnimationFrame(playbackFrameRef.current)
         playbackFrameRef.current = null
-        setPlayingIndex(null)
       }
+      setIsAnimating(false)
+      setPlayingIndex(null)
+      setPausedIndex(null)
     }
   }, [routePoints])
 
@@ -208,8 +247,8 @@ export function SegmentElevationProfile({
     )
   }
 
-  const isPlaying = playingIndex != null
-  const playingPoint = isPlaying ? profile.points[playingIndex] : null
+  const hasPlaybackPosition = playingIndex != null
+  const playingPoint = hasPlaybackPosition ? profile.points[playingIndex] : null
   const accessibleSummary = `Elevation profile from ${formatFeet(profile.startElevationFeet)} at the segment start to ${formatFeet(profile.finishElevationFeet)} at the finish, with ${formatFeet(profile.elevationGainFeet)} of elevation gain over ${profile.distanceMiles.toFixed(2)} miles.`
 
   return (
@@ -235,12 +274,12 @@ export function SegmentElevationProfile({
             size="sm"
             data-testid="segment-elevation-play-button"
             aria-label={
-              isPlaying ? 'Pause route playback' : 'Play route playback'
+              isAnimating ? 'Pause route playback' : 'Play route playback'
             }
             onClick={togglePlayback}
             disabled={profile.points.length < 2}
           >
-            {isPlaying ? (
+            {isAnimating ? (
               <Pause className="h-4 w-4" aria-hidden="true" />
             ) : (
               <Play className="h-4 w-4" aria-hidden="true" />
@@ -275,12 +314,12 @@ export function SegmentElevationProfile({
             onMouseMove={(state: {
               activeTooltipIndex?: number | string | null
             }) => {
-              if (isPlaying) stopPlayback()
+              if (hasPlaybackPosition) stopPlayback()
               const point = pointFromTooltipState(state, profile.points)
               if (point) queueActivePointChange(point)
             }}
             onMouseLeave={() => {
-              if (isPlaying) return
+              if (hasPlaybackPosition) return
               queueActivePointChange(null)
             }}
           >


### PR DESCRIPTION
## Summary

The segment elevation chart's Play button already showed a Pause icon while animating (and its `aria-label` already said "Pause route playback"), but clicking it called `stopPlayback`, which cleared both the current position (`playingIndex`) and the active point entirely (`queueActivePointChange(null)`). So the button looked like a pause control but behaved like stop+reset: the marker, map, and Speed/HR leaderboard cells all snapped back to idle, and pressing Play again always restarted the whole route from index 0 instead of resuming.

## Fix

- Splits the previous `stopPlayback` into two functions:
  - `stopPlayback` — true reset (cancels the frame, clears position and active point entirely). Still used for route changes and manual chart hover, which should fully take over.
  - `pausePlayback` — cancels the animation frame but **keeps** the current index and active point, so the marker/leaderboard stay showing the paused position.
- `startPlayback` now resumes from the paused index (`pausedIndex ?? 0`) instead of always starting at 0.
- The resumed animation's start time is back-dated so the remaining distance plays over its proportional share of the 6s `PLAYBACK_DURATION_MS`, rather than giving the remainder a fresh full 6s — total playback time stays ~6s regardless of how many times it's paused and resumed.
- Introduced a real `isAnimating` state (separate from `playingIndex != null`) to drive the Play/Pause icon and the hover-interrupt logic correctly, since `playingIndex` now stays set while paused.

## Test plan
- [x] `npx vitest run src/components/garmin/SegmentElevationProfile.test.tsx` — 15/15 passing, including a new test that plays to the halfway point, pauses (asserting the marker/active point stay at the paused position, not null), resumes, and confirms the remaining half of the route finishes using only the *remaining* proportional duration rather than a fresh full 6s — the actual proof that resume doesn't restart.
- [x] `npx vitest run` (full suite) — 504/504 passing
- [x] `npx tsc --noEmit` / `eslint` / `prettier --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)