### PR TITLE
perf(routing): lazy-load routes to shrink the initial JS chunk

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -91,21 +91,23 @@ describe('App routes', () => {
     expect(screen.queryByText('Layout shell')).not.toBeInTheDocument()
   })
 
-  it('renders application routes inside the shared layout', () => {
+  it('renders application routes inside the shared layout', async () => {
     window.history.replaceState({}, '', '/references')
 
     render(<App />)
 
+    expect(await screen.findByText('References page')).toBeInTheDocument()
     expect(screen.getByText('Layout shell')).toBeInTheDocument()
-    expect(screen.getByText('References page')).toBeInTheDocument()
   })
 
-  it('renders the daily summary detail route inside the shared layout', () => {
+  it('renders the daily summary detail route inside the shared layout', async () => {
     window.history.replaceState({}, '', '/daily-summary/2026-03-14')
 
     render(<App />)
 
+    expect(
+      await screen.findByText('Daily summary detail page'),
+    ).toBeInTheDocument()
     expect(screen.getByText('Layout shell')).toBeInTheDocument()
-    expect(screen.getByText('Daily summary detail page')).toBeInTheDocument()
   })
 })

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,7 +12,7 @@ import { CallbackPage } from '@/pages/CallbackPage'
 
 // Lazy-loaded so each route's code (and its dependencies, e.g. Leaflet,
 // Recharts) only downloads when a user actually navigates there, instead of
-// all 14 pages bundling into the single >800KB initial chunk. Dashboard and
+// all 15 pages bundling into the single >800KB initial chunk. Dashboard and
 // Callback stay static: Dashboard is the landing route (no loading flash on
 // first paint), Callback is the OAuth redirect target (must resolve fast).
 const LocationsPage = lazy(() =>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,3 +1,4 @@
+import { lazy, Suspense } from 'react'
 import { BrowserRouter, Routes, Route } from 'react-router-dom'
 import { ApolloProvider } from '@apollo/client/react'
 import { Toaster } from 'sonner'
@@ -5,21 +6,72 @@ import { getApolloClient } from '@/lib/apollo'
 import { ThemeProvider } from '@/contexts/ThemeContext'
 import { AuthProvider } from '@/contexts/AuthContext'
 import { AppLayout } from '@/components/layout/AppLayout'
+import { LoadingState } from '@/components/shared/LoadingState'
 import { DashboardPage } from '@/pages/DashboardPage'
-import { LocationsPage } from '@/pages/LocationsPage'
-import { LocationDetailPage } from '@/pages/LocationDetailPage'
-import { GarminPage } from '@/pages/GarminPage'
-import { GarminDetailPage } from '@/pages/GarminDetailPage'
-import { LapComparisonPage } from '@/pages/LapComparisonPage'
-import { GarminSegmentsPage } from '@/pages/GarminSegmentsPage'
-import { GarminSegmentDetailPage } from '@/pages/GarminSegmentDetailPage'
-import { MapPage } from '@/pages/MapPage'
-import { DailySummaryPage } from '@/pages/DailySummaryPage'
-import { DailySummaryDetailPage } from '@/pages/DailySummaryDetailPage'
-import { ReferencesPage } from '@/pages/ReferencesPage'
-import { SpatialPage } from '@/pages/SpatialPage'
-import { GeocodingPage } from '@/pages/GeocodingPage'
 import { CallbackPage } from '@/pages/CallbackPage'
+
+// Lazy-loaded so each route's code (and its dependencies, e.g. Leaflet,
+// Recharts) only downloads when a user actually navigates there, instead of
+// all 14 pages bundling into the single >800KB initial chunk. Dashboard and
+// Callback stay static: Dashboard is the landing route (no loading flash on
+// first paint), Callback is the OAuth redirect target (must resolve fast).
+const LocationsPage = lazy(() =>
+  import('@/pages/LocationsPage').then((m) => ({ default: m.LocationsPage })),
+)
+const LocationDetailPage = lazy(() =>
+  import('@/pages/LocationDetailPage').then((m) => ({
+    default: m.LocationDetailPage,
+  })),
+)
+const GarminPage = lazy(() =>
+  import('@/pages/GarminPage').then((m) => ({ default: m.GarminPage })),
+)
+const GarminDetailPage = lazy(() =>
+  import('@/pages/GarminDetailPage').then((m) => ({
+    default: m.GarminDetailPage,
+  })),
+)
+const LapComparisonPage = lazy(() =>
+  import('@/pages/LapComparisonPage').then((m) => ({
+    default: m.LapComparisonPage,
+  })),
+)
+const GarminSegmentsPage = lazy(() =>
+  import('@/pages/GarminSegmentsPage').then((m) => ({
+    default: m.GarminSegmentsPage,
+  })),
+)
+const GarminSegmentDetailPage = lazy(() =>
+  import('@/pages/GarminSegmentDetailPage').then((m) => ({
+    default: m.GarminSegmentDetailPage,
+  })),
+)
+const MapPage = lazy(() =>
+  import('@/pages/MapPage').then((m) => ({ default: m.MapPage })),
+)
+const DailySummaryPage = lazy(() =>
+  import('@/pages/DailySummaryPage').then((m) => ({
+    default: m.DailySummaryPage,
+  })),
+)
+const DailySummaryDetailPage = lazy(() =>
+  import('@/pages/DailySummaryDetailPage').then((m) => ({
+    default: m.DailySummaryDetailPage,
+  })),
+)
+const ReferencesPage = lazy(() =>
+  import('@/pages/ReferencesPage').then((m) => ({
+    default: m.ReferencesPage,
+  })),
+)
+const SpatialPage = lazy(() =>
+  import('@/pages/SpatialPage').then((m) => ({ default: m.SpatialPage })),
+)
+const GeocodingPage = lazy(() =>
+  import('@/pages/GeocodingPage').then((m) => ({
+    default: m.GeocodingPage,
+  })),
+)
 
 export default function App() {
   return (
@@ -28,37 +80,45 @@ export default function App() {
         <AuthProvider>
           <Toaster richColors />
           <BrowserRouter>
-            <Routes>
-              <Route path="/callback" element={<CallbackPage />} />
-              <Route element={<AppLayout />}>
-                <Route index element={<DashboardPage />} />
-                <Route path="locations" element={<LocationsPage />} />
-                <Route path="locations/:id" element={<LocationDetailPage />} />
-                <Route path="garmin" element={<GarminPage />} />
-                <Route path="garmin/compare" element={<LapComparisonPage />} />
-                <Route
-                  path="garmin/segments"
-                  element={<GarminSegmentsPage />}
-                />
-                <Route
-                  path="garmin/segments/:segmentId"
-                  element={<GarminSegmentDetailPage />}
-                />
-                <Route
-                  path="garmin/:activityId"
-                  element={<GarminDetailPage />}
-                />
-                <Route path="map" element={<MapPage />} />
-                <Route path="daily-summary" element={<DailySummaryPage />} />
-                <Route
-                  path="daily-summary/:date"
-                  element={<DailySummaryDetailPage />}
-                />
-                <Route path="references" element={<ReferencesPage />} />
-                <Route path="spatial" element={<SpatialPage />} />
-                <Route path="geocoding" element={<GeocodingPage />} />
-              </Route>
-            </Routes>
+            <Suspense fallback={<LoadingState message="Loading page..." />}>
+              <Routes>
+                <Route path="/callback" element={<CallbackPage />} />
+                <Route element={<AppLayout />}>
+                  <Route index element={<DashboardPage />} />
+                  <Route path="locations" element={<LocationsPage />} />
+                  <Route
+                    path="locations/:id"
+                    element={<LocationDetailPage />}
+                  />
+                  <Route path="garmin" element={<GarminPage />} />
+                  <Route
+                    path="garmin/compare"
+                    element={<LapComparisonPage />}
+                  />
+                  <Route
+                    path="garmin/segments"
+                    element={<GarminSegmentsPage />}
+                  />
+                  <Route
+                    path="garmin/segments/:segmentId"
+                    element={<GarminSegmentDetailPage />}
+                  />
+                  <Route
+                    path="garmin/:activityId"
+                    element={<GarminDetailPage />}
+                  />
+                  <Route path="map" element={<MapPage />} />
+                  <Route path="daily-summary" element={<DailySummaryPage />} />
+                  <Route
+                    path="daily-summary/:date"
+                    element={<DailySummaryDetailPage />}
+                  />
+                  <Route path="references" element={<ReferencesPage />} />
+                  <Route path="spatial" element={<SpatialPage />} />
+                  <Route path="geocoding" element={<GeocodingPage />} />
+                </Route>
+              </Routes>
+            </Suspense>
           </BrowserRouter>
         </AuthProvider>
       </ThemeProvider>


### PR DESCRIPTION
## Summary
Vite's build was warning about a chunk over its 500KB threshold: the "everything else" `index-*.js` chunk was **838.16KB raw / 248.80KB gzipped**. Root cause: all 15 pages were statically imported in `App.tsx`, so every page's code — and its dependencies (Leaflet, Recharts, etc.) — bundled together regardless of which route a user actually visits.

## Change
Converted all routes to `React.lazy` + `Suspense`, except:
- **Dashboard** (index route) — stays static, it's the landing page; no loading flash on first paint
- **Callback** (OAuth redirect target) — stays static, needs to resolve fast

Reused the existing `LoadingState` component as the `Suspense` fallback for UX consistency with the rest of the app (query loading states already use it).

## Measured impact
| | Before | After |
|---|---|---|
| Main chunk (raw) | 838.16 KB | 472.72 KB (**-44%**) |
| Main chunk (gzip) | 248.80 KB | 145.56 KB (**-41%**) |
| 500KB build warning | present | gone |

Each page now lands in its own small chunk, downloaded only on navigation — e.g. `MapPage` 2.31KB, `GarminSegmentDetailPage` 21.72KB, `GarminDetailPage` 83.97KB.

## Test plan
- [x] `npm run lint` / `npm run type-check` — clean
- [x] Full unit suite: 507/507 passed
- [x] `App.test.tsx`'s two route tests updated to `await screen.findByText(...)` instead of synchronous `getByText`, since lazy routes now resolve after `Suspense` rather than immediately
- [x] Verified in a real browser (local dev server) across 9 routes including one with Leaflet mini-maps (`/garmin/segments`) — all load correctly, no console errors, no missing content

🤖 Generated with [Claude Code](https://claude.com/claude-code)
