### PR TITLE
fix: wire NRBA keys through entrypoint.sh runtime config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,13 @@ VITE_COGNITO_ISSUER=https://cognito-idp.us-east-1.amazonaws.com/us-east-1_ZL7M5Q
 VITE_APP_VERSION=dev
 VITE_APP_NAME=otel-data-ui
 
+# New Relic Browser Agent (optional — get from: New Relic → Browser → Setup)
+VITE_NRBA_ACCOUNT_ID=YOUR_NRBA_ACCOUNT_ID
+VITE_NRBA_APPLICATION_ID=YOUR_NRBA_APPLICATION_ID
+VITE_NRBA_LICENSE_KEY=YOUR_NRBA_LICENSE_KEY
+VITE_NRBA_TRUST_KEY=YOUR_NRBA_TRUST_KEY
+VITE_NRBA_AGENT_ID=YOUR_NRBA_AGENT_ID
+
 # SonarQube scanner configuration
 SONAR_HOST_URL=https://sonar.lab.informationcart.com
 SONAR_PROJECT_KEY=otel-data-ui

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -16,7 +16,12 @@ window.__ENV__ = {
   COGNITO_ISSUER: "${VITE_COGNITO_ISSUER:-https://cognito-idp.us-east-1.amazonaws.com/us-east-1_ZL7M5Qa7K}",
   APP_VERSION: "${VITE_APP_VERSION:-dev}",
   APP_NAME: "${VITE_APP_NAME:-otel-data-ui}",
-  GEOCODER_URL: "${VITE_GEOCODER_URL:-https://geocoder.lab.informationcart.com}"
+  GEOCODER_URL: "${VITE_GEOCODER_URL:-https://geocoder.lab.informationcart.com}",
+  NRBA_ACCOUNT_ID: "${VITE_NRBA_ACCOUNT_ID:-}",
+  NRBA_APPLICATION_ID: "${VITE_NRBA_APPLICATION_ID:-}",
+  NRBA_LICENSE_KEY: "${VITE_NRBA_LICENSE_KEY:-}",
+  NRBA_TRUST_KEY: "${VITE_NRBA_TRUST_KEY:-}",
+  NRBA_AGENT_ID: "${VITE_NRBA_AGENT_ID:-}"
 };
 EOF
 

--- a/src/lib/newrelic-browser.ts
+++ b/src/lib/newrelic-browser.ts
@@ -30,7 +30,9 @@ export function initNewRelicBrowser(): void {
       init: {
         distributed_tracing: { enabled: true },
         privacy: { cookies_enabled: true },
-        ajax: { deny_list: [] },
+        // Exclude the agent's own beacon endpoint so it doesn't monitor
+        // (and generate AJAX events for) its own telemetry uploads.
+        ajax: { deny_list: ['bam.nr-data.net'] },
       },
       info: {
         beacon: 'bam.nr-data.net',


### PR DESCRIPTION
## Summary
- `entrypoint.sh` now writes the 5 `NRBA_*` keys into `window.__ENV__` (config.js) from their `VITE_NRBA_*` container env vars
- `src/lib/newrelic-browser.ts`: exclude the agent's own beacon endpoint (`bam.nr-data.net`) from AJAX monitoring
- `.env.example`: document the `VITE_NRBA_*` vars for local dev

## Why
The New Relic Browser Agent init code (`newrelic-browser.ts`) and runtime-config reader (`config/runtime.ts`) already exist, but `entrypoint.sh` never actually wrote the `NRBA_*` keys into `config.js` — so `window.__ENV__.NRBA_ACCOUNT_ID` was always empty in production and `initNewRelicBrowser()` silently no-op'd (`if (!accountId) return`). This is why the browser agent has never actually been active.

Redoes the fix from #34 (closed 2026-07-26 after it accidentally bundled an unrelated repo-wide pre-commit/secrets-baseline setup) as an isolated change.

**Companion PR:** k8s-gitops (redoing #234, which is now stale/conflicting against current master — same rebase issue) provides the actual `VITE_NRBA_*` values via ConfigMap/Deployment.

## Test plan
- [x] `npm run lint`, `npm run build`
- [x] `vitest run` on `newrelic-browser.test.ts` / `runtime.test.ts` (11 passed)
- [x] `shellcheck entrypoint.sh` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)