### PR TITLE
ci: skip lint/test/build/docker jobs on draft PRs

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -12,6 +12,11 @@ on:
         type: boolean
   pull_request:
     branches: [master, develop]
+    # Explicit types (GitHub's default omits ready_for_review): without
+    # this, marking a draft "ready for review" wouldn't re-trigger the
+    # workflow unless a new commit was also pushed, leaving the required
+    # checks in their draft-skipped (passing) state through a merge.
+    types: [opened, synchronize, reopened, ready_for_review]
 
 concurrency:
   group: docker-${{ github.workflow }}-${{ github.ref }}
@@ -24,6 +29,7 @@ jobs:
   build:
     name: Build and Push
     runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     permissions:
       contents: read
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,6 +5,11 @@ on:
     branches: [master, develop]
   pull_request:
     branches: [master, develop]
+    # Explicit types (GitHub's default omits ready_for_review): without
+    # this, marking a draft "ready for review" wouldn't re-trigger the
+    # workflow unless a new commit was also pushed, leaving the required
+    # checks in their draft-skipped (passing) state through a merge.
+    types: [opened, synchronize, reopened, ready_for_review]
 
 concurrency:
   group: lint-${{ github.workflow }}-${{ github.ref }}
@@ -22,6 +27,7 @@ jobs:
     name: ESLint and TypeScript Check
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -63,6 +69,7 @@ jobs:
     name: Build Check
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -83,6 +90,7 @@ jobs:
     name: Dockerfile Lint
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -96,6 +104,7 @@ jobs:
     name: Security Audit
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -116,6 +125,7 @@ jobs:
     name: Tests and Coverage
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     steps:
       - name: Checkout
         uses: actions/checkout@v7


### PR DESCRIPTION
## Summary
- Skip ESLint/TypeScript, Build, Dockerfile Lint, Security Audit, Tests/Coverage, and Docker build-and-push when the triggering PR is a draft
- Add `ready_for_review` to both workflows' `pull_request` trigger types

## Why
Same pattern as [otel-data-gateway#240](https://github.com/stuartshay/otel-data-gateway/pull/240) and [otel-data-api#243](https://github.com/stuartshay/otel-data-api/pull/243): Renovate opens major-version bump PRs as drafts when they need manual review (e.g. [#297](https://github.com/stuartshay/otel-data-ui/pull/297), TypeScript v7, blocked on `ts-jest`/`typescript-eslint` not supporting it yet), and every rebase push re-ran the full pipeline — including the Docker buildx job — for a result that can't change until the underlying blocker is resolved.

## Is this safe for required status checks?
Branch protection requires `ESLint and TypeScript Check`, `Build Check`, and `Build and Push`. GitHub doesn't block merging on a *conditionally-skipped* required check, and a draft PR can't be merged at all regardless. `ready_for_review` is added explicitly to both workflows' trigger types since GitHub's default (`[opened, synchronize, reopened]`) omits it — without that, marking a draft ready without also pushing a new commit would leave the required checks in their draft-skipped (passing) state through a merge.

The `summary` (Workflow Summary) job's `needs.*.result` handling already has a case for `skipped` and runs with `if: always()`, so no change needed there.

## Test plan
- [x] YAML validated

🤖 Generated with [Claude Code](https://claude.com/claude-code)