### PR TITLE
fix(ci): allow perf/* branches in PR source branch policy

### DIFF
--- a/.github/workflows/validate-pr-branch.yml
+++ b/.github/workflows/validate-pr-branch.yml
@@ -21,7 +21,7 @@ jobs:
           echo "Target branch: ${{ github.base_ref }}"
 
           # Check if source branch matches allowed patterns
-          if [[ "$HEAD_REF" =~ ^(develop|feature/.+|fix/.+|test/.+|codex/.+|update-.+|renovate/.+)$ ]]; then
+          if [[ "$HEAD_REF" =~ ^(develop|feature/.+|fix/.+|perf/.+|test/.+|codex/.+|update-.+|renovate/.+)$ ]]; then
             echo "✅ Valid source branch: $HEAD_REF"
             echo "PR is from an allowed branch - APPROVED"
           else
@@ -35,6 +35,7 @@ jobs:
             echo "  ✓ develop branch"
             echo "  ✓ feature/* branches"
             echo "  ✓ fix/* branches"
+            echo "  ✓ perf/* branches"
             echo "  ✓ test/* branches"
             echo "  ✓ codex/* branches"
             echo "  ✓ update-* branches (automated dependency updates)"


### PR DESCRIPTION
## Summary
- `Validate PR Source Branch` currently allows `develop`, `feature/*`, `fix/*`, `test/*`, `codex/*`, `update-*`, `renovate/*` — but not `perf/*`
- `perf/*` is a conventional, Conventional-Commits-aligned prefix (matches the `perf:` commit type) with no principled difference from the already-allowed prefixes
- otel-data-ui#538 (a build-time optimization PR, branch `perf/arm64-only-docker-build`) failed this check for exactly this reason

## Test plan
- [x] YAML syntax validated
- [x] Regex tested locally against `perf/arm64-only-docker-build` — matches
- [ ] Once merged, re-run `Validate PR Source Branch` on #538 to confirm it now passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)