### PR TITLE
fix(build): resolve dead esbuild config and deprecated advancedChunks warning

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
 
-export default defineConfig(({ command }) => ({
+export default defineConfig(() => ({
   plugins: [react(), tailwindcss()],
   resolve: {
     alias: {
@@ -14,8 +14,9 @@ export default defineConfig(({ command }) => ({
     rollupOptions: {
       output: {
         // Vite 8 uses Rolldown; the object form of `manualChunks` was removed.
-        // Use Rolldown's `advancedChunks.groups` to keep the same chunking.
-        advancedChunks: {
+        // Use Rolldown's `codeSplitting.groups` to keep the same chunking
+        // (this superseded `advancedChunks`, which is now deprecated).
+        codeSplitting: {
           groups: [
             {
               name: 'leaflet',
@@ -34,10 +35,4 @@ export default defineConfig(({ command }) => ({
       },
     },
   },
-  ...(command === 'build' && {
-    esbuild: {
-      drop: ['debugger'],
-      pure: ['console.log', 'console.debug', 'console.info', 'console.warn'],
-    },
-  }),
 }))


### PR DESCRIPTION
## Summary
Investigating build hygiene surfaced two issues in `vite.config.ts` (a Vite 8/Rolldown API-migration mismatch, not new bugs from this PR):

1. **`esbuild.drop`/`pure` was dead configuration.** Vite 8's Rolldown/oxc minifier wins whenever both esbuild and oxc options are set — the build printed *"Both esbuild and oxc options were set. oxc options will be used and esbuild options will be ignored."* Practical effect: `console.log/debug/info/warn` were **not actually being stripped** from production builds despite the config implying they were.

   oxc's replacement (`dropConsole`) has no per-method granularity — it's all-or-nothing, unlike esbuild's `pure` list which could target specific console methods. The original config deliberately kept `console.error` (5 real call sites in `auth.ts`/`AuthContext.tsx`/`CallbackPage.tsx` for debugging auth failures) while dropping the noisier ones. Rather than silently regress that with `dropConsole: true`, I removed the block outright — a repo-wide grep confirmed **zero** `console.log/debug/info/warn` calls exist outside tests today, so this has no practical bundle impact; `console.error` stays visible in prod, which is what actually mattered. (`dropDebugger` already defaults to `true` in oxc, so the explicit `drop: ['debugger']` was redundant even before this bug.)

2. **`advancedChunks` is deprecated** in favor of `codeSplitting` (identical `groups` shape) — build printed *"WARN advancedChunks option is deprecated, please use codeSplitting instead."* Migrated.

## Verification
- Confirmed both warnings are gone from `npm run build` output
- Confirmed chunk output is unchanged: `leaflet` 148.81KB, `apollo` ~194.5KB, `recharts` 395.32KB — same grouping, same sizes as before
- `npm run lint` / `npm run type-check` — clean

## Note
The jsdom version-drift issue flagged in the original investigation (`package.json` said `^29`, installed was `30.0.0`) has already been resolved by a Renovate merge since — confirmed `npm ls jsdom` is clean with no `invalid` flag. Nothing to do there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)