### PR TITLE
feat(garmin): add date-range filter to segment detail page

### DIFF
--- a/src/components/garmin/SegmentEffortsLeaderboard.test.tsx
+++ b/src/components/garmin/SegmentEffortsLeaderboard.test.tsx
@@ -227,25 +227,25 @@ describe('SegmentEffortsLeaderboard', () => {
     })
   })
 
-  it('only includes the top 20 rows of the current sort in the batch request', () => {
-    const efforts = Array.from({ length: 25 }, (_, i) =>
+  it('only includes the top 50 rows of the current sort in the batch request', () => {
+    const efforts = Array.from({ length: 55 }, (_, i) =>
       effort({
         activity_id: `activity-${i}`,
-        activity_start_time: `2026-06-${String(i + 1).padStart(2, '0')}T10:00:00Z`,
-        effort_start: `2026-06-${String(i + 1).padStart(2, '0')}T10:00:00Z`,
+        activity_start_time: `2026-06-${String((i % 28) + 1).padStart(2, '0')}T10:00:00Z`,
+        effort_start: `2026-06-${String((i % 28) + 1).padStart(2, '0')}T10:00:00Z`,
       }),
     )
 
     renderLeaderboard(efforts, { segmentId: 5, activeFraction: 0.5 })
 
-    // One batched call total (not one per row), covering only the top 20.
+    // One batched call total (not one per row), covering only the top 50.
     expect(
       seriesHooks.useGarminSegmentEffortSeriesBatchQuery,
     ).toHaveBeenCalledTimes(1)
     const call =
       seriesHooks.useGarminSegmentEffortSeriesBatchQuery.mock.calls[0][0]
     expect(call.skip).toBe(false)
-    expect(call.variables.efforts).toHaveLength(20)
+    expect(call.variables.efforts).toHaveLength(50)
   })
 
   it('renders static em dashes without a segment id', () => {

--- a/src/components/garmin/SegmentEffortsLeaderboard.tsx
+++ b/src/components/garmin/SegmentEffortsLeaderboard.tsx
@@ -31,10 +31,13 @@ import {
 
 /**
  * Only this many top rows (under the current sort) fetch live series data.
- * Roughly one screen's worth of rows; keeps the request fan-out bounded on segments with
- * hundreds of efforts while covering the rows users actually watch.
+ * Matches the batch endpoint's request cap (SegmentEffortSeriesBatchRequest,
+ * otel-data-api's app/models/garmin.py) -- raising this further requires
+ * raising that limit too. Combined with the segment page's date-range
+ * filter, this keeps request fan-out bounded on segments with hundreds of
+ * efforts while covering the rows users actually watch.
  */
-const LIVE_ROW_LIMIT = 20
+const LIVE_ROW_LIMIT = 50
 
 interface SegmentEffortsLeaderboardProps {
   efforts: SegmentEffort[]

--- a/src/pages/GarminSegmentDetailPage.test.tsx
+++ b/src/pages/GarminSegmentDetailPage.test.tsx
@@ -9,6 +9,12 @@ const segmentHooks = vi.hoisted(() => ({
   useGarminSegmentQuery: vi.fn(),
   useGarminSegmentEffortsQuery: vi.fn(),
   useGarminChartDataQuery: vi.fn(),
+  useGarminDateRangeQuery: vi.fn(() => ({
+    data: {
+      garminDateRange: { min_date: '2010-01-01', max_date: '2026-07-31' },
+    },
+    loading: false,
+  })),
   useGarminSegmentEffortSeriesBatchQuery: vi.fn(() => ({
     data: undefined,
     loading: false,

--- a/src/pages/GarminSegmentDetailPage.test.tsx
+++ b/src/pages/GarminSegmentDetailPage.test.tsx
@@ -332,6 +332,9 @@ describe('GarminSegmentDetailPage', () => {
         skip: true,
       }),
     )
+    expect(segmentHooks.useGarminDateRangeQuery).toHaveBeenCalledWith(
+      expect.objectContaining({ skip: true }),
+    )
   })
 
   it('renders the segment loading state', () => {

--- a/src/pages/GarminSegmentDetailPage.tsx
+++ b/src/pages/GarminSegmentDetailPage.tsx
@@ -82,7 +82,7 @@ export function GarminSegmentDetailPage() {
 
   const dateFromParam = searchParams.get('date_from')
   const dateToParam = searchParams.get('date_to')
-  const { data: dateRangeData } = useGarminDateRangeQuery()
+  const { data: dateRangeData } = useGarminDateRangeQuery({ skip: !validId })
   const DATA_MIN_DATE = dateRangeData?.garminDateRange?.min_date
     ? toLocalDate(dateRangeData.garminDateRange.min_date)
     : undefined

--- a/src/pages/GarminSegmentDetailPage.tsx
+++ b/src/pages/GarminSegmentDetailPage.tsx
@@ -5,16 +5,19 @@ import {
   useState,
   type ReactNode,
 } from 'react'
-import { Link, useNavigate, useParams } from 'react-router-dom'
+import { Link, useNavigate, useParams, useSearchParams } from 'react-router-dom'
 import { ArrowLeft } from 'lucide-react'
+import { format as formatDate } from 'date-fns'
 import {
   useGarminSegmentQuery,
   useGarminSegmentEffortsQuery,
   useGarminChartDataQuery,
+  useGarminDateRangeQuery,
 } from '@/__generated__/graphql'
 import { LoadingState } from '@/components/shared/LoadingState'
 import { ErrorState } from '@/components/shared/ErrorState'
 import { EmptyState } from '@/components/shared/EmptyState'
+import { DateRangePicker } from '@/components/shared/DateRangePicker'
 import { Badge } from '@/components/ui/badge'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { SegmentStartEndMap } from '@/components/garmin/SegmentStartEndMap'
@@ -34,6 +37,7 @@ import {
 } from '@/components/garmin/segmentEfforts'
 import { getSegmentRoutePoints } from '@/components/garmin/segmentRoute'
 import { setNRCustomAttribute } from '@/lib/newrelic-browser'
+import { parseDateRangeParams, toLocalDate } from '@/lib/date-range'
 
 // 500 is the otel-data-api's max; an activity that laps a loop segment
 // several times now yields one effort per lap instead of just its fastest,
@@ -48,6 +52,7 @@ interface ActiveElevationSelection {
 export function GarminSegmentDetailPage() {
   const { segmentId } = useParams<{ segmentId: string }>()
   const navigate = useNavigate()
+  const [searchParams, setSearchParams] = useSearchParams()
   const id = Number(segmentId)
   const validId = Number.isInteger(id) && id > 0
   const [activeElevationSelection, setActiveElevationSelection] =
@@ -75,13 +80,37 @@ export function GarminSegmentDetailPage() {
     refetch: refetchSegment,
   } = useGarminSegmentQuery({ variables: { id }, skip: !validId })
 
+  const dateFromParam = searchParams.get('date_from')
+  const dateToParam = searchParams.get('date_to')
+  const { data: dateRangeData } = useGarminDateRangeQuery()
+  const DATA_MIN_DATE = dateRangeData?.garminDateRange?.min_date
+    ? toLocalDate(dateRangeData.garminDateRange.min_date)
+    : undefined
+  const DATA_MAX_DATE = dateRangeData?.garminDateRange?.max_date
+    ? toLocalDate(dateRangeData.garminDateRange.max_date)
+    : new Date()
+  const {
+    dateFrom,
+    dateTo,
+    dateFromParam: dateFromStr,
+    dateToParam: dateToStr,
+  } = parseDateRangeParams(dateFromParam, dateToParam, {
+    minDate: DATA_MIN_DATE,
+    maxDate: DATA_MAX_DATE,
+  })
+
   const {
     data: effortsData,
     loading: effortsLoading,
     error: effortsError,
     refetch: refetchEfforts,
   } = useGarminSegmentEffortsQuery({
-    variables: { id, limit: EFFORTS_LIMIT },
+    variables: {
+      id,
+      limit: EFFORTS_LIMIT,
+      date_from: dateFromStr,
+      date_to: dateToStr,
+    },
     skip: !validId,
   })
 
@@ -209,7 +238,11 @@ export function GarminSegmentDetailPage() {
     effortsStatusNode = (
       <EmptyState
         title="No efforts yet"
-        message="No activities have traversed this segment's corridor."
+        message={
+          dateFromStr || dateToStr
+            ? 'No efforts match the selected date range. Try a different range.'
+            : "No activities have traversed this segment's corridor."
+        }
       />
     )
   }
@@ -291,8 +324,23 @@ export function GarminSegmentDetailPage() {
         </Card>
 
         <Card>
-          <CardHeader>
+          <CardHeader className="flex flex-row flex-wrap items-center justify-between gap-2">
             <CardTitle>Effort leaderboard</CardTitle>
+            <DateRangePicker
+              dateFrom={dateFrom}
+              dateTo={dateTo}
+              minDate={DATA_MIN_DATE}
+              maxDate={DATA_MAX_DATE}
+              onRangeChange={(from, to) => {
+                const params = new URLSearchParams(searchParams)
+                if (from)
+                  params.set('date_from', formatDate(from, 'yyyy-MM-dd'))
+                else params.delete('date_from')
+                if (to) params.set('date_to', formatDate(to, 'yyyy-MM-dd'))
+                else params.delete('date_to')
+                setSearchParams(params)
+              }}
+            />
           </CardHeader>
           <CardContent>
             {effortsStatusNode ?? (


### PR DESCRIPTION
## Summary
- Segments with long histories (e.g. #17, "59th Street Bridge Submit," 152 efforts back to 2010) show `—` for the Speed @ pt/HR @ pt columns beyond the top 20 rows — only that many efforts fetch the live per-point series batch, a perf guard against unbounded request fan-out on segments with hundreds of efforts.
- Investigated whether raising the cap was actually safe: ran `EXPLAIN ANALYZE` against prod with the real batch query at N=20/50/100/150/200 efforts. Cost scales linearly, plan shape stays a clean index-only-scan the whole way (no N+1, single DB round-trip regardless of N) — ~15ms at 20 rows, ~55ms at 100, ~70-95ms for a full 150-200-row segment. **Performance was never actually the constraint.**

## Changes
1. **Raise `LIVE_ROW_LIMIT` 20 → 50** (`SegmentEffortsLeaderboard.tsx`), matching `otel-data-api`'s `SegmentEffortSeriesBatchRequest.max_length` ceiling — going higher would require bumping that too.
2. **Add a date-range filter to the segment detail page** (`GarminSegmentDetailPage.tsx`), reusing the exact `DateRangePicker` + `useSearchParams` + `parseDateRangeParams` + `useGarminDateRangeQuery` pattern already used on `GarminPage`/`LocationsPage`/`DailySummaryPage`. The `date_from`/`date_to` GraphQL variables already existed end-to-end on `garminSegmentEfforts` (gateway resolver → REST endpoint → SQL `WHERE` clause) but were never wired into this page's query.

Together, these mean filtering to a shorter date range brings segments with 100+ efforts within the live-data cap, rather than relying on a single raised cap to ever fully cover large segments.

## Test plan
- [x] `npm run type-check` — clean
- [x] `npm run lint` — clean
- [x] Full unit suite: 507/507 passed (65 files)
- [x] Verified locally against the live gateway (`npm run dev`) on segment 17 (152 efforts):
  - Date picker renders next to "Effort leaderboard" title
  - Clicking "Last 30 days" preset narrows 152 → 1 matching effort, URL updates to `?date_from=...&date_to=...`
  - Navigating without params shows all 152 again
- [x] Updated `SegmentEffortsLeaderboard.test.tsx`'s row-cap assertion (20 → 50) and `GarminSegmentDetailPage.test.tsx`'s mock (added `useGarminDateRangeQuery`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)