### PR TITLE
chore: address remaining knip findings from #559

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^10.0.0",
+        "@graphql-codegen/add": "^7.1.0",
         "@graphql-codegen/cli": "^7.1.3",
         "@graphql-codegen/typescript": "^6.0.1",
         "@graphql-codegen/typescript-operations": "^6.0.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,6 @@
         "react-calendar-heatmap": "^1.10.0",
         "react-day-picker": "^10.0.0",
         "react-dom": "^19.2.0",
-        "react-leaflet": "^5.0.0",
         "react-router-dom": "^7.18.0",
         "recharts": "^3.8.0",
         "sonner": "^2.0.7",
@@ -6742,17 +6741,6 @@
       "resolved": "https://registry.npmjs.org/@radix-ui/rect/-/rect-1.1.3.tgz",
       "integrity": "sha512-JtyZR+mqgBibTo8xea3B6ZRmzZiM/YeVBtUkas6zMuXjAlfIFIW2FgqeM9eLyvEaYX66vr6DJMK+4U6LV0KhNw==",
       "license": "MIT"
-    },
-    "node_modules/@react-leaflet/core": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@react-leaflet/core/-/core-3.0.0.tgz",
-      "integrity": "sha512-3EWmekh4Nz+pGcr+xjf0KNyYfC3U2JjnkWsh0zcqaexYqmmB5ZhH37kz41JXGmKzpaMZCnPofBBm64i+YrEvGQ==",
-      "license": "Hippocratic-2.1",
-      "peerDependencies": {
-        "leaflet": "^1.9.0",
-        "react": "^19.0.0",
-        "react-dom": "^19.0.0"
-      }
     },
     "node_modules/@reduxjs/toolkit": {
       "version": "2.11.2",
@@ -15356,20 +15344,6 @@
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "license": "MIT",
       "peer": true
-    },
-    "node_modules/react-leaflet": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/react-leaflet/-/react-leaflet-5.0.0.tgz",
-      "integrity": "sha512-CWbTpr5vcHw5bt9i4zSlPEVQdTVcML390TjeDG0cK59z1ylexpqC6M1PJFjV8jD7CF+ACBFsLIDs6DRMoLEofw==",
-      "license": "Hippocratic-2.1",
-      "dependencies": {
-        "@react-leaflet/core": "^3.0.0"
-      },
-      "peerDependencies": {
-        "leaflet": "^1.9.0",
-        "react": "^19.0.0",
-        "react-dom": "^19.0.0"
-      }
     },
     "node_modules/react-redux": {
       "version": "9.2.0",

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^10.0.0",
+    "@graphql-codegen/add": "^7.1.0",
     "@graphql-codegen/cli": "^7.1.3",
     "@graphql-codegen/typescript": "^6.0.1",
     "@graphql-codegen/typescript-operations": "^6.0.4",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
     "react-calendar-heatmap": "^1.10.0",
     "react-day-picker": "^10.0.0",
     "react-dom": "^19.2.0",
-    "react-leaflet": "^5.0.0",
     "react-router-dom": "^7.18.0",
     "recharts": "^3.8.0",
     "sonner": "^2.0.7",

--- a/src/components/garmin/WeatherPanel.tsx
+++ b/src/components/garmin/WeatherPanel.tsx
@@ -12,7 +12,7 @@ import {
   type WeatherHourlyPoint,
 } from './WeatherHourlyBreakdown'
 
-export interface WeatherPanelData {
+interface WeatherPanelData {
   temperature_c?: number | null
   apparent_temperature_c?: number | null
   relative_humidity_pct?: number | null

--- a/src/components/garmin/lapComparison.ts
+++ b/src/components/garmin/lapComparison.ts
@@ -14,7 +14,7 @@ export interface ComparisonLap {
   calories: number | null
 }
 
-export interface ComparisonActivity {
+interface ComparisonActivity {
   activity_id: string
   sport?: string | null
   sub_sport?: string | null
@@ -124,7 +124,7 @@ export function getMetricDef(metric: LapMetric): MetricDef {
   return LAP_METRICS.find((m) => m.key === metric) ?? LAP_METRICS[0]
 }
 
-export interface MatrixCell {
+interface MatrixCell {
   lapIndex: number
   value: number | null
   formatted: string
@@ -134,13 +134,13 @@ export interface MatrixCell {
   isPR: boolean
 }
 
-export interface MatrixRow {
+interface MatrixRow {
   activityId: string
   startTime: string | null
   cells: MatrixCell[]
 }
 
-export interface ColumnSummary {
+interface ColumnSummary {
   lapIndex: number
   best: string
   worst: string

--- a/src/components/garmin/savedPointColors.ts
+++ b/src/components/garmin/savedPointColors.ts
@@ -3,7 +3,7 @@
  * from the route speed legend (blue/green/yellow/red) and the chart series
  * colors (gray elevation, blue speed) so saved markers stay visually separable.
  */
-export const SAVED_POINT_PALETTE = [
+const SAVED_POINT_PALETTE = [
   '#a855f7', // purple
   '#14b8a6', // teal
   '#ec4899', // pink

--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -117,4 +117,3 @@ class AuthService {
 }
 
 export const authService = new AuthService()
-export default authService


### PR DESCRIPTION
## Summary
Follow-up on the two items flagged in #559 but deliberately not fixed there (knip is advisory, findings need human triage before acting):

1. **`@graphql-codegen/add` was only a transitive dependency** of `@graphql-codegen/cli` — `codegen.ts`'s plugin shorthand `{ add: { ... } }` resolves to it by convention, but nothing in this repo's own `package.json` declared it. Worked by npm hoisting luck; a future major bump of `@graphql-codegen/cli`/`client-preset` could silently break codegen with no direct signal here. Added as an explicit devDependency.

2. **Unused exports/dependencies cleanup**, each verified individually (including against `.test.ts`/`.test.tsx` files) before touching:
   - Removed `react-leaflet` (dependency) — confirmed zero imports anywhere in `src/`. This app uses raw `leaflet` directly (5 map components), not the `react-leaflet` wrapper.
   - Dropped `export` from `SAVED_POINT_PALETTE`, `ComparisonActivity`/`MatrixCell`/`MatrixRow`/`ColumnSummary` (`lapComparison.ts`), and `WeatherPanelData` (`WeatherPanel.tsx`) — each only referenced within its own file.
   - Removed `auth.ts`'s `export default authService` — confirmed every consumer (`CallbackPage.tsx`, `apollo.ts`, `AuthContext.tsx`) uses the named import; the default export had zero consumers.

## Deliberately left as-is
`PeliasProperties`/`PeliasGeometry` (`geocoder.ts`) are still flagged by knip but left exported — unlike the others, these describe a small public API shape for the Pelias geocoder integration (nested inside the already-exported `PeliasFeature`/`PeliasResponse`), not internal implementation detail. A conservative call rather than mechanically stripping every finding.

## Test plan
- [x] `npm run lint` / `npm run type-check` / `npm run build` — clean, main chunk unchanged at 472.73KB (confirms `react-leaflet` was never actually bundled)
- [x] Full unit suite: 507/507 passed
- [x] `npx knip` — down to just the 2 deliberately-kept `Pelias*` types

🤖 Generated with [Claude Code](https://claude.com/claude-code)