### PR TITLE
fix(ci): allow chore/* and docs/* branches in PR source branch policy

### DIFF
--- a/.github/workflows/validate-pr-branch.yml
+++ b/.github/workflows/validate-pr-branch.yml
@@ -21,7 +21,7 @@ jobs:
           echo "Target branch: ${{ github.base_ref }}"
 
           # Check if source branch matches allowed patterns
-          if [[ "$HEAD_REF" =~ ^(develop|feature/.+|fix/.+|perf/.+|test/.+|codex/.+|update-.+|renovate/.+)$ ]]; then
+          if [[ "$HEAD_REF" =~ ^(develop|feature/.+|fix/.+|perf/.+|chore/.+|test/.+|codex/.+|update-.+|renovate/.+)$ ]]; then
             echo "✅ Valid source branch: $HEAD_REF"
             echo "PR is from an allowed branch - APPROVED"
           else
@@ -36,6 +36,7 @@ jobs:
             echo "  ✓ feature/* branches"
             echo "  ✓ fix/* branches"
             echo "  ✓ perf/* branches"
+            echo "  ✓ chore/* branches"
             echo "  ✓ test/* branches"
             echo "  ✓ codex/* branches"
             echo "  ✓ update-* branches (automated dependency updates)"

--- a/.github/workflows/validate-pr-branch.yml
+++ b/.github/workflows/validate-pr-branch.yml
@@ -21,7 +21,7 @@ jobs:
           echo "Target branch: ${{ github.base_ref }}"
 
           # Check if source branch matches allowed patterns
-          if [[ "$HEAD_REF" =~ ^(develop|feature/.+|fix/.+|perf/.+|chore/.+|test/.+|codex/.+|update-.+|renovate/.+)$ ]]; then
+          if [[ "$HEAD_REF" =~ ^(develop|feature/.+|fix/.+|perf/.+|chore/.+|docs/.+|test/.+|codex/.+|update-.+|renovate/.+)$ ]]; then
             echo "✅ Valid source branch: $HEAD_REF"
             echo "PR is from an allowed branch - APPROVED"
           else
@@ -37,6 +37,7 @@ jobs:
             echo "  ✓ fix/* branches"
             echo "  ✓ perf/* branches"
             echo "  ✓ chore/* branches"
+            echo "  ✓ docs/* branches"
             echo "  ✓ test/* branches"
             echo "  ✓ codex/* branches"
             echo "  ✓ update-* branches (automated dependency updates)"


### PR DESCRIPTION
## Summary
- Same gap as #540 (which added `perf/*`): `chore/*` and `docs/*` are standard Conventional Commits types, both used by this session's tooling/hygiene/docs PRs
- otel-data-ui#559 (`chore/add-knip-unused-code-detection`) and a pending docs PR (`docs/refresh-readme`) both failed `Validate PR Source Branch` for exactly this reason

## Test plan
- [x] Regex tested locally against both `chore/add-knip-unused-code-detection` and `docs/refresh-readme` — both match
- [ ] Once merged, re-run `Validate PR Source Branch` on the affected PRs to confirm they now pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)