### PR TITLE
fix: getConfig empty window.__ENV__ value must not shadow a fallback

### DIFF
--- a/src/config/runtime.test.ts
+++ b/src/config/runtime.test.ts
@@ -7,13 +7,16 @@ describe('runtime config', () => {
     // don't set it themselves can silently inherit a previous test's value.
     window.__ENV__ = undefined
     // Vite loads .env.local into import.meta.env for test runs same as
-    // dev/build. A developer's local NRBA_* values there would otherwise
-    // leak into these tests non-deterministically once an empty
-    // window.__ENV__ value correctly falls through to it.
+    // dev/build. A developer's local values there would otherwise leak
+    // into these tests non-deterministically once an empty window.__ENV__
+    // value correctly falls through to it.
     vi.unstubAllEnvs()
     vi.stubEnv('VITE_NRBA_ACCOUNT_ID', '')
     vi.stubEnv('VITE_NRBA_APPLICATION_ID', '')
     vi.stubEnv('VITE_NRBA_LICENSE_KEY', '')
+    vi.stubEnv('VITE_NRBA_TRUST_KEY', '')
+    vi.stubEnv('VITE_NRBA_AGENT_ID', '')
+    vi.stubEnv('VITE_APP_VERSION', '')
   })
 
   it('prefers runtime window config over Vite env values', () => {

--- a/src/config/runtime.test.ts
+++ b/src/config/runtime.test.ts
@@ -1,7 +1,21 @@
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { getAllConfig, getConfig } from './runtime'
 
 describe('runtime config', () => {
+  beforeEach(() => {
+    // window.__ENV__ is a mutable global; without resetting it, tests that
+    // don't set it themselves can silently inherit a previous test's value.
+    window.__ENV__ = undefined
+    // Vite loads .env.local into import.meta.env for test runs same as
+    // dev/build. A developer's local NRBA_* values there would otherwise
+    // leak into these tests non-deterministically once an empty
+    // window.__ENV__ value correctly falls through to it.
+    vi.unstubAllEnvs()
+    vi.stubEnv('VITE_NRBA_ACCOUNT_ID', '')
+    vi.stubEnv('VITE_NRBA_APPLICATION_ID', '')
+    vi.stubEnv('VITE_NRBA_LICENSE_KEY', '')
+  })
+
   it('prefers runtime window config over Vite env values', () => {
     window.__ENV__ = {
       GRAPHQL_URL: 'https://runtime.example.com/graphql',
@@ -31,6 +45,31 @@ describe('runtime config', () => {
 
   it('uses the provided fallback for missing optional config', () => {
     expect(getConfig('APP_VERSION', 'dev')).toBe('dev')
+  })
+
+  it('uses the provided fallback when window.__ENV__ has an empty string', () => {
+    // entrypoint.sh writes every window.__ENV__ key, even when the
+    // underlying container env var is unset -- an empty string there must
+    // not shadow a caller-supplied fallback (regression: this silently
+    // zeroed out NRBA_TRUST_KEY/NRBA_AGENT_ID at runtime).
+    window.__ENV__ = {
+      GRAPHQL_URL: 'https://runtime.example.com/graphql',
+      COGNITO_DOMAIN: 'runtime-domain',
+      COGNITO_CLIENT_ID: 'runtime-client',
+      COGNITO_REDIRECT_URI: 'https://runtime.example.com/callback',
+      COGNITO_ISSUER: 'https://issuer.runtime.example.com',
+      APP_VERSION: '2.3.4',
+      APP_NAME: 'runtime-ui',
+      NRBA_ACCOUNT_ID: '7574022',
+      NRBA_APPLICATION_ID: '1134672998',
+      NRBA_LICENSE_KEY: 'test-license-key',
+      NRBA_TRUST_KEY: '',
+      NRBA_AGENT_ID: '',
+      GEOCODER_URL: 'https://geocoder.runtime.example.com',
+    }
+
+    expect(getConfig('NRBA_TRUST_KEY', '7574022')).toBe('7574022')
+    expect(getConfig('NRBA_AGENT_ID', '1134672998')).toBe('1134672998')
   })
 
   it('throws when required configuration is missing', () => {

--- a/src/config/runtime.ts
+++ b/src/config/runtime.ts
@@ -26,15 +26,9 @@ export function getConfig<K extends keyof RuntimeConfig>(
 ): string {
   if (typeof window !== 'undefined' && window.__ENV__) {
     const value = window.__ENV__[key]
-    // An empty string from window.__ENV__ (entrypoint.sh always writes every
-    // key, even when the underlying container env var is unset) must fall
-    // through to the Vite env / fallback below rather than winning outright
-    // -- otherwise a caller-supplied fallback can never actually be used at
-    // runtime. Verified live: this silently zeroed out NRBA_TRUST_KEY/
-    // NRBA_AGENT_ID (falling back to accountId/applicationId in
-    // newrelic-browser.ts), which made the agent's distributed-tracing
-    // payload generation bail out entirely (it requires a non-empty
-    // agentID) even with allowed_origins configured correctly.
+    // An empty string in window.__ENV__ must be treated as absent and fall
+    // through to the Vite env / fallback below -- otherwise a caller-
+    // supplied fallback can never actually be used at runtime.
     if (value !== undefined && value !== null && value !== '') {
       return value
     }

--- a/src/config/runtime.ts
+++ b/src/config/runtime.ts
@@ -26,8 +26,17 @@ export function getConfig<K extends keyof RuntimeConfig>(
 ): string {
   if (typeof window !== 'undefined' && window.__ENV__) {
     const value = window.__ENV__[key]
-    if (value !== undefined && value !== null) {
-      if (value !== '' || fallback !== undefined) return value
+    // An empty string from window.__ENV__ (entrypoint.sh always writes every
+    // key, even when the underlying container env var is unset) must fall
+    // through to the Vite env / fallback below rather than winning outright
+    // -- otherwise a caller-supplied fallback can never actually be used at
+    // runtime. Verified live: this silently zeroed out NRBA_TRUST_KEY/
+    // NRBA_AGENT_ID (falling back to accountId/applicationId in
+    // newrelic-browser.ts), which made the agent's distributed-tracing
+    // payload generation bail out entirely (it requires a non-empty
+    // agentID) even with allowed_origins configured correctly.
+    if (value !== undefined && value !== null && value !== '') {
+      return value
     }
   }
 


### PR DESCRIPTION
## Summary
- \`getConfig()\` now treats an empty string from \`window.__ENV__\` as absent, falling through to the Vite env / caller-supplied fallback — instead of returning the empty string whenever a fallback happened to be provided

## Why
Found live while verifying end-to-end distributed tracing (Playwright against production, following #514). The NR Browser Agent was fully active — but its own \`loader_config.agentID\`/\`trustKey\` were empty strings despite \`newrelic-browser.ts\` passing \`accountId\`/\`applicationId\` as fallbacks. That made the agent's distributed-tracing payload generation bail out entirely (\`@newrelic/browser-agent\`'s \`DT.generateTracePayload\` requires a non-empty \`agentID\`), even with \`allowed_origins\` configured correctly.

Root cause: \`entrypoint.sh\` writes every \`window.__ENV__\` key, even when the underlying container env var is unset (as \`""\`) — and the old \`getConfig\` logic special-cased "return the empty value anyway" whenever a fallback was provided, which is backwards.

## Test plan
- [x] Added a regression test reproducing the exact scenario (empty \`window.__ENV__\` value + non-empty fallback)
- [x] Full suite: \`npm run lint\`, \`npm run build\`, \`vitest run\` (506/506 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)