### PR TITLE
perf(ci): build arm64-only, drop wasted amd64 Docker build

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -119,7 +119,8 @@ jobs:
         with:
           context: .
           # k8s-pi5-cluster (the only deployment target) is arm64-only --
-          # confirmed via `kubectl get nodes -o jsonpath='{.status.nodeInfo.architecture}'`
+          # confirmed via
+          # `kubectl get nodes -o jsonpath='{.items[*].status.nodeInfo.architecture}'`
           # across all 4 nodes. amd64 was never deployed, so building it
           # (on PRs and master alike) was pure waste; arm64 now covers both.
           platforms: linux/arm64

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -118,7 +118,11 @@ jobs:
         uses: docker/build-push-action@v7
         with:
           context: .
-          platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64' || 'linux/amd64,linux/arm64' }}
+          # k8s-pi5-cluster (the only deployment target) is arm64-only --
+          # confirmed via `kubectl get nodes -o jsonpath='{.status.nodeInfo.architecture}'`
+          # across all 4 nodes. amd64 was never deployed, so building it
+          # (on PRs and master alike) was pure waste; arm64 now covers both.
+          platforms: linux/arm64
           push: ${{ steps.push.outputs.should_push }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,11 @@
 # =============================================================================
 # Stage 1: Build React application
 #
-# Pinned to $BUILDPLATFORM so multi-arch builds (linux/amd64,linux/arm64) run
-# `npm ci`/`vite build` natively on the runner instead of under QEMU. The
-# resulting dist/ is pure static assets and architecture-independent, so only
-# the final nginx stage needs to be cross-built.
+# Pinned to $BUILDPLATFORM so the cross-build to linux/arm64 (the only
+# deployment target, k8s-pi5-cluster) runs `npm ci`/`vite build` natively on
+# the amd64 GitHub runner instead of under QEMU. The resulting dist/ is pure
+# static assets and architecture-independent, so only the final nginx stage
+# needs to be cross-built.
 # =============================================================================
 FROM --platform=$BUILDPLATFORM node:24-alpine AS builder
 


### PR DESCRIPTION
## Summary
- k8s-pi5-cluster (the only deployment target) is arm64-only — confirmed via `kubectl get nodes`, all 4 nodes report `arm64`
- PR builds were previously **amd64-only** (backwards — validating an architecture that's never deployed) and master builds were both arches; both now build `linux/arm64` only
- The `$BUILDPLATFORM`-pinned builder stage (npm ci/vite build running natively rather than under QEMU) is unaffected — that optimization still applies since the runner is amd64 and the target is arm64

## Expected impact
Removes the wasted amd64 leg from every PR and master build. PR builds specifically go from "build the wrong architecture" to "build the one that matters."

## Test plan
- [x] YAML syntax validated
- [x] `hadolint` clean on the Dockerfile
- [ ] Confirm the next master build only produces/pushes an arm64 manifest

🤖 Generated with [Claude Code](https://claude.com/claude-code)