### PR TITLE
chore: dedupe @radix-ui/react-slot in favor of the radix-ui meta-package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
         "@apollo/client": "^4.1.6",
         "@fontsource-variable/geist": "^5.2.8",
         "@newrelic/browser-agent": "^1.314.0",
-        "@radix-ui/react-slot": "^1.3.0",
         "@stuartshay/otel-graphql-types": "1.0.597",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "@apollo/client": "^4.1.6",
     "@fontsource-variable/geist": "^5.2.8",
     "@newrelic/browser-agent": "^1.314.0",
-    "@radix-ui/react-slot": "^1.3.0",
     "@stuartshay/otel-graphql-types": "1.0.597",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { Slot } from '@radix-ui/react-slot'
+import { Slot } from 'radix-ui'
 import { cva, type VariantProps } from 'class-variance-authority'
 import { cn } from '@/lib/utils'
 
@@ -42,7 +42,7 @@ export interface ButtonProps
 
 const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
   ({ className, variant, size, asChild = false, ...props }, ref) => {
-    const Comp = asChild ? Slot : 'button'
+    const Comp = asChild ? Slot.Root : 'button'
     return (
       <Comp
         className={cn(buttonVariants({ variant, size, className }))}


### PR DESCRIPTION
## Summary
Both `radix-ui` (the all-in-one meta-package) and the standalone `@radix-ui/react-slot` were declared as direct dependencies. `select.tsx`/`popover.tsx`/`tabs.tsx` already import their primitives from `radix-ui`; `button.tsx` was the one holdout still importing `Slot` from the standalone package `radix-ui` already re-exports.

## Not a literal drop-in — found and fixed a runtime bug along the way
`radix-ui` re-exports each sub-package as a **namespace**, not the component directly:
```ts
import * as reactSlot from '@radix-ui/react-slot'
export { reactSlot as Slot }
```
So `Slot` from `'radix-ui'` is the whole module object, not the `Slot` component. Using it directly as a JSX tag **type-checks** (TypeScript's structural typing doesn't catch this) but **throws at runtime**: `Element type is invalid... but got: object`.

Caught this by testing in an actual browser rather than trusting `tsc --noEmit` alone. The fix is `Slot.Root` (matching `@radix-ui/react-slot`'s own `export { Slot as Root, Slot, ... }`), consistent with how the other vendored primitives in this repo already use the `XxxPrimitive.Root` convention.

## Test plan
- [x] `npm run lint` / `npm run type-check` — clean
- [x] Full unit suite: 507/507 passed
- [x] `npm run build` — succeeds
- [x] **Verified in a real browser** (local dev server, not just `tsc`): both places that exercise `Button`'s `asChild` prop —
  - `DailySummaryDetailPage.tsx` (Previous/Next Day, OwnTracks/Garmin toggle buttons)
  - `ActivityHeader.tsx` (back-to-list button)
  
  render as the correct underlying element (`<a>`) with no console errors

## Note
This branch uses the `chore/*` prefix — needs #560 (adds `chore/*` to the allowed branch policy) merged first before `Validate PR Source Branch` will pass here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)