### PR TITLE
perf(test): use worker threads pool for faster test runs

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -12,6 +12,7 @@ export default defineConfig({
   },
   test: {
     environment: 'jsdom',
+    pool: 'threads',
     setupFiles: ['./src/test/setup.ts'],
     include: ['src/**/*.test.{ts,tsx}'],
     css: true,


### PR DESCRIPTION
## Summary
Investigated the "Tests and Coverage" CI job since it's the actual wall-clock bottleneck for this workflow (measured: ~89s in CI, every other job finishes in <50s and runs in parallel — the workflow's total time is bounded by this one job).

- Switched Vitest's `pool` from the default `forks` to `threads`. Forks spawns a fresh OS process per test file; threads reuses worker threads, avoiding that spawn cost. Measured locally (4 cores): `vitest run --coverage` went from ~131s to ~125s wall-clock, stable across repeat runs, identical pass/fail results and coverage numbers.

## What I tried and rejected
- `isolate: false` — would give a much bigger win (Vitest's own timing breakdown shows `environment` setup at ~118s cumulative, the single largest cost bucket, well ahead of actual test execution at ~74s) since it stops creating a fresh jsdom environment per file. **Breaks 9 tests** via cross-file mock/module state leakage. Fixing each test's isolation assumptions is real, separate work with correctness risk — not appropriate to bundle into a CI-speed PR. Flagging as a future investigation if test time keeps growing.
- Explicit `maxThreads`/`minThreads` pinning — no measurable difference over the pool's default worker count on this core count.

## Test plan
- [x] `npx vitest run` — 507/507 passed, twice in a row (no flakiness introduced)
- [x] `npx vitest run --coverage` — same coverage numbers both runs (96.18% statements, 90.36% branches, 97.96% functions, 97.87% lines) — well above the 80%/70%/80%/80% thresholds
- [x] `npm run lint` / `npm run type-check` — unaffected, unrelated to this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)